### PR TITLE
PathColumn : Provide root path to headerData

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -55,6 +55,7 @@ API
   - Improved automatic parenting via the `with parent` syntax. Children are now guaranteed to be fully constructed before they are parented.
   - Turned `toolTip`, `parenting` and `displayTransform` keyword-only constructor arguments.
 - Light : Simplified implementation of derived classes, which are now merely responsible for passing a Shader node to the base class constructor.
+- PathColumn : `headerData()` is now passed the root Path.
 
 Breaking Changes
 ----------------
@@ -92,6 +93,7 @@ Breaking Changes
 - OSLShader : Removed ability to load from `.gfr` files prior to version 0.45.0.0. If necessary, resave from Gaffer 1.6.
 - Light : Removed public constructor. Lights may now only be constructed via derived classes, which are now responsible for providing a Shader node to the base class.
 - OSLCode : Removed `shaderCompiledSignal()`.
+- PathColumn : Changed `headerData()` signature.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -43,6 +43,7 @@ Fixes
 - CyclesLight, ArnoldLight, LightFilter : Fixed potential hang when loading shaders (GIL management bug in `loadShader()` binding).
 - StandardNodeGadget : Fixed crash caused by the node emitting `errorSignal()` while the gadget is undergoing construction.
 - Shader : Fixed hash for output plugs.
+- LightEditor : Fixed context used to compute the solo column header icon, this now uses the correct context with respect to the focus node.
 
 API
 ---

--- a/include/GafferSceneUI/Private/InspectorColumn.h
+++ b/include/GafferSceneUI/Private/InspectorColumn.h
@@ -70,7 +70,7 @@ class GAFFERSCENEUI_API InspectorColumn : public GafferUI::PathColumn
 		Gaffer::ConstContextPtr inspectorContext( const Gaffer::Path &path, const IECore::Canceller *canceller = nullptr ) const;
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
-		CellData headerData( const IECore::Canceller *canceller ) const override;
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override;
 
 		/// Exposes the value-formatting part of `cellData()` so that it may
 		/// be reused by `_HistoryWindow`.

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -148,7 +148,7 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		/// Returns the data needed to draw a column cell.
 		virtual CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller = nullptr ) const = 0;
 		/// Returns the data needed to draw a column header.
-		virtual CellData headerData( const IECore::Canceller *canceller = nullptr ) const = 0;
+		virtual CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller = nullptr ) const = 0;
 
 		using PathColumnSignal = Gaffer::Signals::Signal<void ( PathColumn * ), Gaffer::Signals::CatchingCombiner<void>>;
 		/// Subclasses should emit this signal when something changes
@@ -225,7 +225,7 @@ class GAFFERUI_API StandardPathColumn : public PathColumn
 		IECore::InternedString property() const;
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
-		CellData headerData( const IECore::Canceller *canceller ) const override;
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override;
 
 	private :
 
@@ -257,7 +257,7 @@ class GAFFERUI_API IconPathColumn : public PathColumn
 		IECore::InternedString property() const;
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
-		CellData headerData( const IECore::Canceller *canceller ) const override;
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override;
 
 	private :
 
@@ -281,7 +281,7 @@ class GAFFERUI_API FileIconPathColumn : public PathColumn
 		FileIconPathColumn( PathColumn::SizeMode sizeMode = Default );
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
-		CellData headerData( const IECore::Canceller *canceller ) const override;
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override;
 
 	private :
 

--- a/python/GafferDispatchUI/LocalJobs.py
+++ b/python/GafferDispatchUI/LocalJobs.py
@@ -140,7 +140,7 @@ class _StatusColumn( GafferUI.PathColumn ) :
 			sortValue = int( GafferDispatch.LocalDispatcher.Job.Status[status] )
 		)
 
-	def headerData( self, canceller ) :
+	def headerData( self, rootPath, canceller ) :
 
 		return GafferUI.PathColumn.CellData( value = "Status" )
 
@@ -159,7 +159,7 @@ class _RunningTimeColumn( GafferUI.PathColumn ) :
 			sortValue = seconds
 		)
 
-	def headerData( self, canceller ) :
+	def headerData( self, rootPath, canceller ) :
 
 		return GafferUI.PathColumn.CellData( value = "Running Time" )
 
@@ -175,7 +175,7 @@ class _CPUUsageColumn( GafferUI.PathColumn ) :
 			toolTip = "CPU usage for current batch"
 		)
 
-	def headerData( self, canceller ) :
+	def headerData( self, rootPath, canceller ) :
 
 		return GafferUI.PathColumn.CellData( value = "CPU" )
 
@@ -191,7 +191,7 @@ class _MemoryUsageColumn( GafferUI.PathColumn ) :
 			toolTip = "Memory usage for current batch"
 		)
 
-	def headerData( self, canceller ) :
+	def headerData( self, rootPath, canceller ) :
 
 		return GafferUI.PathColumn.CellData( value = "Memory" )
 

--- a/python/GafferSceneUI/CatalogueUI.py
+++ b/python/GafferSceneUI/CatalogueUI.py
@@ -126,7 +126,7 @@ class Column( GafferUI.PathColumn ) :
 
 		return self.CellData()
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( value = self.__title )
 
@@ -320,7 +320,7 @@ class __OutputIndexColumn( Column ) :
 		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ) )
 		self.buttonReleaseSignal().connect( Gaffer.WeakMethod( self.__buttonRelease ) )
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( icon = "catalogueOutputHeader.png", toolTip = "Output Index" )
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1030,7 +1030,7 @@ class _AdderColumn( GafferUI.PathColumn ) :
 
 		return GafferUI.PathColumn.CellData( value = "", toolTip = "Click on the header to add columns." )
 
-	def headerData( self, canceller ) :
+	def headerData( self, rootPath, canceller ) :
 
 		return GafferUI.PathColumn.CellData( value = "", icon = IECore.CompoundData( { "state:normal" : "plus.png", "state:highlighted" : "plusHighlighted.png" } ), toolTip = "Click to add columns." )
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -457,7 +457,7 @@ class _DuplicateIconColumn ( GafferUI.PathColumn ) :
 
 		return data
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( self.__title )
 
@@ -492,7 +492,7 @@ class _ShaderInputColumn ( GafferUI.PathColumn ) :
 
 		return data
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( self.__title )
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -429,7 +429,7 @@ GafferUI.GraphEditor.plugContextMenuSignal().connect( __graphEditorPlugContextMe
 # ShaderParameterDialog
 ##########################################################################
 
-class _DuplicateIconColumn ( GafferUI.PathColumn ) :
+class _DuplicateIconColumn( GafferUI.PathColumn ) :
 
 	def __init__( self, title, property ) :
 
@@ -461,7 +461,7 @@ class _DuplicateIconColumn ( GafferUI.PathColumn ) :
 
 		return self.CellData( self.__title )
 
-class _ShaderInputColumn ( GafferUI.PathColumn ) :
+class _ShaderInputColumn( GafferUI.PathColumn ) :
 
 	def __init__( self, title ) :
 

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -107,7 +107,7 @@ class _OperationIconColumn( GafferUI.PathColumn ) :
 
 		return data
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( "Operation" )
 
@@ -128,7 +128,7 @@ class _NodeNameColumn( GafferUI.PathColumn ) :
 		else :
 			return self.CellData( node.relativeName( node.scriptNode() ) )
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( "Node" )
 
@@ -152,7 +152,7 @@ class _ValueColumn( GafferUI.PathColumn ) :
 
 		return data
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( "Value" )
 
@@ -177,7 +177,7 @@ class _ContextVariableColumn( GafferUI.PathColumn ) :
 
 		return self.CellData( value )
 
-	def headerData( self, canceller = None ) :
+	def headerData( self, rootPath, canceller = None ) :
 
 		return self.CellData( "${{{}}}".format( self.__variable ) )
 

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -122,7 +122,8 @@ def __toggleableInspections( pathListing ) :
 	nonEditableReason = ""
 	toggleShouldDisable = True
 
-	path = pathListing.getPath().copy()
+	rootPath = pathListing.getPath()
+	path = rootPath.copy()
 	for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 		for pathString in columnSelection.paths() :
 			path.setFromString( pathString )
@@ -141,7 +142,7 @@ def __toggleableInspections( pathListing ) :
 				inspections.append( inspection )
 			elif nonEditableReason == "" :
 				# Prefix reason with the column header to disambiguate when more than one column has selection
-				nonEditableReason = "{} : ".format( column.headerData().value ) if len( [ x for x in pathListing.getSelection() if not x.isEmpty() ] ) > 1 else ""
+				nonEditableReason = "{} : ".format( column.headerData( rootPath ).value ) if len( [ x for x in pathListing.getSelection() if not x.isEmpty() ] ) > 1 else ""
 				nonEditableReason += inspection.nonDisableableReason() if toggleShouldDisable else inspection.nonEditableReason()
 
 	return inspections, nonEditableReason, toggleShouldDisable
@@ -284,9 +285,10 @@ def __showHistory( pathListing ) :
 	columns = pathListing.getColumns()
 	selection = pathListing.getSelection()
 
+	rootPath = pathListing.getPath()
+	path = rootPath.copy()
 	for i, column in enumerate( columns ) :
 		for pathString in selection[i].paths() :
-			path = pathListing.getPath().copy()
 			path.setFromString( pathString )
 			if column.inspectorContext( path ) is None or column.inspector( path ) is None :
 				continue
@@ -294,7 +296,7 @@ def __showHistory( pathListing ) :
 				column,
 				pathListing.getPath(),
 				pathString,
-				"History : {} : {}".format( pathString, column.headerData().value )
+				"History : {} : {}".format( pathString, column.headerData( rootPath ).value )
 			)
 			pathListing.ancestor( GafferUI.Window ).addChildWindow( window, removeOnClose = True )
 			window.setVisible( True )
@@ -810,7 +812,6 @@ def _copySelectedValues( pathListing ) :
 ## Returns the pathListing selection as data, or the reason why the selection is not valid.
 def _dataFromPathListingOrReason( pathListing ) :
 
-	path = pathListing.getPath().copy()
 	selection = __orderedSelection( pathListing )
 
 	if not selection :
@@ -822,6 +823,8 @@ def _dataFromPathListingOrReason( pathListing ) :
 		## \todo Relax this constraint?
 		return "Each row in the selection must contain the same number of cells."
 
+	rootPath = pathListing.getPath()
+	path = rootPath.copy()
 	objectMatrix = IECore.ObjectMatrix( len( selection ), numColumns )
 	rowIndex = 0
 	for pathString, columns in selection :
@@ -843,7 +846,7 @@ def _dataFromPathListingOrReason( pathListing ) :
 			if value is None :
 				reason = "No value to copy."
 				if len( columns ) > 1 :
-					return "{} : {}".format( column.headerData().value, reason )
+					return "{} : {}".format( column.headerData( rootPath ).value, reason )
 				else :
 					return reason
 
@@ -935,7 +938,8 @@ def __pasteFunctionsOrNonPasteableReason( pathListing, objectMatrix ) :
 
 	pasteFunctions = []
 
-	path = pathListing.getPath().copy()
+	rootPath = pathListing.getPath()
+	path = rootPath.copy()
 	selection = __orderedSelection( pathListing )
 	## \todo Allow a N x 1 or 1 x N sized clipboard to be pasted as either a row or column
 	for rowIndex, (pathString, columns) in enumerate( selection ) :
@@ -954,7 +958,7 @@ def __pasteFunctionsOrNonPasteableReason( pathListing, objectMatrix ) :
 			if inspection.canEdit( value ) :
 				pasteFunctions.append( functools.partial( inspection.edit, value ) )
 			elif len( columns ) > 1 :
-				return "{} : {}".format( column.headerData().value, inspection.nonEditableReason( value ) )
+				return "{} : {}".format( column.headerData( rootPath ).value, inspection.nonEditableReason( value ) )
 			else :
 				return inspection.nonEditableReason( value )
 

--- a/python/GafferSceneUITest/InspectorColumnTest.py
+++ b/python/GafferSceneUITest/InspectorColumnTest.py
@@ -135,20 +135,20 @@ class InspectorColumnTest( GafferUITest.TestCase ) :
 		c = GafferSceneUI.Private.InspectorColumn( inspector, "label", "help!" )
 		self.assertEqual( c.inspector( path ), inspector )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
-		self.assertEqual( c.headerData().value, "Label" )
-		self.assertEqual( c.headerData().toolTip, "help!" )
+		self.assertEqual( c.headerData( path ).value, "Label" )
+		self.assertEqual( c.headerData( path ).toolTip, "help!" )
 
 		c = GafferSceneUI.Private.InspectorColumn( inspector, "Fancy ( Label )", "" )
 		self.assertEqual( c.inspector( path ), inspector )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
-		self.assertEqual( c.headerData().value, "Fancy ( Label )" )
-		self.assertEqual( c.headerData().toolTip, "" )
+		self.assertEqual( c.headerData( path ).value, "Fancy ( Label )" )
+		self.assertEqual( c.headerData( path ).toolTip, "" )
 
 		c = GafferSceneUI.Private.InspectorColumn( inspector )
 		self.assertEqual( c.inspector( path ), inspector )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
-		self.assertEqual( c.headerData().value, "Gl:visualiser:scale" )
-		self.assertEqual( c.headerData().toolTip, "" )
+		self.assertEqual( c.headerData( path ).value, "Gl:visualiser:scale" )
+		self.assertEqual( c.headerData( path ).toolTip, "" )
 
 		c = GafferSceneUI.Private.InspectorColumn(
 			inspector,
@@ -157,8 +157,8 @@ class InspectorColumnTest( GafferUITest.TestCase ) :
 		)
 		self.assertEqual( c.inspector( path ), inspector )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
-		self.assertEqual( c.headerData().value, "Fancy ( Label )" )
-		self.assertEqual( c.headerData().toolTip, "help!" )
+		self.assertEqual( c.headerData( path ).value, "Fancy ( Label )" )
+		self.assertEqual( c.headerData( path ).toolTip, "help!" )
 
 	def testObjectMatrixFromSelection( self ) :
 

--- a/python/GafferSceneUITest/LightEditorTest.py
+++ b/python/GafferSceneUITest/LightEditorTest.py
@@ -758,16 +758,16 @@ class LightEditorTest( GafferUITest.TestCase ) :
 
 		# Find the columns for our `add.a` and `exposure` parameters
 		widget = editor._LightEditor__pathListing
-
+		path = widget.getPath()
 		addAInspector = None
 		exposureInspector = None
 		for c in widget.getColumns() :
 			if not isinstance( c, GafferSceneUI.Private.InspectorColumn ) :
 				continue
-			if c.headerData().value == "A" :
-				addAInspector = c.inspector( widget.getPath() )
-			elif c.headerData().value == "Exposure" :
-				exposureInspector = c.inspector( widget.getPath() )
+			if c.headerData( path ).value == "A" :
+				addAInspector = c.inspector( path )
+			elif c.headerData( path ).value == "Exposure" :
+				exposureInspector = c.inspector( path )
 
 		self.assertIsNotNone( addAInspector )
 		self.assertIsNotNone( exposureInspector )
@@ -811,8 +811,9 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
 
 		widget = editor._LightEditor__pathListing
+		path = widget.getPath()
 
-		columnNames = [ c.headerData().value for c in widget.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in widget.getColumns() ]
 		self.assertIn( "P", columnNames )
 		self.assertIn( "X", columnNames )
 		self.assertIn( "A", columnNames )
@@ -824,7 +825,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		editor._LightEditor__updateColumns()
 		GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
 
-		columnNames = [ c.headerData().value for c in widget.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
 		self.assertIn( "X", columnNames )
 		self.assertIn( "A", columnNames )
@@ -836,7 +837,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		editor._LightEditor__updateColumns()
 		GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
 
-		columnNames = [ c.headerData().value for c in widget.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
 		self.assertNotIn( "X", columnNames )
 		self.assertIn( "A", columnNames )
@@ -848,7 +849,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		editor._LightEditor__updateColumns()
 		GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
 
-		columnNames = [ c.headerData().value for c in widget.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
 		self.assertNotIn( "X", columnNames )
 		self.assertNotIn( "A", columnNames )
@@ -860,7 +861,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		editor._LightEditor__updateColumns()
 		GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
 
-		columnNames = [ c.headerData().value for c in widget.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
 		self.assertNotIn( "X", columnNames )
 		self.assertNotIn( "A", columnNames )
@@ -872,7 +873,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		editor._LightEditor__updateColumns()
 		GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
 
-		columnNames = [ c.headerData().value for c in widget.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
 		self.assertNotIn( "X", columnNames )
 		self.assertNotIn( "A", columnNames )

--- a/python/GafferSceneUITest/RenderPassEditorTest.py
+++ b/python/GafferSceneUITest/RenderPassEditorTest.py
@@ -450,8 +450,9 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 		GafferSceneUI.RenderPassEditor._RenderPassEditor__updateColumns.flush( editor )
 
 		pathListing = editor._RenderPassEditor__pathListing
+		path = pathListing.getPath()
 
-		columnNames = [ c.headerData().value for c in pathListing.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in pathListing.getColumns() ]
 		for columnName in [ "A", "B", "C", "D", "E" ] :
 			self.assertIn( columnName, columnNames )
 
@@ -460,7 +461,7 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 		editor._RenderPassEditor__updateColumns()
 		GafferSceneUI.RenderPassEditor._RenderPassEditor__updateColumns.flush( editor )
 
-		columnNames = [ c.headerData().value for c in pathListing.getColumns() ]
+		columnNames = [ c.headerData( path ).value for c in pathListing.getColumns() ]
 		self.assertNotIn( "B", columnNames )
 		self.assertIn( "A", columnNames )
 		self.assertIn( "C", columnNames )
@@ -480,8 +481,9 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 				self.addCleanup( GafferSceneUI.RenderPassEditor.deregisterColumn, "*", columnName, "Test" )
 
 			editor._RenderPassEditor__updateColumns()
+			path = editor._RenderPassEditor__pathListing.getPath()
 			GafferSceneUI.RenderPassEditor._RenderPassEditor__updateColumns.flush( editor )
-			columnNames = [ c.headerData().value for c in editor._RenderPassEditor__pathListing.getColumns() if isinstance( c, GafferSceneUI.Private.InspectorColumn ) ]
+			columnNames = [ c.headerData( path ).value for c in editor._RenderPassEditor__pathListing.getColumns() if isinstance( c, GafferSceneUI.Private.InspectorColumn ) ]
 			self.assertEqual( columnNames, order )
 
 			for columnName, _ in columns :

--- a/python/GafferUITest/PathColumnTest.py
+++ b/python/GafferUITest/PathColumnTest.py
@@ -40,6 +40,7 @@ import imath
 
 import IECore
 
+import Gaffer
 import GafferTest
 import GafferUI
 import GafferUITest
@@ -106,9 +107,10 @@ class PathColumnTest( GafferUITest.TestCase ) :
 	def testStandardPathColumnConstructors( self ) :
 
 		c = GafferUI.StandardPathColumn( "label", "property" )
+		path = Gaffer.Path()
 		self.assertEqual( c.property(), "property" )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
-		self.assertEqual( c.headerData().value, "label" )
+		self.assertEqual( c.headerData( path ).value, "label" )
 
 		c = GafferUI.StandardPathColumn(
 			GafferUI.PathColumn.CellData( value = "label", toolTip = "help!" ),
@@ -116,16 +118,17 @@ class PathColumnTest( GafferUITest.TestCase ) :
 		)
 		self.assertEqual( c.property(), "property" )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
-		self.assertEqual( c.headerData().value, "label" )
-		self.assertEqual( c.headerData().toolTip, "help!" )
+		self.assertEqual( c.headerData( path ).value, "label" )
+		self.assertEqual( c.headerData( path ).toolTip, "help!" )
 
 	def testIconPathColumnConstructors( self ) :
 
 		c = GafferUI.IconPathColumn( "label", "prefix", "property" )
+		path = Gaffer.Path()
 		self.assertEqual( c.prefix(), "prefix" )
 		self.assertEqual( c.property(), "property" )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
-		self.assertEqual( c.headerData().value, "label" )
+		self.assertEqual( c.headerData( path ).value, "label" )
 
 		c = GafferUI.IconPathColumn(
 			GafferUI.PathColumn.CellData( value = "label", toolTip = "help!" ),
@@ -134,8 +137,8 @@ class PathColumnTest( GafferUITest.TestCase ) :
 		self.assertEqual( c.prefix(), "prefix" )
 		self.assertEqual( c.property(), "property" )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
-		self.assertEqual( c.headerData().value, "label" )
-		self.assertEqual( c.headerData().toolTip, "help!" )
+		self.assertEqual( c.headerData( path ).value, "label" )
+		self.assertEqual( c.headerData( path ).toolTip, "help!" )
 
 	def testInstanceCreatedSignal( self ) :
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -1316,7 +1316,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 					time.sleep( 0.01 )
 					IECore.Canceller.check( canceller )
 
-			def headerData( self, canceller = None ) :
+			def headerData( self, rootPath, canceller = None ) :
 
 				return self.CellData( value = "Title" )
 
@@ -1862,9 +1862,9 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 				return self.CellData()
 
-			def headerData( self, canceller = None ) :
+			def headerData( self, rootPath, canceller = None ) :
 
-				return self.CellData( value = self.__title )
+				return self.CellData( value = self.__title, toolTip = str( rootPath ) )
 
 		path = self.InfinitePath( "/" )
 
@@ -1887,23 +1887,28 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		# When we first query the header, we should get nothing, because it won't
 		# have been evaluated yet.
 		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), None )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), None )
 		# But the query should trigger a background update that should update it
 		# asynchronously.
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( model ) )
 		self.assertEqual( changes, [ ( QtCore.Qt.Horizontal, 0, 0 ) ] )
 		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), "Title" )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), "/" )
 		# The next query shouldn't trigger any update.
 		del changes[:]
 		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), "Title" )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), "/" )
 		self.assertEqual( changes, [] )
 
 		# Changing the column title should trigger another async update.
 		widget.getColumns()[0].setTitle( "Title 2" )
 		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), "Title" )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), "/" )
 		self.assertEqual( changes, [] )
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( model ) )
 		self.assertEqual( changes, [ ( QtCore.Qt.Horizontal, 0, 0 ) ] )
 		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), "Title 2" )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), "/" )
 
 		# If the column changes for some other reason, then even though we'll
 		# get an async update happening, it won't find any changes to notify us
@@ -1913,6 +1918,17 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( model ) )
 		self.assertEqual( changes, [] )
 		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), "Title 2" )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), "/" )
+
+		# Changing the PathListingWidget's root path should trigger another async update.
+		widget.setPath( self.InfinitePath( "/other" ) )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), "Title 2" )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), "/" )
+		self.assertEqual( changes, [] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( model ) )
+		self.assertEqual( changes, [ ( QtCore.Qt.Horizontal, 0, 0 ) ] )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal ), "Title 2" )
+		self.assertEqual( model.headerData( 0, QtCore.Qt.Horizontal, QtCore.Qt.ToolTipRole ), "/other" )
 
 	def testUpdateFinished( self ) :
 
@@ -2002,7 +2018,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 			self.cellDataCalls.append( str( path ) )
 			return self.CellData( value = 1 )
 
-		def headerData( self, canceller = None ) :
+		def headerData( self, rootPath, canceller = None ) :
 
 			return self.CellData( value = "Title" )
 

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -165,7 +165,7 @@ PathColumn::CellData InspectorColumn::cellData( const Gaffer::Path &path, const 
 	return cellDataFromInspection( inspectorResult.get() );
 }
 
-PathColumn::CellData InspectorColumn::headerData( const IECore::Canceller *canceller ) const
+PathColumn::CellData InspectorColumn::headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const
 {
 	return m_headerData;
 }

--- a/src/GafferSceneUIModule/HierarchyViewBinding.cpp
+++ b/src/GafferSceneUIModule/HierarchyViewBinding.cpp
@@ -159,7 +159,7 @@ class InclusionsColumn : public PathColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
 			return CellData( /* value = */ nullptr, /* icon = */ m_visibleSet.inclusions.isEmpty() ? g_ancestorIncludedIconName : g_locationIncludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Inclusions" ) );
 		}
@@ -362,7 +362,7 @@ class ExclusionsColumn : public PathColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
 			return CellData( /* value = */ nullptr, /* icon = */ m_visibleSet.exclusions.isEmpty() ? g_ancestorExcludedIconName : g_locationExcludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Exclusions" ) );
 		}

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -317,46 +317,17 @@ class SetMembershipColumn : public InspectorColumn
 		{
 			CellData result = InspectorColumn::headerData( rootPath, canceller );
 
-			if( auto sceneInput = m_scene->getInput() )
+			ConstContextPtr context = inspectorContext( rootPath, canceller );
+			if( !context )
 			{
-				auto scriptNode = sceneInput->ancestor<ScriptNode>();
-
-				// Hack to recover ScriptNode from nodes hosted in an
-				// Editor.Settings node - see `BackgroundTask.cpp` and
-				// `Editor.Settings`.
-				/// \todo Provide root path to `headerData()` so we can do this more simply.
-				if( !scriptNode )
-				{
-					GraphComponent *graphComponent = sceneInput->parent();
-					while( graphComponent )
-					{
-						if( auto node = runTimeCast<Node>( graphComponent ) )
-						{
-							if( node->isInstanceOf( "GafferUI::Editor::Settings" ) )
-							{
-								if( auto p = node->getChild<Plug>( "__scriptNode" ) )
-								{
-									if( auto pInput = p->getInput() )
-									{
-										scriptNode = pInput->ancestor<ScriptNode>();
-										break;
-									}
-								}
-							}
-						}
-						graphComponent = graphComponent->parent();
-					}
-				}
-
-				if( scriptNode )
-				{
-					Context::EditableScope contextScope( scriptNode->context() );
-					contextScope.setCanceller( canceller );
-
-					ConstPathMatcherDataPtr setMembersData = m_scene->set( m_setName );
-					result.icon = setMembersData->readable().isEmpty() ? m_setEmpty : m_setHasMembers;
-				}
+				return result;
 			}
+
+			Context::EditableScope contextScope( context.get() );
+			contextScope.setCanceller( canceller );
+
+			ConstPathMatcherDataPtr setMembersData = m_scene->set( m_setName );
+			result.icon = setMembersData->readable().isEmpty() ? m_setEmpty : m_setHasMembers;
 
 			return result;
 		}

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -313,9 +313,9 @@ class SetMembershipColumn : public InspectorColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
-			CellData result = InspectorColumn::headerData( canceller );
+			CellData result = InspectorColumn::headerData( rootPath, canceller );
 
 			if( auto sceneInput = m_scene->getInput() )
 			{

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -610,7 +610,7 @@ class RenderPassActiveColumn : public PathColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
 			return CellData( nullptr, /* icon = */ g_activeRenderPassIcon, /* background = */ nullptr, new IECore::StringData( "The currently active render pass." ) );
 		}

--- a/src/GafferSceneUIModule/SetEditorBinding.cpp
+++ b/src/GafferSceneUIModule/SetEditorBinding.cpp
@@ -463,9 +463,9 @@ class SetMembersColumn : public StandardPathColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
-			CellData result = StandardPathColumn::headerData( canceller );
+			CellData result = StandardPathColumn::headerData( rootPath, canceller );
 			result.toolTip = new IECore::StringData( "The number of scene locations that are set members" );
 
 			return result;
@@ -509,7 +509,7 @@ class SetSelectionColumn : public PathColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
 			CellData result;
 			result.value = g_headerValue;
@@ -627,7 +627,7 @@ class VisibleSetInclusionsColumn : public PathColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
 			return CellData( /* value = */ nullptr, /* icon = */ m_visibleSet.inclusions.isEmpty() ? g_inclusionsEmptyIconName : g_setIncludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Inclusions" ) );
 		}
@@ -841,7 +841,7 @@ class VisibleSetExclusionsColumn : public PathColumn
 			return result;
 		}
 
-		CellData headerData( const IECore::Canceller *canceller ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const override
 		{
 			return CellData( /* value = */ nullptr, /* icon = */ m_visibleSet.exclusions.isEmpty() ? g_exclusionsEmptyIconName : g_setExcludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Exclusions" ) );
 		}

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -166,7 +166,7 @@ PathColumn::CellData StandardPathColumn::cellData( const Gaffer::Path &path, con
 	return CellData( cellData );
 }
 
-PathColumn::CellData StandardPathColumn::headerData( const IECore::Canceller *canceller ) const
+PathColumn::CellData StandardPathColumn::headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const
 {
 	return m_headerData;
 }
@@ -229,7 +229,7 @@ PathColumn::CellData IconPathColumn::cellData( const Gaffer::Path &path, const I
 	return result;
 }
 
-PathColumn::CellData IconPathColumn::headerData( const IECore::Canceller *canceller ) const
+PathColumn::CellData IconPathColumn::headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const
 {
 	return m_headerData;
 }
@@ -271,7 +271,7 @@ PathColumn::CellData FileIconPathColumn::cellData( const Gaffer::Path &path, con
 	return result;
 }
 
-PathColumn::CellData FileIconPathColumn::headerData( const IECore::Canceller *canceller ) const
+PathColumn::CellData FileIconPathColumn::headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller ) const
 {
 	return CellData( m_label );
 }

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -279,7 +279,7 @@ class PathColumnWrapper : public IECorePython::RefCountedWrapper<PathColumn>
 			throw IECore::Exception( "PathColumn::cellData() python method not defined" );
 		}
 
-		CellData headerData( const IECore::Canceller *canceller = nullptr ) const override
+		CellData headerData( const Gaffer::Path &rootPath, const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( isSubclassed() )
 			{
@@ -290,7 +290,7 @@ class PathColumnWrapper : public IECorePython::RefCountedWrapper<PathColumn>
 					if( f )
 					{
 						return extract<CellData>(
-							f( CancellerPtr( const_cast<IECore::Canceller *>( canceller ) ) )
+							f( PathPtr( const_cast<Path *>( &rootPath ) ), CancellerPtr( const_cast<IECore::Canceller *>( canceller ) ) )
 						);
 					}
 				}
@@ -370,10 +370,10 @@ PathColumn::CellData cellDataWrapper( PathColumn &pathColumn, const Path &path, 
 	return pathColumn.cellData( path, canceller );
 }
 
-PathColumn::CellData headerDataWrapper( PathColumn &pathColumn, const Canceller *canceller )
+PathColumn::CellData headerDataWrapper( PathColumn &pathColumn, const Path &rootPath, const Canceller *canceller )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	return pathColumn.headerData( canceller );
+	return pathColumn.headerData( rootPath, canceller );
 }
 
 struct ChangedSignalSlotCaller
@@ -563,7 +563,7 @@ void GafferUIModule::bindPathColumn()
 	pathColumnClass.def( init<PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::SizeMode::Default ) )
 		.def( "changedSignal", &PathColumn::changedSignal, return_internal_reference<1>() )
 		.def( "cellData", &cellDataWrapper, ( arg( "path" ), arg( "canceller" ) = object() ) )
-		.def( "headerData", &headerDataWrapper, ( arg( "canceller" ) = object() ) )
+		.def( "headerData", &headerDataWrapper, ( arg( "rootPath" ), arg( "canceller" ) = object() ) )
 		.def( "buttonPressSignal", &PathColumn::buttonPressSignal, return_internal_reference<1>() )
 		.def( "buttonReleaseSignal", &PathColumn::buttonReleaseSignal, return_internal_reference<1>() )
 		.def( "buttonDoubleClickSignal", &PathColumn::buttonDoubleClickSignal, return_internal_reference<1>() )

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -765,6 +765,7 @@ class PathModel : public QAbstractItemModel
 			cancelUpdate();
 			m_rootPath = root;
 			m_rootItem->dirty();
+			m_headerDataState = State::Dirty;
 			m_recursiveExpansionPath.reset();
 			// Schedule update to process the dirtied items.
 			scheduleUpdate();
@@ -1366,7 +1367,7 @@ class PathModel : public QAbstractItemModel
 			std::vector<CellVariants> newHeaderData;
 			for( auto &column : m_columns )
 			{
-				newHeaderData.push_back( column->headerData( canceller ) );
+				newHeaderData.push_back( column->headerData( *m_rootPath, canceller ) );
 			}
 
 			if( m_headerData == newHeaderData )


### PR DESCRIPTION
This addresses a recent todo added to `LightEditor::SetMembershipColumn` in `1.6_maintenance`, tidying some convoluted efforts to find the ScriptNode and fixes the context used to display the column header icon.