### PR TITLE
PlugValueWidgetTest : Fix bug in `testContextForEditorSettings()`

### DIFF
--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -394,13 +394,11 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		editor.settings()["__contextQuery"].addQuery( Gaffer.StringPlug(), "testVariable" )
 		editor.settings()["testPlug"].setInput( editor.settings()["__contextQuery"]["out"][0]["value"] )
 
-		with GafferUI.Window() as window :
-			widget = self.UpdateCountPlugValueWidget( editor.settings()["testPlug"] )
+		widget = self.UpdateCountPlugValueWidget( editor.settings()["testPlug"] )
 
 		# Editor not viewing anything yet, so we just use the default
 		# script context.
 
-		window.setVisible( True )
 		self.waitForUpdate( widget )
 		self.assertEqual( widget.updateCount, 2 ) # One at the start of the background update, and one on completion
 		self.assertEqual( widget.updateContexts[1], script.context() )


### PR DESCRIPTION
This was causing the following intermittent timeout on CI :

```
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/python/GafferUITest/PlugValueWidgetTest.py", line 404, in testContextForEditorSettings
    self.waitForUpdate( widget )
  File "/__w/gaffer/gaffer/build/python/GafferUITest/PlugValueWidgetTest.py", line 62, in waitForUpdate
    handler.assertCalled()
  File "/__w/gaffer/gaffer/build/python/GafferTest/ParallelAlgoTest.py", line 92, in assertCalled
    self.receive( timeout )()
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/gaffer/gaffer/build/python/GafferTest/ParallelAlgoTest.py", line 86, in receive
    raise AssertionError( "UIThread call not made within {} seconds".format( timeout ) )
AssertionError: UIThread call not made within 30.0 seconds
```

The issue was that we were putting the widget in a window, and when the window was made visible it triggered the `__callUpdateFromValues()` LazyMethod. This meant we were now in a race with the creation of the `UIThreadCallHandler` in `waitForUpdate()`. If the background update completed before the UIThreadCallHandler was constructed, then there would be nothing to wait for.

The solution is to mirror what we do in other tests in this file. Don't let the widget become visible, allowing us to manually flush the LazyMethod in `waitForUpdate()`, after the UIThreadCallHandler has been constructed.
