### PR TITLE
InteractiveCyclesRenderTest : Increase point light intensity

### DIFF
--- a/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
+++ b/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
@@ -101,6 +101,8 @@ class InteractiveCyclesRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		light = GafferCycles.CyclesLight()
 		light.loadShader( "point_light" )
+		# Increase intensity to match a default Arnold point_light.
+		light["parameters"]["intensity"].setValue( 5.0 )
 		return light, light["parameters"]["color"]
 
 	def _createSpotLight( self ) :


### PR DESCRIPTION
We've been seeing intermittent failures of `InteractiveCyclesRenderTest.testLightsWithSVM`, particularly with linux-debug builds on CI. That test is asserting the render converges to normalised pixel values matching the colour of the light, though even with the increased render time offered by `assertEventually()` the assertions never reach their expected colour. The contribution of a default Cycles point_light is very low compared to the Arnold equivalent, so this PR tries increasing the intensity to 5.0 to match the Arnold point_light contribution, giving us brighter pixel values to normalise and compare.
