### PR TITLE
.gitignore : Ignore `bin/__private/*.o`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ doc/python
 include/Gaffer/Version.h
 contrib/openColorIOPandemonium/luts/*.spi1d
 contrib/openColorIOPandemonium/luts/*.cube
+bin/__private/*.o
 
 # clang compile commands
 compile_commands.json


### PR DESCRIPTION
This is backported from 40c3fb8fe1e4f17bd9364a61b8c04e8f9bd61d29 which added the gaffer executable.