### PR TITLE
OptionalValuePlugValueWidget : Register Spreadsheet value formatter

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.15.0)
 =======
 
+Fixes
+-----
 
+- Spreadsheet : Fixed formatting of OptionalValuePlug values, such as for the renderer-specific plugs on USDLight nodes.
 
 1.6.15.0 (relative to 1.6.14.2)
 ========

--- a/python/GafferUI/OptionalValuePlugValueWidget.py
+++ b/python/GafferUI/OptionalValuePlugValueWidget.py
@@ -82,3 +82,15 @@ class OptionalValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 GafferUI.PlugValueWidget.registerType( Gaffer.OptionalValuePlug, OptionalValuePlugValueWidget )
 
 Gaffer.Metadata.registerValue( Gaffer.OptionalValuePlug, "enabled", "boolPlugValueWidget:displayMode", "switch" )
+
+def __spreadsheetFormatter( plug, forToolTip ) :
+
+	return GafferUI.SpreadsheetUI.formatValue( plug["value"], forToolTip )
+
+GafferUI.SpreadsheetUI.registerValueFormatter( Gaffer.OptionalValuePlug, __spreadsheetFormatter )
+
+def __spreadsheetDecorator( plug ) :
+
+	return GafferUI.SpreadsheetUI.decoration( plug["value"] )
+
+GafferUI.SpreadsheetUI.registerDecoration( Gaffer.OptionalValuePlug, __spreadsheetDecorator )


### PR DESCRIPTION
Without this, the spreadsheet shows a blank cell.

The equivalent formatter in NameValuePlugValueWidget.py has some special handling for cases where the spreadsheet hasn't adopted the `enabled` plug (see `RowsPlug::addColumn()`). But I have deliberately not catered for that case here, because we think enabled plugs should _always_ be adopted, and OptionalValuePlug was introduced after we started making that the case.
