### PR TITLE
ExtensionAlgo : Don't derive nodes from SubGraph

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -76,6 +76,7 @@ Breaking Changes
 - OpenColorIO : Removed "Legacy (Gaffer 1.2)" config.
 - GLWidget : Removed built-in support for hosting in Maya and Houdini. Implement host integration via `GLWidget._registerQGLWidgetCreator()` instead.
 - StandardLightVisualiser : Made `surfaceTexture()` private. The new `registerSurfaceTexture()` method can be used to register a method to return surface texture data.
+- ExtensionAlgo : Changed base class for extension nodes from SubGraph to DependencyNode.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,8 @@ Fixes
 API
 ---
 
+- SubGraph : Clarified via documentation that SubGraph is _not_ intended as a base class for custom nodes. Nodes should derive from DependencyNode
+  or some other base class instead.
 - Metadata : `ValueFunctions` now receive a `target` parameter. This is particularly useful when registering a function against a wildcard pattern.
 - PlugAlgo : Added `RampffData` and `RampfColor3fData` support to `createPlugFromData()`.
 - Widget :

--- a/include/Gaffer/SubGraph.h
+++ b/include/Gaffer/SubGraph.h
@@ -41,6 +41,10 @@
 namespace Gaffer
 {
 
+/// > Caution : This is _not_ expected to be used as a base class for
+/// > custom nodes. Any Node can use an internal network without needing to
+/// > inherit from SubGraph. SubGraph is only intended for use when the user
+/// > will interact directly with the internal network.
 class GAFFER_API SubGraph : public DependencyNode
 {
 

--- a/python/Gaffer/ExtensionAlgo.py
+++ b/python/Gaffer/ExtensionAlgo.py
@@ -122,19 +122,53 @@ def __indent( text, n ) :
 	prefix = "\t" * n
 	return "\n".join( prefix + l for l in text.split( "\n" ) )
 
+__enabledPlugMethodTemplate = """
+def enabledPlug( self ) :
+
+	return self["{enabledPlugName}"]
+"""
+
+__correspondingInputMethodTemplate = """
+def correspondingInput( self, output ) :
+
+	inputs = {correspondingInputs}
+	return self.descendant( inputs.get( output.relativeName( self ), "" ) )
+"""
+
+def __dependencyNodeMethodDefinitions( box ) :
+
+	enabledPlug = box.enabledPlug()
+	if enabledPlug is None :
+		return ""
+
+	result = __enabledPlugMethodTemplate.format( enabledPlugName = enabledPlug.getName() )
+
+	correspondingInputs = {}
+	for outputPlug in Gaffer.Plug.RecursiveOutputRange( box ) :
+		inputPlug = box.correspondingInput( outputPlug )
+		if inputPlug is not None :
+			correspondingInputs[outputPlug.relativeName( box )] = inputPlug.relativeName( box )
+
+	if correspondingInputs :
+		result += __correspondingInputMethodTemplate.format(
+			correspondingInputs = "{\n" + "\n".join( f'\t\t"{k}" : "{v}"' for k, v in correspondingInputs.items() ) + "\n\t}"
+		)
+
+	return result
+
 __nodeTemplate = """\
 {imports}
 
-class {name}( Gaffer.SubGraph ) :
+class {name}( Gaffer.DependencyNode ) :
 
 	def __init__( self, name = "{name}" ) :
 
-		Gaffer.SubGraph.__init__( self, name )
+		Gaffer.DependencyNode.__init__( self, name )
 
 {constructor}
 
 		self.__removeDynamicFlags()
-
+{dependencyNodeMethods}
 	# Remove dynamic flags using the same logic used by the Reference node.
 	## \todo : Create the plugs without the flags in the first place.
 	def __removeDynamicFlags( self ) :
@@ -178,7 +212,8 @@ def __nodeDefinition( box, moduleName ) :
 		imports = "\n".join( sorted( imports ) ),
 		name = box.getName(),
 		constructor = __indent( "\n".join( constructorLines ), 2 ),
-		moduleName = moduleName
+		dependencyNodeMethods = __indent( __dependencyNodeMethodDefinitions( box ), 1 ),
+		moduleName = moduleName,
 	)
 
 __uiTemplate = """\

--- a/python/GafferImageTest/MetadataOverlayTest.py
+++ b/python/GafferImageTest/MetadataOverlayTest.py
@@ -1,0 +1,52 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferImage
+import GafferImageTest
+
+class MetadataOverlayTest( GafferImageTest.ImageTestCase ) :
+
+	def testDependencyNodeMethods( self ) :
+
+		node = GafferImage.MetadataOverlay()
+		self.assertIsInstance( node, Gaffer.DependencyNode )
+
+		self.assertTrue( node.enabledPlug().isSame( node["enabled"] ) )
+		self.assertTrue( node.correspondingInput( node["out"] ).isSame( node["in"] ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -119,6 +119,7 @@ from .ShuffleImageMetadataTest import ShuffleImageMetadataTest
 from .DiskBlurTest import DiskBlurTest
 from .DataWindowQueryTest import DataWindowQueryTest
 from .SATBlurTest import SATBlurTest
+from .MetadataOverlayTest import MetadataOverlayTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferTest/ExtensionAlgoTest.py
+++ b/python/GafferTest/ExtensionAlgoTest.py
@@ -157,5 +157,38 @@ class ExtensionAlgoTest( GafferTest.TestCase ) :
 		self.assertEqual( script["node1"].keys(), script["node"].keys() )
 		self.assertEqual( script["node1"]["out"].getValue(), 3 )
 
+	def testDependencyNodeMethods( self ) :
+
+		box = Gaffer.Box( "TestDependencyNode" )
+
+		box["__add"] = GafferTest.AddNode()
+
+		box["__in"] = Gaffer.BoxIn()
+		box["__in"].setup( box["__add"]["op1"] )
+		box["__add"]["op1"].setInput( box["__in"]["out"] )
+
+		box["__out"] = Gaffer.BoxOut()
+		box["__out"].setup( box["__add"]["sum"] )
+		box["__out"]["in"].setInput( box["__add"]["sum"] )
+		box["__out"]["passThrough"].setInput( box["__in"]["out"] )
+
+		def assertPassThrough( node ) :
+
+			self.assertIsNotNone( node.enabledPlug() )
+			self.assertTrue( node.enabledPlug().isSame( node["enabled"] ) )
+			self.assertTrue( node.correspondingInput( node["out"] ).isSame( node["in"] ) )
+
+		assertPassThrough( box )
+
+		Gaffer.ExtensionAlgo.exportExtension( "TestDependencyNodeExtension", [ box ], self.temporaryDirectory() )
+		sys.path.append( str( self.temporaryDirectory() / "python" ) )
+		import TestDependencyNodeExtension
+
+		node = TestDependencyNodeExtension.TestDependencyNode()
+		self.assertIsInstance( node, Gaffer.DependencyNode )
+		self.assertFalse( isinstance( node, Gaffer.SubGraph ) )
+
+		assertPassThrough( node )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
SubGraph is intended as a base class for nodes where the user interacts with the child nodes. While that is the case while the user authors an extension node as a Box, it is not the case once the extension has been exported. So we export as a node derived from DependencyNode instead.

This means manually defining the `enabledPlug()` and `correspondingInput()` methods that we were inheriting from SubGraph. But they're pretty simple to implement since their results are statically determined - we just gather the results from SubGraph at export time, and dole them out from the methods when asked. An alternative to this would be to have a version of the original C++ methods available somewhere statically so they could be called by the extension. But that would be a bit of an API wart, and is more complex than necessary. I quite like that the extension is now closer to the code someone would write by hand if they were creating a Python node.

This further clears the decks in preparation for #5664.