### PR TITLE
ShaderTweaks : Support {shaderType=} filter in shader name

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.16.0)
 =======
 
+Features
+--------
+
+- ShaderTweaks : Added support for `{shaderType=someShaderType}` qualifiers in parameter names, allowing tweaking of a parameter on all shaders of a given type.
+
 Fixes
 -----
 

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -708,5 +708,76 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( set( network.shaders().keys() ), { "surface" } )
 		self.assertFalse( network.input( ( "surface", "a" ) ) )
 
+	def testShadertypeFilter( self ) :
+
+		shaderA = GafferSceneTest.TestShader( "A" )
+		shaderB = GafferSceneTest.TestShader( "B" )
+		shaderB.loadShader( "mix" )
+		shaderB["parameters"]["a"].setInput( shaderA["out"]["c"] )
+		shaderC = GafferSceneTest.TestShader( "C" )
+		shaderC.loadShader( "mixClosures" )
+		shaderC["type"].setValue( "surface" )
+		shaderC["parameters"]["mix"].setInput( shaderB["out"]["c"]["r"] )
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		assignment = GafferScene.ShaderAssignment()
+		assignment["in"].setInput( plane["out"] )
+		assignment["filter"].setInput( planeFilter["out"] )
+		assignment["shader"].setInput( shaderC["out"] )
+
+		tweaks = GafferScene.ShaderTweaks()
+		tweaks["in"].setInput( assignment["out"] )
+		tweaks["shader"].setValue( "surface" )
+		tweaks["filter"].setInput( planeFilter["out"] )
+
+		originalNetwork = tweaks["out"].attributes( "/plane" )["surface"]
+
+		tweaks["tweaks"].addChild(
+			Gaffer.TweakPlug( "{shaderType=mix}.mix", 42, mode = Gaffer.TweakPlug.Mode.Add )
+		)
+
+		tweaked = tweaks["out"].attributes( "/plane" )["surface"]
+		self.assertEqual( tweaked.shaders()["B"].parameters["mix"].value, 42.5 )
+
+		tweaks["tweaks"][0]["name"].setValue( "{shaderType=mixClosures}.mix" )
+
+		with self.assertRaisesRegex( RuntimeError, 'Cannot apply tweak "{shaderType=mixClosures}.mix" to "C.mix" : "Add" mode is not compatible with an existing input connection.' ):
+			tweaks["out"].attributes( "/plane" )
+
+		# If we use both a handle and a shaderType, then both must match
+		tweaks["tweaks"][0]["name"].setValue( "B{shaderType=mixClosures}.mix" )
+		self.assertEqual( tweaks["out"].attributes( "/plane" )["surface"], originalNetwork )
+
+		tweaks["tweaks"][0]["name"].setValue( "B{shaderType=mix}.mix" )
+		self.assertEqual( tweaks["out"].attributes( "/plane" )["surface"], tweaked )
+
+		tweaks["tweaks"][0]["name"].setValue( "*{shaderType=mix}.mix" )
+		self.assertEqual( tweaks["out"].attributes( "/plane" )["surface"], tweaked )
+
+		# Filtering on an empty shader type matches nothing
+		tweaks["tweaks"][0]["name"].setValue( "*{shaderType=}.mix" )
+		self.assertEqual( tweaks["out"].attributes( "/plane" )["surface"], originalNetwork )
+
+		# In order to be valid, the parameter name must either be a valid shaderType qualifier, with an optional
+		# shader handle, and a parameter name, or a simple `handle.parameter`, or lastly, just a parameter
+		# name, with no braces or periods. If we get something we don't understand, we throw an exception
+		with self.assertRaisesRegex( RuntimeError, 'Could not parse shader parameter: "\*{shaderType}.mix"' ):
+			tweaks["tweaks"][0]["name"].setValue( "*{shaderType}.mix" )
+			tweaks["out"].attributes( "/plane" )
+		with self.assertRaisesRegex( RuntimeError, 'Could not parse shader parameter: "\*{}.mix"' ):
+			tweaks["tweaks"][0]["name"].setValue( "*{}.mix" )
+			tweaks["out"].attributes( "/plane" )
+		with self.assertRaisesRegex( RuntimeError, 'Could not parse shader parameter: ".mix"' ):
+			tweaks["tweaks"][0]["name"].setValue( ".mix" )
+			tweaks["out"].attributes( "/plane" )
+		with self.assertRaisesRegex( RuntimeError, 'Could not parse shader parameter: "{{{"' ):
+			tweaks["tweaks"][0]["name"].setValue( "{{{" )
+			tweaks["out"].attributes( "/plane" )
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -54,6 +54,16 @@ Gaffer.Metadata.registerNode(
 	"description",
 	"""
 	Makes modifications to shader parameter values.
+
+	Shader parameters are identified by name, and can optionally be filtered by the name and type of the shader they belong to. Examples :
+
+	- `intensity` : Chooses a parameter called `intensity` on the final shader in the network. Particularly convenient for lights, which often include only one shader.
+	- `diffuseTexture.filename`: Chooses a parameter called `filename` on a shader called `diffuseTexture`.
+	- `dustLayer*.alpha` : Chooses all parameters called `alpha`, on shaders whose name matches `dustLayer*` (any of Gaffer's other standard wildcards may also be used to match the shader name).
+	- `{shaderType=image}.mipmap_bias` : Chooses all parameters called `mipmap_bias` on shaders whose type is `image`.
+	- `diffuseTexture*{shaderType=image}.mipmap_bias` : Chooses all parameters called `mipmap_bias` on shaders whose type is `image` and whose name matches `diffuseTexture*`.
+
+	> Tip : Parameters can be dragged from the SceneInspector and dropped into the text field to fill the name automatically.
 	""",
 
 	"layout:section:Settings.Tweaks:collapsed", False,
@@ -148,6 +158,21 @@ Gaffer.Metadata.registerNode(
 
 		},
 
+		"tweaks.*.name" : {
+
+			"description" :
+			"""
+			Identifies the parameter to be tweaked. Parameters are identified by name, and can optionally be filtered by the name and type of the shader they belong to. Examples :
+
+			- `intensity` : Chooses a parameter called `intensity` on the final shader in the network. Particularly convenient for lights, which often include only one shader.
+			- `diffuseTexture.filename`: Chooses a parameter called `filename` on a shader called `diffuseTexture`.
+			- `dustLayer*.alpha` : Chooses all parameters called `alpha`, on shaders whose name matches `dustLayer*` (any of Gaffer's other standard wildcards may also be used to match the shader name).
+			- `{shaderType=image}.mipmap_bias` : Chooses all parameters called `mipmap_bias` on shaders whose type is `image`.
+			- `diffuseTexture*{shaderType=image}.mipmap_bias` : Chooses all parameters called `mipmap_bias` on shaders whose type is `image` and whose name matches `diffuseTexture*`.
+
+			> Tip : Parameters can be dragged from the SceneInspector and dropped into the text field to fill the name automatically.
+			"""
+		},
 	}
 
 )

--- a/src/GafferScene/ShaderTweaks.cpp
+++ b/src/GafferScene/ShaderTweaks.cpp
@@ -54,6 +54,7 @@
 
 #include "fmt/format.h"
 
+#include <regex>
 #include <unordered_map>
 
 using namespace std;
@@ -179,7 +180,7 @@ void checkForCycle( const ShaderNetwork &network, const IECore::InternedString &
 	}
 }
 
-bool applyTweakInternal( ShaderNetwork *shaderNetwork, unordered_map<InternedString, IECoreScene::ShaderPtr> &modifiedShaders, const TweakPlug *tweakPlug, const ShaderNetwork *inputNetwork, const std::string &tweakLabel, const ShaderNetwork::Parameter &parameter, const IECoreScene::Shader *shader, TweakPlug::MissingMode missingMode, bool &removedConnections )
+bool applyTweakInternal( ShaderNetwork *shaderNetwork, unordered_map<InternedString, IECoreScene::ShaderPtr> &modifiedShaders, const TweakPlug *tweakPlug, const ShaderNetwork *inputNetwork, const std::string &tweakLabel, const ShaderNetwork::Parameter &parameter, const std::optional<std::string> &shaderTypeFilter, const IECoreScene::Shader *shader, TweakPlug::MissingMode missingMode, bool &removedConnections )
 {
 	if( !shader )
 	{
@@ -199,6 +200,11 @@ bool applyTweakInternal( ShaderNetwork *shaderNetwork, unordered_map<InternedStr
 		{
 			return false;
 		}
+	}
+
+	if( shaderTypeFilter && shader->getName() != *shaderTypeFilter )
+	{
+		return false;
 	}
 
 	const TweakPlug::Mode mode = static_cast<TweakPlug::Mode>( tweakPlug->modePlug()->getValue() );
@@ -382,6 +388,11 @@ bool applyTweakInternal( ShaderNetwork *shaderNetwork, unordered_map<InternedStr
 			missingMode
 		);
 	}
+}
+
+IECore::InternedString regexSubMatchToInterned( const std::ssub_match &subMatch )
+{
+	return IECore::InternedString( &( *subMatch.first ), subMatch.length() );
 }
 
 }  // namespace
@@ -591,24 +602,55 @@ bool ShaderTweaks::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, Tweak
 
 		}
 
+		const static std::regex shaderTypeRegex( R"(([^{}]*)(\{shaderType=(.*)\})?\.(.*))" );
+
 		ShaderNetwork::Parameter parameter;
-		const size_t dotPos = name.find_last_of( '.' );
-		if( dotPos == string::npos )
+		std::optional<std::string> shaderTypeFilter;
+
+		std::smatch regexMatch;
+
+		// In order to be a valid expression for finding a shader parameter, it should match the regex, and have
+		// either a shader handle, or shaderType qualifier
+		if( std::regex_match( name, regexMatch, shaderTypeRegex ) && ( regexMatch[1].length() || regexMatch[2].length() ) )
 		{
-			parameter.shader = shaderNetwork->getOutput().shader;
-			parameter.name = name;
+			if( regexMatch[2].length() )
+			{
+				// Subgroup 3 is just the actual shader type
+				shaderTypeFilter = regexSubMatchToInterned( regexMatch[3] );
+			}
+
+			if( regexMatch[1].length() )
+			{
+				parameter.shader = regexSubMatchToInterned( regexMatch[1] );
+			}
+			else
+			{
+				// It's allowed to omit the handle when using a shaderType filter,
+				// in which case we want to match everything with the shaderType
+				parameter.shader = "*";
+			}
+			parameter.name = regexSubMatchToInterned( regexMatch[4] );
 		}
 		else
 		{
-			parameter.shader = InternedString( name.c_str(), dotPos );
-			parameter.name = InternedString( name.c_str() + dotPos + 1 );
+			// If we weren't able to parse it, the name should be a simple parameter name, which we
+			// find on the output shader. If there are any special tokens in the name at this point,
+			// something has gone wrong.
+			const static std::regex hasSyntax( R"([{}.])" );
+			if( std::regex_search( name, hasSyntax ) )
+			{
+				throw IECore::Exception( fmt::format( "Could not parse shader parameter: \"{}\"", name  ) );
+			}
+
+			parameter.shader = shaderNetwork->getOutput().shader;
+			parameter.name = name;
 		}
 
 		if( !IECore::StringAlgo::hasWildcards( parameter.shader.string() ) )
 		{
 			appliedTweaks |= applyTweakInternal(
 				shaderNetwork, modifiedShaders, tweakPlug.get(), inputNetwork,
-				name, parameter, nullptr,
+				name, parameter, shaderTypeFilter, nullptr,
 				missingMode, removedConnections
 			);
 		}
@@ -620,7 +662,7 @@ bool ShaderTweaks::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, Tweak
 				{
 					appliedTweaks |= applyTweakInternal(
 						shaderNetwork, modifiedShaders, tweakPlug.get(), inputNetwork,
-						name, { s.first, parameter.name }, s.second.get(),
+						name, { s.first, parameter.name }, shaderTypeFilter, s.second.get(),
 						TweakPlug::MissingMode::Ignore, removedConnections
 					);
 				}


### PR DESCRIPTION
Pretty straightforward implementation of the syntax we discussed.

The only missing part is the documentation - as I mentioned offline, we currently don't seem to currently even have any documentation for the support for globbing in shader names, just getting the default TweakPlug documentation: "The name of the parameter to apply the tweak to." So there's probably quite a bit of information to try and cram into that tooltip ... John said he was willing to take a swing at this, since I struggle with writing this sort of thing without coming across as overly detailed. Oh, and we need a Changelog entry, but that can probably be based on how we describe it in the tooltip.

Main implementation thing I hesitated on was that I rewrote the existing handling to also use a regex ... feels a bit more consistent, but there might be an argument for leaving it the way it was before.
