### PR TITLE
RenderMan : Add progress reporting option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - GraphEditor : Improved responsiveness of select-drag, by deferring NodeEditor update until the drag ends.
+- RenderManOptions : Added `ri:progress` option to control logging of render progress.
 
 API
 ---

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -167,6 +167,31 @@ class RendererTest( GafferTest.TestCase ) :
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
 		self.assertEqual( max( image["A"] ), 1 )
 
+	def testProgress( self ) :
+
+		messageHandler = IECore.CapturingMessageHandler()
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			self.renderer,
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+			messageHandler = messageHandler
+		)
+
+		renderer.output(
+			"beauty",
+			IECoreScene.Output(
+				( self.temporaryDirectory() / "beauty.exr" ).as_posix(),
+				"exr",
+				"rgba",
+				{
+				}
+			)
+		)
+
+		renderer.option( "ri:progressMode", IECore.IntData( 2 ) )
+		renderer.render()
+
+		self.assertRegex( "".join( [ m.message for m in messageHandler.messages ] ), "R90000.*%" )
+
 	def testMissingLightShader( self ) :
 
 		messageHandler = IECore.CapturingMessageHandler()

--- a/src/IECoreRenderMan/Globals.h
+++ b/src/IECoreRenderMan/Globals.h
@@ -98,6 +98,7 @@ class Globals : public boost::noncopyable
 
 		RtParamList m_rileyParameters;
 		RtParamList m_options;
+		RtParamList m_renderParameters;
 		std::string m_cameraOption;
 		IECoreScene::ConstShaderPtr m_integratorToConvert;
 		IECoreScene::ConstShaderNetworkPtr m_displayFilterToConvert;

--- a/src/IECoreRenderMan/Session.cpp
+++ b/src/IECoreRenderMan/Session.cpp
@@ -59,6 +59,7 @@ const RtUString g_lightColorUStr( "lightColor" );
 const RtUString g_lightColorMapUStr( "lightColorMap" );
 const RtUString g_portalNameUStr( "portalName" );
 const RtUString g_portalToDomeUStr( "portalToDome" );
+const RtUString g_progressModeUStr( "progressMode" );
 const RtUString g_pxrDomeLightUStr( "PxrDomeLight" );
 const RtUString g_pxrPortalLightUStr( "PxrPortalLight" );
 const RtUString g_tintUStr( "tint" );
@@ -167,7 +168,14 @@ Session::Session( RtUString rileyVariant, const RtParamList &rileyParameters, IE
 		args.push_back( "-recover" );
 		args.push_back( "1" );
 	}
-
+	int32_t progressMode = 0;
+	if( options.GetInteger( g_progressModeUStr, progressMode ) && progressMode )
+	{
+		// This is needed for RIS, but doesn't do anything for XPU. For XPU
+		// we have to pass `progressMode` to the `Riley::Render()` call - see
+		// `Globals.cpp`.
+		args.push_back( progressMode == 1 ? "-Progress" : "-progress" );
+	}
 	m_riCtl->PRManRenderBegin( args.size(), args.data() );
 
 	if( messageHandler )

--- a/startup/GafferScene/renderManOptions.py
+++ b/startup/GafferScene/renderManOptions.py
@@ -259,8 +259,9 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 		},
 
-		# Add an option to allow checkpoint recovery - this is handled by `IECoreRenderMan::Session::Session()`
-		# since it is not an official RenderMan option.
+		# Add options to allow checkpoint recovery and progress logging - these
+		# are not official RenderMan options so have special handling in
+		# IECoreRenderMan.
 
 		"option:ri:checkpoint:recover" : {
 
@@ -268,6 +269,23 @@ with IECore.IgnoredExceptions( ImportError ) :
 			"description" : "Enables recovery from a checkpoint created by a previous render.",
 			"label" : "Checkpoint Recover",
 			"layout:section" : Gaffer.Metadata.value( "option:ri:checkpoint:interval", "layout:section" ),
+			"plugValueWidget:type" : "GafferUI.BoolPlugValueWidget",
+
+		},
+
+		"option:ri:progressMode" : {
+
+			"defaultValue" : 0,
+			"description" : "Reports render progress percentage.",
+			"label" : "Report Progress",
+			# The statistics section isn't ideal for this, but of the available
+			# sections it's the one that makes most sense. It seems daft to make
+			# a new section for this one thing.
+			"layout:section" : Gaffer.Metadata.value( "option:ri:statistics:jsonFilename", "layout:section" ),
+			# In theory RenderMan accepts values of 0, 1 and 2, but the
+			# distinction (whether or not a linefeed is used) is lost by the
+			# time it is passed through our MessageHandlers. So just present as
+			# a simple boolean option.
 			"plugValueWidget:type" : "GafferUI.BoolPlugValueWidget",
 
 		},


### PR DESCRIPTION
As with checkpoint recovery, there is no real RenderMan option for this - instead we register it ourselves and convert it into a `-progress` argument to the "command line arguments" we pass to `PRManRenderBegin()`.

I wasn't sure what name to use for the option. I looked through the RenderMan USD schemas and there isn't anything to follow there. `hdPrman` internally passes a `progressMode` parameter to `Riley::Render()`, but when I tried that it did nothing. And the `progressMode` used by `hdPrman` is derived from a `-progress` "command line" argument anyway. Unfortunately the commit that introduced this is logged as "A few random changes to hdPrman" and doesn't shed any further light. So I just called it `progress`.

It should also be noted that RenderMan has both a `-progress` and a `-Progress` argument, with the difference being whether or not each percentage goes on a new line. This distinction is irrelevant once passed through our message handler though, so I went for a simple on/off boolean rather than something enum-like.
