### PR TITLE
OSLCode : Generate shader on demand, not on every single edit

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ Fixes
   - Fixed PointsPrimitive motion blur when rendering with even numbers of segments.
 - USDShader : Fixed value of `type` plug after loading a USDLux light.
 - CyclesLight, ArnoldLight, LightFilter : Fixed potential hang when loading shaders (GIL management bug in `loadShader()` binding).
+- StandardNodeGadget : Fixed crash caused by the node emitting `errorSignal()` while the gadget is undergoing construction.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Improvements
 - CurvesPrimitive : Added `Pinned` wrap mode in addition to the existing `Periodic` and `NonPeriodic` modes. This conveniently interpolates CatmullRom
 and BSpline curves to their endpoints automatically, without manual management of duplicate endpoints or "phantom vertices".
 - SceneReader, SceneWriter : Added support for pinned UsdGeomBasisCurves.
+- OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.
 
 Fixes
 -----
@@ -89,6 +90,7 @@ Breaking Changes
   - Removed ability to load from `.gfr` files prior to version 0.45.0.0. If necessary, resave from Gaffer 1.6.
 - OSLShader : Removed ability to load from `.gfr` files prior to version 0.45.0.0. If necessary, resave from Gaffer 1.6.
 - Light : Removed public constructor. Lights may now only be constructed via derived classes, which are now responsible for providing a Shader node to the base class.
+- OSLCode : Removed `shaderCompiledSignal()`.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,7 @@ Fixes
 - USDShader : Fixed value of `type` plug after loading a USDLux light.
 - CyclesLight, ArnoldLight, LightFilter : Fixed potential hang when loading shaders (GIL management bug in `loadShader()` binding).
 - StandardNodeGadget : Fixed crash caused by the node emitting `errorSignal()` while the gadget is undergoing construction.
+- Shader : Fixed hash for output plugs.
 
 API
 ---

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -43,10 +43,6 @@
 namespace GafferOSL
 {
 
-/// \todo It would be better if this node generated the .oso file
-/// on disk on demand, during shader network generation. Rejig the
-/// generation process to allow for this. Also bear in mind the related
-/// todo items in ArnoldDisplacement and ArnoldLight.
 class GAFFEROSL_API OSLCode : public OSLShader
 {
 
@@ -65,31 +61,29 @@ class GAFFEROSL_API OSLCode : public OSLShader
 		/// to give to it.
 		std::string source( const std::string shaderName = "" ) const;
 
-		using ShaderCompiledSignal = Gaffer::Signals::Signal<void ()>;
-		/// Signal emitted when a shader is compiled successfully.
-		/// \todo This exists only so the UI knows when to clear
-		/// the error indicator. When we compile shaders on demand,
-		/// we can instead use the same `errorSignal()`/`plugDirtiedSignal()`
-		/// combo we use everywhere else.
-		ShaderCompiledSignal &shaderCompiledSignal();
-
 		// This is implemented to do nothing, because OSLCode node generates the shader from
 		// the plugs, and not the other way around.  We don't want to inherit the loading behaviour
 		// from OSLShader which tries to match the plugs to a shader on disk
 		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
 	private :
 
-		void updateShader();
-		void plugSet( const Gaffer::Plug *plug );
-		void parameterAdded( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
-		void parameterRemoved( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child );
-		void parameterNameChanged();
+		// We connect the output from this into our `name` plug, allowing us
+		// to generate the shader on disk "just in time", when the NetworkCreator
+		// evaluates the name.
+		Gaffer::StringPlug *shaderNamePlug();
+		const Gaffer::StringPlug *shaderNamePlug() const;
+
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
+		void outputAdded();
+		void outputRemoved();
 
 		static size_t g_firstPlugIndex;
-
-		ShaderCompiledSignal m_shaderCompiledSignal;
-		std::unordered_map<const Gaffer::GraphComponent *, Gaffer::Signals::ScopedConnection> m_nameChangedConnections;
 
 };
 

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -435,6 +435,14 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		self.assertIsNone( oslCode.shaderMetadata( "test" ) )
 		self.assertIsNone( oslCode.parameterMetadata( oslCode["parameters"]["i"], "test" ) )
 
+	def testOutputGetValueDoesntThrowOnCodingError( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["out"]["i"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["code"].setValue( "oops!" )
+
+		self.assertEqual( oslCode["out"]["i"].getValue(), 0 )
+
 	def __osoFileName( self, oslCode ) :
 
 		result = oslCode.attributes()["osl:shader"].outputShader().name

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -51,6 +51,19 @@ import GafferOSLTest
 
 class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 
+	def setUp( self ) :
+
+		GafferOSLTest.OSLTestCase.setUp( self )
+
+		# Arrange to restore GAFFEROSL_CODE_DIRECTORY env-var, so tests
+		# are free to modify it temporarily.
+
+		oslCodeDir = os.environ.get( "GAFFEROSL_CODE_DIRECTORY" )
+		if oslCodeDir :
+			self.addCleanup( os.environ.__setitem__, "GAFFEROSL_CODE_DIRECTORY", oslCodeDir )
+		else :
+			self.addCleanup( os.environ.__delitem__, "GAFFEROSL_CODE_DIRECTORY" )
+
 	def testPlugTypes( self ) :
 
 		oslCode = GafferOSL.OSLCode()
@@ -97,7 +110,9 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 	def testParseError( self ) :
 
 		n = GafferOSL.OSLCode()
-		self.__assertError( n, n["code"].setValue, "oops" )
+		n["code"].setValue( "oops" )
+		with self.assertRaisesRegex( Gaffer.ProcessException, "'oops' was not declared in this scope" ) :
+			self.__osoFileName( n )
 
 	def testParseErrorDoesntDestroyExistingPlugs( self ) :
 
@@ -106,18 +121,11 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		n["out"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		originalPlugs = n["parameters"].children() + n["out"].children()
 
-		self.__assertError( n, n["code"].setValue, "oops" )
+		n["code"].setValue( "oops" )
+		with self.assertRaisesRegex( Gaffer.ProcessException, "'oops' was not declared in this scope" ) :
+			self.__osoFileName( n )
 
 		self.assertEqual( n["parameters"].children() + n["out"].children(), originalPlugs )
-
-	def testChildAddedSignalNotSuppressedByError( self ) :
-
-		n = GafferOSL.OSLCode()
-		self.__assertError( n, n["code"].setValue, "oops" )
-
-		cs = GafferTest.CapturingSlot( n["parameters"].childAddedSignal() )
-		n["parameters"]["in"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		self.assertEqual( len( cs ), 1 )
 
 	def testEmpty( self ) :
 
@@ -171,13 +179,15 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 
 		oslCode = GafferOSL.OSLCode()
 		oslCode["out"]["out"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		self.__assertNoError( oslCode, oslCode["code"].setValue, 'out = inFloat( "s", 0 );' )
+		oslCode["code"].setValue( 'out = inFloat( "s", 0 );' )
+		self.__osoFileName( oslCode ) # Will error if can't compile shader
 
 	def testImageProcessingFunctions( self ) :
 
 		oslCode = GafferOSL.OSLCode()
 		oslCode["out"]["out"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-		self.__assertNoError( oslCode, oslCode["code"].setValue, 'out = inChannel( "R", 0 );' )
+		oslCode["code"].setValue( 'out = inChannel( "R", 0 );' )
+		self.__osoFileName( oslCode ) # Will error if can't compile shader
 
 	def testColorRamp( self ) :
 
@@ -242,11 +252,14 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 			s["o"]["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		f2 = self.__osoFileName( s["o"] )
+		self.assertNotEqual( f2, f1 )
 
 		with Gaffer.UndoScope( s ) :
 			s["o"]["code"].setValue( "o = i * color( u, v, 0 );")
 
 		f3 = self.__osoFileName( s["o"] )
+		self.assertNotEqual( f3, f1 )
+		self.assertNotEqual( f3, f2 )
 
 		s.undo()
 		self.assertEqual( self.__osoFileName( s["o"] ), f2 )
@@ -306,22 +319,21 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		oslCode = GafferOSL.OSLCode()
 		oslCode["parameters"]["i"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		oslCode["out"]["o"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["code"].setValue( "o = in" )
 
-		self.__assertError( oslCode, oslCode["code"].setValue, "o = in" )
+		with self.assertRaisesRegex( Gaffer.ProcessException, "'in' was not declared in this scope" ) :
+			self.__osoFileName( oslCode )
 
 		cs = GafferTest.CapturingSlot( oslCode.plugDirtiedSignal() )
-		self.__assertNoError( oslCode, oslCode["parameters"]["i"].setName, "in" )
+		oslCode["parameters"]["i"].setName( "in" )
 		self.assertTrue( oslCode["out"] in [ x[0] for x in cs ] )
+		self.__osoFileName( oslCode )
 
-		self.__assertError( oslCode, oslCode["parameters"]["in"].setName, "i" )
+		oslCode["parameters"]["in"].setName( "i" )
+		with self.assertRaisesRegex( Gaffer.ProcessException, "'in' was not declared in this scope" ) :
+			self.__osoFileName( oslCode )
 
 	def testMoveCodeDirectory( self ) :
-
-		oslCodeDir = os.environ.get( "GAFFEROSL_CODE_DIRECTORY" )
-		if oslCodeDir :
-			self.addCleanup( os.environ.__setitem__, "GAFFEROSL_CODE_DIRECTORY", oslCodeDir )
-		else :
-			self.addCleanup( os.environ.__delitem__, "GAFFEROSL_CODE_DIRECTORY" )
 
 		# Make an OSL shader in a specific code directory.
 
@@ -339,15 +351,32 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		# Now simulate the loading of that script in a different environment,
 		# with a different code directory.
 
-		ss = s.serialise()
+		scriptFileName = self.temporaryDirectory() / "test.gfr"
+		s["fileName"].setValue( scriptFileName )
+		s.save()
 
 		shutil.rmtree( os.environ["GAFFEROSL_CODE_DIRECTORY"] )
-		os.environ["GAFFEROSL_CODE_DIRECTORY"] = ( self.temporaryDirectory() / "codeDirectoryB" ).as_posix()
 
-		s2 = Gaffer.ScriptNode()
-		s2.execute( ss )
+		env = os.environ.copy()
+		env["GAFFEROSL_CODE_DIRECTORY"] = ( self.temporaryDirectory() / "codeDirectoryB" ).as_posix()
 
-		self.assertTrue( self.__osoFileName( s2["o"] ).startswith( os.environ["GAFFEROSL_CODE_DIRECTORY"] ) )
+		subprocess.check_call(
+			[
+				str( Gaffer.executablePath() ), "env", "python", "-c",
+				"import GafferOSLTest; GafferOSLTest.OSLCodeTest()._assertMovedCodeDirectoryOK( '{scriptFileName}' )".format(
+					scriptFileName = scriptFileName.as_posix()
+				)
+			],
+			env = env
+		)
+
+	def _assertMovedCodeDirectoryOK( self, scriptFileName ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( scriptFileName )
+		s.load()
+
+		self.assertTrue( self.__osoFileName( s["o"] ).startswith( os.environ["GAFFEROSL_CODE_DIRECTORY"] ) )
 
 	def testRenameRemovedParameter( self ) :
 
@@ -355,58 +384,62 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 
 		oslCode = GafferOSL.OSLCode()
 		oslCode["parameters"]["c"] = parameter
-
-		cs = GafferTest.CapturingSlot( oslCode.shaderCompiledSignal() )
 		oslCode["parameters"].removeChild( parameter )
-		self.assertEqual( len( cs ), 1 )
 
 		# Changing name is irrelevant now we've removed the parameter,
-		# and shouldn't trigger a recompile.
+		# and shouldn't propagate dirtiness.
 
-		del cs[:]
+		cs = GafferTest.CapturingSlot( oslCode.plugDirtiedSignal() )
 		parameter.setName( "d" )
 		self.assertEqual( len( cs ), 0 )
 
 	def testParseErrorLineNumbers( self ) :
 
 		oslCode = GafferOSL.OSLCode()
-		cs = GafferTest.CapturingSlot( oslCode.errorSignal() )
 		oslCode["code"].setValue( "undefined" )
 
-		self.assertEqual( len( cs ), 1 )
-		self.assertRegex( cs[0][2], "code:1: error: 'undefined' was not declared in this scope$" )
+		with self.assertRaisesRegex( Gaffer.ProcessException, "code:1: error: 'undefined' was not declared in this scope$" ) :
+			self.__osoFileName( oslCode )
+
+	def testShaderNotCompiledForEveryParameterAddition( self ) :
+
+		directory = self.temporaryDirectory() / "oslCode"
+		os.environ["GAFFEROSL_CODE_DIRECTORY"] = directory.as_posix()
+		self.assertFalse( directory.exists() )
+
+		# Shader is only generated when we ask for it.
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["parameters"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		self.assertFalse( directory.exists() )
+
+		self.__osoFileName( oslCode )
+		self.assertTrue( directory.exists() )
+		self.assertEqual( len( list( directory.iterdir() ) ), 1 )
+
+		# And is only regenerated when we ask for it again.
+
+		oslCode["parameters"]["j"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["parameters"]["k"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		self.assertEqual( len( list( directory.iterdir() ) ), 1 )
+
+		self.__osoFileName( oslCode )
+		self.assertEqual( len( list( directory.iterdir() ) ), 2 )
+
+	def testMetadataDoesntThrowOnCodingError( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		oslCode["parameters"]["i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		oslCode["code"].setValue( "oops!" )
+
+		self.assertIsNone( oslCode.shaderMetadata( "test" ) )
+		self.assertIsNone( oslCode.parameterMetadata( oslCode["parameters"]["i"], "test" ) )
 
 	def __osoFileName( self, oslCode ) :
 
-		# Right now we could get this information by
-		# getting the value directly from the "name" plug
-		# on the OSLCode node, but we're getting it from
-		# the computed shader instead, in the hope that
-		# one day we can refactor things so that it's the
-		# generation of the shader network that also generates
-		# the file on disk. It might be that the
-		# `GafferScene::Shader` base class shouldn't even
-		# mandate the existence of "name" and "type" plugs.
-
-		return oslCode.attributes()["osl:shader"].outputShader().name
-
-	def __assertError( self, oslCode, fn, *args, **kw ) :
-
-		cs = GafferTest.CapturingSlot( oslCode.errorSignal() )
-
-		fn( *args, **kw )
-		self.__osoFileName( oslCode )
-
-		self.assertEqual( len( cs ), 1 )
-
-	def __assertNoError( self, oslCode, fn, *args, **kw ) :
-
-		cs = GafferTest.CapturingSlot( oslCode.errorSignal() )
-
-		fn( *args, **kw )
-		self.__osoFileName( oslCode )
-
-		self.assertEqual( len( cs ), 0 )
+		result = oslCode.attributes()["osl:shader"].outputShader().name
+		self.assertTrue( pathlib.Path( result ).with_suffix( ".oso" ).is_file() )
+		return result
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -319,20 +319,27 @@ class _ErrorWidget( GafferUI.Widget ) :
 		self.__messageWidget = GafferUI.MessageWidget()
 		GafferUI.Widget.__init__( self, self.__messageWidget, **kw )
 
+		self.__node = node
 		node.errorSignal().connect( Gaffer.WeakMethod( self.__error ) )
-		node.shaderCompiledSignal().connect( Gaffer.WeakMethod( self.__shaderCompiled ) )
+		node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) )
 
 		self.__messageWidget.setVisible( False )
 
 	def __error( self, plug, source, error ) :
 
+		if plug.isSame( self.__node["__shaderName"] ) :
+			Gaffer.ParallelAlgo.callOnUIThread( functools.partial( self.__displayError, error ) )
+
+	def __displayError( self, error ) :
+
 		self.__messageWidget.clear()
 		self.__messageWidget.messageHandler().handle( IECore.Msg.Level.Error, "Compilation error", error )
 		self.__messageWidget.setVisible( True )
 
-	def __shaderCompiled( self ) :
+	def __plugDirtied( self, plug ) :
 
-		self.__messageWidget.setVisible( False )
+		if plug.isSame( self.__node["__shaderName"] ) :
+			self.__messageWidget.setVisible( False )
 
 ##########################################################################
 # Plug menu

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -145,7 +145,11 @@ def __plugWidgetType( plug ) :
 
 	# See comments in `__plugNoduleVisibility()`.
 	node = plug.node()
-	parameterKey = node["type"].getValue() + ":" + node["name"].getValue() + ":" + plug.getName()
+	try :
+		parameterKey = node["type"].getValue() + ":" + node["name"].getValue() + ":" + plug.getName()
+	except :
+		return None
+
 	return Gaffer.Metadata.value( parameterKey, "plugValueWidget:type" )
 
 def __plugNoduleType( plug ) :
@@ -188,7 +192,10 @@ def __plugNoduleVisibility( plug ) :
 	# Before we can do this, we need to modify `Metadata::ValueFunction` so that
 	# it is passed a `target` argument.
 	if visible is None :
-		shaderKey = node["type"].getValue() + ":" + node["name"].getValue()
+		try :
+			shaderKey = node["type"].getValue() + ":" + node["name"].getValue()
+		except :
+			return None
 		parameterKey = shaderKey + ":" + plug.getName()
 		visible = Gaffer.Metadata.value( parameterKey, "noduleLayout:visible" )
 		if visible is None :

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -59,9 +59,13 @@ from GafferUI.PlugValueWidget import sole
 
 def __shaderMetadata( node, key ) :
 
-	return Gaffer.Metadata.value(
-		node["type"].getValue() + ":" + node["name"].getValue(), key
-	)
+	try :
+		type = node["type"].getValue()
+		name = node["name"].getValue()
+	except :
+		return None
+
+	return Gaffer.Metadata.value( f"{type}:{name}", key )
 
 def __nodeDescriptionMetadata( node ) :
 
@@ -75,8 +79,14 @@ def __nodeDescriptionMetadata( node ) :
 def __parameterMetadata( plug, key, shaderFallbackKey = None ) :
 
 	shader = plug.node()
+	try :
+		type = shader["type"].getValue()
+		name = shader["name"].getValue()
+	except :
+		return None
+
 	result = Gaffer.Metadata.value(
-		shader["type"].getValue() + ":" + shader["name"].getValue() + ":" + plug.relativeName( shader["parameters"] ),
+		"{}:{}:{}".format( type, name, plug.relativeName( shader["parameters"] ) ),
 		key
 	)
 
@@ -268,7 +278,10 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 def __shaderNameExtractor( node ) :
 
 	if isinstance( node, GafferScene.Shader ) :
-		return node["name"].getValue()
+		try :
+			return node["name"].getValue()
+		except :
+			return ""
 	else :
 		return ""
 

--- a/python/GafferUITest/StandardNodeGadgetTest.py
+++ b/python/GafferUITest/StandardNodeGadgetTest.py
@@ -350,5 +350,22 @@ class StandardNodeGadgetTest( GafferUITest.TestCase ) :
 		self.assertFalse( fOut.getLabelVisible() )
 		self.assertFalse( iOut.getLabelVisible() )
 
+	def testErrorSignalDuringConstruction( self ) :
+
+		Gaffer.Metadata.registerValue( GafferTest.BadNode, "iconScale", lambda node : node["out3"].getValue() )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, GafferTest.BadNode, "iconScale" )
+
+		node = GafferTest.BadNode()
+		## \todo We don't really want the construction of the gadget to throw, but
+		# it currently does, because it calls our metadata function which throws.
+		# It would seem a pity for all metadata clients to have to manage
+		# exceptions, so perhaps that should be dealt with centrally in the
+		# Metadata API?
+		with self.assertRaises( Gaffer.ProcessException ) :
+			# The real purpose of this test is to check that this doesn't
+			# crash when `Node::errorSignal()` is emitted by our metadata
+			# function.
+			GafferUI.StandardNodeGadget( node )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -78,6 +78,12 @@ string colorSplineParameter( const RampfColor3fPlug *plug )
 	return result;
 }
 
+void hashParameter( const Plug *plug, IECore::MurmurHash &h )
+{
+	h.append( plug->getName() );
+	h.append( plug->typeId() );
+}
+
 string parameter( const Plug *plug )
 {
 	const Gaffer::TypeId plugType = (Gaffer::TypeId)plug->typeId();
@@ -339,35 +345,7 @@ std::filesystem::path compile( const std::string &shaderName, const std::string 
 	return osoFileName;
 }
 
-class CompileProcess : public Gaffer::Process
-{
-
-	public :
-
-		CompileProcess( OSLCode *oslCode )
-			:	Process( g_type, oslCode->outPlug() )
-		{
-			try
-			{
-				string shaderName;
-				string shaderSource = generate( oslCode, shaderName );
-				std::filesystem::path shaderFile = compile( shaderName, shaderSource );
-				oslCode->namePlug()->setValue( shaderFile.replace_extension().generic_string() );
-				oslCode->typePlug()->setValue( "osl:shader" );
-			}
-			catch( ... )
-			{
-				handleException();
-			}
-		}
-
-		static InternedString g_type;
-
-};
-
-InternedString CompileProcess::g_type( "oslCode:compile" );
-
-};
+} // namespace
 
 //////////////////////////////////////////////////////////////////////////
 // OSLCode
@@ -382,26 +360,16 @@ OSLCode::OSLCode( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	// Must not accept inputs for now, because we need to use `plugSetSignal()`
-	// to do the code generation.
-	/// \todo Rejig the NetworkGenerator so there is a hook for us to do our
-	/// code generation on demand at network generation time, and allow inputs
-	/// again.
-	addChild( new StringPlug( "code", Plug::In, "", Plug::Default & ~Plug::AcceptsInputs, IECore::StringAlgo::NoSubstitutions ) );
+	addChild( new StringPlug( "code", Plug::In, "", Plug::Default, IECore::StringAlgo::NoSubstitutions ) );
+	addChild( new StringPlug( "__shaderName", Plug::Out, "", Plug::Default | Plug::AcceptsDependencyCycles ) );
 
-	// Must disable serialisation on the name because the GAFFEROSL_CODE_DIRECTORY
-	// might not be the same when we come to be loaded again.
+	typePlug()->setValue( "osl:shader" );
+	namePlug()->setInput( shaderNamePlug() );
+	// Disable serialisation of private internal connection.
 	namePlug()->setFlags( Plug::Serialisable, false );
 
-	parametersPlug()->childAddedSignal().connect( boost::bind( &OSLCode::parameterAdded, this, ::_1, ::_2 ) );
-	parametersPlug()->childRemovedSignal().connect( boost::bind( &OSLCode::parameterRemoved, this, ::_1, ::_2 ) );
-
-	outPlug()->childAddedSignal().connect( boost::bind( &OSLCode::parameterAdded, this, ::_1, ::_2 ) );
-	outPlug()->childRemovedSignal().connect( boost::bind( &OSLCode::parameterRemoved, this, ::_1, ::_2 ) );
-
-	plugSetSignal().connect( boost::bind( &OSLCode::plugSet, this, ::_1 ) );
-
-	updateShader();
+	outPlug()->childAddedSignal().connect( boost::bind( &OSLCode::outputAdded, this ) );
+	outPlug()->childRemovedSignal().connect( boost::bind( &OSLCode::outputRemoved, this ) );
 }
 
 OSLCode::~OSLCode()
@@ -418,6 +386,16 @@ const Gaffer::StringPlug *OSLCode::codePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
+Gaffer::StringPlug *OSLCode::shaderNamePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *OSLCode::shaderNamePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
 std::string OSLCode::source( const std::string shaderName ) const
 {
 	string shaderNameCopy = shaderName;
@@ -428,88 +406,85 @@ void OSLCode::loadShader( const std::string &shaderName, bool keepExistingValues
 {
 }
 
-OSLCode::ShaderCompiledSignal &OSLCode::shaderCompiledSignal()
+void OSLCode::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
-	return m_shaderCompiledSignal;
-}
-
-void OSLCode::updateShader()
-{
-	try
+	OSLShader::affects( input, outputs );
+	if(
+		parametersPlug()->isAncestorOf( input ) ||
+		outPlug()->isAncestorOf( input ) ||
+		input == codePlug()
+	)
 	{
-		CompileProcess compileProcess( this );
-		shaderCompiledSignal()();
-	}
-	catch( ... )
-	{
-		// We call updateShader() from `plugSet()`
-		// and `parameterAddedOrRemoved()`, and the
-		// client code that set the plug or added
-		// the parameter is not designed to deal with
-		// such fundamental actions throwing. So we suppress
-		// any exceptions here rather than let them
-		// percolate back out to the caller.
-		//
-		// This doesn't affect the exception handling
-		// already being performed by the CompileProcess,
-		// so we're not totally suppressing errors - they're
-		// still being reported via errorSignal().
-		//
-		// When we refactor to perform the shader
-		// generation on the fly at network
-		// generation time, this will not be necessary
-		// because client code for performing
-		// computations is designed to handle exceptions.
-		//
-		/// \todo There might well be a case for redefining
-		/// the signals themselves to use a CatchingSignalCombiner,
-		/// since then we'd be making the whole system robust
-		/// to badly behaving slots. Currently we have
-		/// a mixture of catching and non-catching signals,
-		/// but I think that's mostly a historical artifact
-		/// rather than through any thought-out design.
+		outputs.push_back( shaderNamePlug() );
 	}
 }
 
-void OSLCode::plugSet( const Gaffer::Plug *plug )
+void OSLCode::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	if( plug == codePlug() )
+	if( output == shaderNamePlug() )
 	{
-		updateShader();
+		OSLShader::hash( output, context, h );
+		for( const auto &plug : Plug::Range( *parametersPlug() ) )
+		{
+			hashParameter( plug.get(), h );
+		}
+		for( const auto &plug : Plug::Range( *outPlug() ) )
+		{
+			hashParameter( plug.get(), h );
+		}
+		codePlug()->hash( h );
+	}
+	else
+	{
+		OSLShader::hash( output, context, h );
 	}
 }
 
-void OSLCode::parameterAdded( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child )
+void OSLCode::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
 {
-	if( parent == outPlug() && parent->children().size() == 1 )
+	if( output == shaderNamePlug() )
 	{
-		// OSLShaderUI registers a dynamic metadata entry which depends on whether or
-		// not the plug has children, so we must notify the world that the value will
-		// have changed.
-		Metadata::plugValueChangedSignal( this )( outPlug(), "nodule:type", Metadata::ValueChangedReason::StaticRegistration );
+		string shaderName;
+		const string shaderSource = generate( this, shaderName );
+		std::filesystem::path shaderFile = compile( shaderName, shaderSource );
+		static_cast<StringPlug *>( output )->setValue( shaderFile.replace_extension() );
 	}
-
-	m_nameChangedConnections[child] = child->nameChangedSignal().connect(
-		boost::bind( &OSLCode::parameterNameChanged, this )
-	);
-	updateShader();
+	else
+	{
+		OSLShader::compute( output, context );
+	}
 }
 
-void OSLCode::parameterRemoved( const Gaffer::GraphComponent *parent, Gaffer::GraphComponent *child )
+ValuePlug::CachePolicy OSLCode::computeCachePolicy( const Gaffer::ValuePlug *output ) const
 {
-	if( parent == outPlug() && parent->children().size() == 0 )
+	if( output == shaderNamePlug() )
+	{
+		// We don't use TBB, but it's common for many clients to want the same thing
+		// at once, and there's no point in parallel threads fighting over the creation
+		// of the file.
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	return OSLShader::computeCachePolicy( output );
+}
+
+void OSLCode::outputAdded()
+{
+	if( outPlug()->children().size() == 1 )
 	{
 		// OSLShaderUI registers a dynamic metadata entry which depends on whether or
 		// not the plug has children, so we must notify the world that the value will
 		// have changed.
 		Metadata::plugValueChangedSignal( this )( outPlug(), "nodule:type", Metadata::ValueChangedReason::StaticRegistration );
 	}
-
-	m_nameChangedConnections.erase( child );
-	updateShader();
 }
 
-void OSLCode::parameterNameChanged()
+void OSLCode::outputRemoved()
 {
-	updateShader();
+	if( outPlug()->children().size() == 0 )
+	{
+		// OSLShaderUI registers a dynamic metadata entry which depends on whether or
+		// not the plug has children, so we must notify the world that the value will
+		// have changed.
+		Metadata::plugValueChangedSignal( this )( outPlug(), "nodule:type", Metadata::ValueChangedReason::StaticRegistration );
+	}
 }

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -1623,7 +1623,19 @@ const IECore::CompoundData *OSLShader::metadata() const
 		return m_metadata.get();
 	}
 
-	m_metadata = g_metadataCache.get( namePlug()->getValue() );
+	std::string name;
+	try
+	{
+		name = namePlug()->getValue();
+	}
+	catch( ... )
+	{
+		// OSLCode drives the shader name with a compute that compiles the
+		// shader. This can error, in which case there can be no metadata.
+		return nullptr;
+	}
+
+	m_metadata = g_metadataCache.get( name );
 	return m_metadata.get();
 }
 

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -266,10 +266,7 @@ BOOST_PYTHON_MODULE( _GafferOSL )
 	{
 		scope s = GafferBindings::DependencyNodeClass<OSLCode>()
 			.def( "source", &oslCodeSource, ( arg_( "shaderName" ) = "" ) )
-			.def( "shaderCompiledSignal", &OSLCode::shaderCompiledSignal, return_internal_reference<1>() )
 		;
-
-		SignalClass<OSLCode::ShaderCompiledSignal>( "ShaderCompiledSignal" );
 
 		// Use a default serialiser for OSLCode, so that we don't get a
 		// loadShader call like every other kind of shader.

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -1078,9 +1078,7 @@ void Shader::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	{
 		if( output == o || o->isAncestorOf( output ) )
 		{
-			ComputeNode::hash( output, context, h );
-			namePlug()->hash( h );
-			typePlug()->hash( h );
+			h = output->defaultHash();
 			return;
 		}
 	}

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -44,6 +44,7 @@
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/OptionalValuePlug.h"
 #include "Gaffer/PlugAlgo.h"
+#include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/RampPlug.h"
@@ -1021,9 +1022,19 @@ const Gaffer::Plug *Shader::correspondingInput( const Gaffer::Plug *output ) con
 	{
 		if( out->isAncestorOf( output ) )
 		{
-			const string metadataTarget = fmt::format(
-				"{}:{}:{}", typePlug()->getValue(), namePlug()->getValue(), output->relativeName( out )
-			);
+			string metadataTarget;
+			try
+			{
+				metadataTarget = fmt::format(
+					"{}:{}:{}", typePlug()->getValue(), namePlug()->getValue(), output->relativeName( out )
+				);
+			}
+			catch( const Gaffer::ProcessException & )
+			{
+				// Exception computing plug value. The UI will display this for
+				// us, so we can just ignore it.
+				return nullptr;
+			}
 			IECore::ConstStringDataPtr metadata = Metadata::value<const IECore::StringData>( metadataTarget, g_correspondingInputMetadataName );
 			if( metadata )
 			{

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -1518,6 +1518,13 @@ StandardNodeGadget::ErrorGadget *StandardNodeGadget::errorGadget( bool createIfM
 
 void StandardNodeGadget::error( const Gaffer::Plug *plug, const Gaffer::Plug *source, const std::string &message )
 {
+	if( !refCount() )
+	{
+		// We're in the process of being constructed, and can't add a reference
+		// to ourselves without causing a double delete. Just do nothing.
+		return;
+	}
+
 	std::string header;
 	if( source->node() == node() )
 	{

--- a/startup/GafferOSL/oslObjectAndImageCompatibility.py
+++ b/startup/GafferOSL/oslObjectAndImageCompatibility.py
@@ -73,7 +73,7 @@ GafferOSL.OSLImage.__getitem__ = __oslReplaceShaderGetItem( GafferOSL.OSLImage._
 def __oslShaderGetItem( originalGetItem ) :
 
 	def getItem( self, key ) :
-		if key != "out":
+		if key != "out" or isinstance( self, GafferOSL.OSLCode ) :
 			return originalGetItem( self, key )
 
 		if originalGetItem( self, "name" ).getValue() not in [ "ObjectProcessing/OutObject", "ImageProcessing/OutImage" ]:


### PR DESCRIPTION
The OSLCode node needs to generate and compile an OSL shader on disk somewhere, for use downstream by renderers and OSLImage/OSLObject. We originally did this every time the `code` plug was edited or a parameter plug was added or removed. This wasn't too bad for interactive use, because typically after each edit you'd want to see the result anyway. But it was pretty poor when loading a file - during loading, we add parameter plugs one by one, and were recompiling for _every single addition_. So if we had 10 plugs, we'd do 10 compilations, with all of them being bogus. Only the final compilation when the `code` plug was set would be of any use.

This PR switches things up so that the code is only generated and compiled on demand, when anything accesses the `OSLCode.name` plug to get the name of the shader on disk. I think this is a definite improvement, but it has brought all sorts of bugs out of the woodwork in other components. Along with those in #6880, there are a couple of important fixes in this PR too. Close review and some interactive testing is recommended, in case other gremlins lurk.