### PR TITLE
InspectorColumn : Support ShaderNetwork `label` metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - SceneInspector, AttributeEditor, HierarchyView, LightEditor, RenderPassEditor : Added inspection of scene edits performed by render adaptors registered to `client = "SceneEditor"`, such as those used by the Render Pass Editor to modify the scene at render time. Cells with values sourced from a render adaptor are displayed with a faded orange background and cannot be directly edited as render adaptors exist externally to the script and are not user-editable. The `render:defaultRenderer` option must be set in the scene globals in order for renderer-specific edits to be shown.
 - Render, InteractiveRender : The `render:defaultRenderer` option is now created as a fallback when viewing these nodes. The option is created with the current value of the node's `renderer` plug so Editors can display edits from render adaptors matching the currently selected renderer.
+- SceneInspector : Added support for the custom label created by the `ShaderAssignment.label` plug (#6872).
 
 Fixes
 -----

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -435,8 +435,12 @@ class Shader::NetworkBuilder
 			m_hasProxyNodes |= ShaderTweakProxy::isProxy( shader.get() );
 
 			const std::string nodeName = shaderNode->nodeNamePlug()->getValue();
+			/// \todo  Stop storing `label` and `gaffer:nodeName` metadata. It
+			/// was just used as a crutch until the SceneInspector could show
+			/// the history of the shader, which it now can. And either remove
+			/// `gaffer:nodeColor` metadata or update the SceneInspector to show
+			/// it again.
 			shader->blindData()->writable()[g_label] = new IECore::StringData( nodeName );
-			// \todo: deprecated, stop storing gaffer:nodeName after a grace period
 			shader->blindData()->writable()[g_gafferNodeName] = new IECore::StringData( nodeName );
 			shader->blindData()->writable()[g_gafferNodeColor] = new IECore::Color3fData( shaderNode->nodeColorPlug()->getValue() );
 

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -65,6 +65,8 @@ const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = 
 const Color4fDataPtr g_fallbackValueForegroundColor = new Color4fData( Imath::Color4f( 163, 163, 163, 255 ) / 255.0f );
 const ConstStringDataPtr g_missingOutputShader = new StringData( "Missing output shader" );
 const StringDataPtr g_shaderConnectionIcon = new StringData( "sceneInspectorShaderConnection.png" );
+const InternedString g_shaderLabel( "label" );
+const InternedString g_shaderNodeName( "gaffer:nodeName" );
 
 }  // namespace
 
@@ -208,7 +210,23 @@ PathColumn::CellData InspectorColumn::cellDataFromValue( const IECore::Object *v
 		/// somewhere. Or perhaps if InspectorColumn moves to GafferUI, we would
 		/// just derive a specialisation from it in GafferSceneUI.
 		const IECoreScene::Shader *shader = shaderNetwork->outputShader();
-		return CellData( shader ? new StringData( shader->getName() ) : g_missingOutputShader );
+		if( !shader )
+		{
+			return CellData( g_missingOutputShader );
+		}
+		auto label = shader->blindData()->member<StringData>( g_shaderLabel );
+		auto nodeName = shader->blindData()->member<StringData>( g_shaderNodeName );
+		if( label && (!nodeName || label->readable() != nodeName->readable() ) )
+		{
+			// The Shader node creates `label` and `gaffer:nodeName` metadata
+			// with identical values. If the label is different it is because
+			// the user has provided something meaningful via the
+			// `ShaderAssignment.label` plug, so show that.
+			/// \todo Remove metadata creation from Shader.cpp and simplify the
+			/// logic here.
+			return CellData( label );
+		}
+		return CellData( new StringData( shader->getName() ) );
 	}
 	else if( const auto shader = runTimeCast<const IECoreScene::Shader>( value ) )
 	{


### PR DESCRIPTION
Fixes #6872.

In the discussion for that issue, I made out that this would be a bit tricky :

> But there's a problem : a label exists on the shader even if it hasn't been overridden by the ShaderAssignment node, so we currently can't know if you used that feature or not. 

But fortuitously, we can use the deprecated `gaffer:nodeName` blind data to tell if the label has been explicitly authored by the user using `ShaderAssignment.label`. So that's what we do. On `main` we can simplify this further by stripping out the blind data creation from Shader.cpp entirely.