### PR TITLE
ExtensionAlgo : Add `childNodesAreReadOnly` metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,12 @@ Improvements
 
 - GraphEditor : Improved responsiveness of select-drag, by deferring NodeEditor update until the drag ends.
 
+Fixes
+-----
+
+- Anaglyph, ArnoldProcedural, ContactSheet, FocalBlur, MetadataOverlay, PromotePointInstances : Fixed bug that allowed the internal nodes to be edited.
+- ExtensionAlgo : Exported extensions now have `childNodesAreReadOnly` metadata applied correctly.
+
 API
 ---
 

--- a/python/Gaffer/ExtensionAlgo.py
+++ b/python/Gaffer/ExtensionAlgo.py
@@ -191,7 +191,9 @@ Gaffer.Metadata.registerNode(
 
 	{moduleName}.{name},
 
+	"childNodesAreReadOnly", True,
 {metadata}
+
 {plugMetadata}
 
 )

--- a/python/GafferTest/ExtensionAlgoTest.py
+++ b/python/GafferTest/ExtensionAlgoTest.py
@@ -95,6 +95,8 @@ class ExtensionAlgoTest( GafferTest.TestCase ) :
 			self.assertEqual( Gaffer.Metadata.value( node["out"], "description" ), "The output" )
 			self.assertEqual( Gaffer.Metadata.value( node["in"], "test" ), 1 )
 
+			self.assertTrue( Gaffer.MetadataAlgo.readOnly( node["__add"] ) )
+
 		assertExpectedMetadata( script["node"] )
 
 		# Copy/paste and test


### PR DESCRIPTION
The internal node graph is an implementation detail, and shouldn't be edited by a user since the changes won't be serialised.
