### PR TITLE
Cycles : Update to 5.1.0

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a9/cortex-10.7.0.0a9-{platform}-{vfxPlatform}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/11.0.0a6/gafferDependencies-11.0.0a6-{platform}-{vfxPlatform}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -103,7 +103,7 @@ Build
 
 - Boost : Updated to version 1.85.0.
 - Cortex : Updated to version 10.7.0.0a9.
-- Cycles : Updated to version 5.0.0.
+- Cycles : Updated to version 5.1.0.
 - Embree : Updated to version 4.4.0.
 - Imath : Updated to version 3.1.12.
 - Jemalloc : Removed when building on macOS.
@@ -117,6 +117,7 @@ Build
 - PySide : Updated to version 6.5.8.
 - Python : Updated to version 3.11.14.
 - Qt : Updated to version 6.5.8.
+- SSE2NEON : Added version 1.9.1 when building on macOS.
 - TBB : Updated to version 2021.13.0.
 - USD : Updated to version 26.03.
 

--- a/Changes.md
+++ b/Changes.md
@@ -38,7 +38,7 @@ Fixes
 - DeleteCurves : Fixed deletion of periodic curves.
 - ResamplePrimitiveVariables : Fixed resampling between Vertex and Varying for linear curves.
 - Cycles :
-  - Reduced memory usage when rendering a single segment of deformation blur on CPU devices.
+  - Reduced memory usage when rendering a single segment of deformation blur.
   - Fixed PointsPrimitive motion blur when rendering with even numbers of segments.
   - Fixed translation of Uniform `N` primitive variables, these are now resampled to FaceVarying.
 - USDShader : Fixed value of `type` plug after loading a USDLux light.

--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ Fixes
 - Cycles :
   - Reduced memory usage when rendering a single segment of deformation blur on CPU devices.
   - Fixed PointsPrimitive motion blur when rendering with even numbers of segments.
+  - Fixed translation of Uniform `N` primitive variables, these are now resampled to FaceVarying.
 - USDShader : Fixed value of `type` plug after loading a USDLux light.
 - CyclesLight, ArnoldLight, LightFilter : Fixed potential hang when loading shaders (GIL management bug in `loadShader()` binding).
 - StandardNodeGadget : Fixed crash caused by the node emitting `errorSignal()` while the gadget is undergoing construction.

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Features
 --------
 
-- Cycles : Updated to version 5.0.0.
+- Cycles : Updated to version 5.1.0.
 - CurvesInterpolation : Added node for modifying CurvesPrimitive `basis` and `wrap`. This includes the ability to convert curves with `Pinned` wrap to `NonPeriodic`, adding the appropriate "phantom" points to maintain curve shape.
 
 Improvements

--- a/SConstruct
+++ b/SConstruct
@@ -1390,7 +1390,7 @@ libraries = {
 			"LIBS" : [
 				"IECoreScene$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX",
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferOSL",
-				"cycles_device", "cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_kernel", "cycles_kernel_osl",
+				"cycles_device", "cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_kernel_cpu", "cycles_kernel_osl",
 				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky", "extern_cuew",
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslcomp$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
 				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "openpgl", "zstd",

--- a/SConstruct
+++ b/SConstruct
@@ -1390,7 +1390,7 @@ libraries = {
 			"LIBS" : [
 				"IECoreScene$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX",
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferOSL",
-				"cycles_device", "cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_kernel", "cycles_kernel_osl",
+				"cycles_device", "cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_kernel_cpu", "cycles_kernel_osl",
 				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky", "extern_cuew",
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslcomp$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
 				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "openpgl", "zstd",

--- a/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
@@ -62,7 +62,7 @@ namespace GeometryAlgo
 {
 
 /// Converts animated samples of an `IECore::Object` into an equivalent `ccl::Geometry` object.
-IECORECYCLES_API ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Session *session );
+IECORECYCLES_API ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Scene *scene );
 
 /// Converts a primitive variable to a `ccl::Attribute` inside of a `ccl::AttributeSet`.
 IECORECYCLES_API void convertPrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, ccl::AttributeSet &attributes, ccl::AttributeElement attributeElement );

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -900,9 +900,7 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertTrue( isinstance( image, IECoreImage.ImagePrimitive ) )
 
 		color = self.__colorAtUV( image, imath.V2f( 0.5 ) )
-		self.assertEqual( color.r, points["N"].data[0].x )
-		self.assertEqual( color.g, points["N"].data[0].y )
-		self.assertEqual( color.b, points["N"].data[0].z )
+		self.assertEqualWithAbsError( imath.Color3f( color.r, color.g, color.b ), points["N"].data[0].normalize(), 0.0001 )
 
 	def __testMeshSmoothing( self, cube, smoothingExpected ) :
 

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -977,6 +977,12 @@ class RendererTest( GafferTest.TestCase ) :
 		cube["N"] = IECoreScene.MeshAlgo.calculateVertexNormals( cube, IECoreScene.MeshAlgo.NormalWeighting.Equal )
 		self.__testMeshSmoothing( cube, smoothingExpected = True )
 
+	def testUniformMeshNormals( self ) :
+
+		cube = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
+		cube["N"] = IECoreScene.MeshAlgo.calculateUniformNormals( cube )
+		self.__testMeshSmoothing( cube, smoothingExpected = False )
+
 	def testUnsupportedMeshNormals( self ) :
 
 		renderer = self.createRenderer()

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -970,7 +970,6 @@ class RendererTest( GafferTest.TestCase ) :
 
 	def testFaceVaryingMeshNormals( self ) :
 
-		# These are treated like non-existent normals, since Cycles doesn't support them.
 		cube = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
 		self.__testMeshSmoothing( cube, smoothingExpected = False )
 
@@ -979,6 +978,36 @@ class RendererTest( GafferTest.TestCase ) :
 		cube = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
 		cube["N"] = IECoreScene.MeshAlgo.calculateVertexNormals( cube, IECoreScene.MeshAlgo.NormalWeighting.Equal )
 		self.__testMeshSmoothing( cube, smoothingExpected = True )
+
+	def testUnsupportedMeshNormals( self ) :
+
+		renderer = self.createRenderer()
+		attributes = renderer.attributes( IECore.CompoundObject() )
+
+		cube = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
+
+		for interpolation in (
+			IECoreScene.PrimitiveVariable.Interpolation.Uniform,
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECoreScene.PrimitiveVariable.Interpolation.FaceVarying,
+		) :
+			with self.subTest( interpolation = interpolation ) :
+
+				cube = cube.copy()
+				cube["N"] = IECoreScene.PrimitiveVariable(
+					interpolation,
+					IECore.V3iVectorData( [ imath.V3i( 0, 1, 0 ) ] * cube.variableSize( interpolation ), IECore.GeometricData.Interpretation.Normal )
+				)
+
+				with IECore.CapturingMessageHandler() as mh :
+
+					renderer.object( str( interpolation ), cube, attributes )
+
+					self.assertEqual( len( mh.messages ), 1 )
+					self.assertEqual(
+						mh.messages[0].message,
+						"Primitive variable \"N\" has unsupported type \"V3iVectorData\" (expected V3fVectorData)."
+					)
 
 	def testUnsupportedPrimitiveVariables( self ) :
 

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -38,7 +38,6 @@
 
 #include "IECoreScene/PrimitiveVariable.h"
 
-#include "IECore/ObjectInterpolator.h"
 #include "IECore/SimpleTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
@@ -240,35 +239,11 @@ namespace IECoreCycles
 namespace GeometryAlgo
 {
 
-ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Session *session )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Scene *scene )
 {
 	if( samples.empty() )
 	{
 		return nullptr;
-	}
-
-	if( samples.size() % 2 == 0 && session->device->info.type != ccl::DeviceType::DEVICE_CPU )
-	{
-		// Cycles requires an odd number of motion samples for some reason, although
-		// experimentally this only seems to be the case when using GPU devices.
-		// Make memory-wasting redundant samples to work around this. Samples are
-		// expected to be spaced evenly in time, so we have to insert a redundant sample
-		// in every gap.
-		IECoreScenePreview::Renderer::ObjectSamples processedSamples;
-		processedSamples.reserve( samples.size() * 2 - 1 );
-		IECoreScenePreview::Renderer::SampleTimes processedTimes;
-		processedTimes.reserve( samples.size() * 2 - 1 );
-		for( size_t i = 0; i < samples.size(); ++i )
-		{
-			processedSamples.push_back( samples[i] );
-			processedTimes.push_back( times[i] );
-			if( i + 1 < samples.size() )
-			{
-				processedSamples.push_back( linearObjectInterpolation( samples[i].get(), samples[i+1].get(), 0.5f ) );
-				processedTimes.push_back( Imath::lerp( times[i], times[i+1], 0.5f ) );
-			}
-		}
-		return convert( processedSamples, processedTimes, session );
 	}
 
 	const IECore::Object *firstSample = samples.front().get();
@@ -290,7 +265,7 @@ ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &sampl
 	// Cycles expects the middle sample (rounding down for even numbers of
 	// samples) to be specified as the main sample, and the other samples to
 	// be provided via ATTR_STD_MOTION_VERTEX_POSITION.
-	return it->second( samples, times, (samples.size() - 1) / 2, session->scene.get() );
+	return it->second( samples, times, (samples.size() - 1) / 2, scene );
 }
 
 void registerConverter( IECore::TypeId fromType, Converter converter )

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -132,7 +132,7 @@ size_t dataSize( const TypedData<T> *data )
 	return 1;
 }
 
-template<typename T>
+template<typename T, bool isNormal = false>
 ccl::Attribute *convertTypedPrimitiveVariable( const std::string &name, const PrimitiveVariable &primitiveVariable, ccl::AttributeSet &attributes, ccl::TypeDesc typeDesc, ccl::AttributeElement attributeElement )
 {
 	// Get the data to convert, expanding indexed data if necessary, since Cycles doesn't support it
@@ -175,7 +175,16 @@ ccl::Attribute *convertTypedPrimitiveVariable( const std::string &name, const Pr
 
 	// Copy data into buffer.
 
-	if constexpr( std::is_same_v<T, V3fVectorData> || std::is_same_v<T, Color3fVectorData> )
+	if constexpr( std::is_same_v<T, V3fVectorData> && isNormal )
+	{
+		// Special case for normals as they need to be octahedrally encoded.
+		ccl::packed_normal *pn = attribute->data_normal();
+		for( const auto &v : data->readable() )
+		{
+			*pn++ = ccl::packed_normal( ccl::make_float3( v.x, v.y, v.z ) );
+		}
+	}
+	else if constexpr( std::is_same_v<T, V3fVectorData> || std::is_same_v<T, Color3fVectorData> )
 	{
 		// Special case for arrays of `float3`, where each element actually contains 4 floats for alignment purposes.
 		ccl::float3 *f3 = attribute->data_float3();
@@ -330,14 +339,27 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 			attr = convertTypedPrimitiveVariable<V2iVectorData>( name, primitiveVariable, attributes, ccl::TypeFloat2, attributeElement );
 			break;
 		case V3iVectorDataTypeId :
+		{
+			const ccl::TypeDesc typeDesc = typeFromGeometricDataInterpretation(
+				static_cast<const V3iVectorData *>( primitiveVariable.data.get() )->getInterpretation()
+			);
+			if( typeDesc == ccl::TypeNormal )
+			{
+				// Prevent a potential crash if the user decided to make an int-based normal.
+				msg(
+					Msg::Warning, "IECoreCyles::GeometryAlgo::convertPrimitiveVariable",
+					fmt::format(
+						"Primitive variable \"{}\" has unsupported type \"{}\" as Geometric Normal.",
+						name, primitiveVariable.data->typeName()
+					)
+				);
+				break;
+			}
 			attr = convertTypedPrimitiveVariable<V3iVectorData>(
-				name, primitiveVariable, attributes,
-				typeFromGeometricDataInterpretation(
-					static_cast<const V3iVectorData *>( primitiveVariable.data.get() )->getInterpretation()
-				),
-				attributeElement
+				name, primitiveVariable, attributes, typeDesc, attributeElement
 			);
 			break;
+		}
 
 		// Simple float-based data.
 
@@ -369,14 +391,25 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 			attr = convertTypedPrimitiveVariable<V2fVectorData>( name, primitiveVariable, attributes, ccl::TypeFloat2, attributeElement );
 			break;
 		case V3fVectorDataTypeId :
-			attr = convertTypedPrimitiveVariable<V3fVectorData>(
-				name, primitiveVariable, attributes,
-				typeFromGeometricDataInterpretation(
-					static_cast<const V3fVectorData *>( primitiveVariable.data.get() )->getInterpretation()
-				),
-				attributeElement
+		{
+			const ccl::TypeDesc typeDesc = typeFromGeometricDataInterpretation(
+				static_cast<const V3fVectorData *>( primitiveVariable.data.get() )->getInterpretation()
 			);
+			if( typeDesc == ccl::TypeNormal )
+			{
+				attr = convertTypedPrimitiveVariable<V3fVectorData, true>(
+					name, primitiveVariable, attributes, typeDesc,
+					( attributeElement == ccl::ATTR_ELEMENT_CORNER ) ? ccl::ATTR_ELEMENT_CORNER_NORMAL : ccl::ATTR_ELEMENT_VERTEX_NORMAL
+				);
+			}
+			else
+			{
+				attr = convertTypedPrimitiveVariable<V3fVectorData>(
+					name, primitiveVariable, attributes, typeDesc, attributeElement
+				);
+			}
 			break;
+		}
 		case Color3fVectorDataTypeId :
 			attr = convertTypedPrimitiveVariable<Color3fVectorData>( name, primitiveVariable, attributes, ccl::TypeColor, attributeElement );
 			break;
@@ -403,9 +436,13 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	/// use `convertPrimitiveVariable()` for most data, instead of having
 	/// custom code paths for `P`, `uv` etc?
 
-	if( name == "N" && attr->element == ccl::ATTR_ELEMENT_VERTEX && attr->type == ccl::TypeNormal )
+	if( name == "N" && attr->element == ccl::ATTR_ELEMENT_VERTEX_NORMAL && attr->type == ccl::TypeNormal )
 	{
 		attr->std = ccl::ATTR_STD_VERTEX_NORMAL;
+	}
+	else if( name == "N" && attr->element == ccl::ATTR_ELEMENT_CORNER_NORMAL && attr->type == ccl::TypeNormal )
+	{
+		attr->std = ccl::ATTR_STD_CORNER_NORMAL;
 	}
 	else if( name == "uv" && attr->type == ccl::TypeFloat2 )
 	{

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -142,6 +142,13 @@ ccl::Attribute *convertTypedPrimitiveVariable( const std::string &name, const Pr
 		data = static_cast<const T *>( primitiveVariable.data.get() );
 	}
 
+	// Special case for normals as they need to be octahedrally encoded.
+	const bool isNormal = typeDesc == ccl::TypeNormal;
+	if( isNormal )
+	{
+		attributeElement = attributeElement == ccl::ATTR_ELEMENT_CORNER ? ccl::ATTR_ELEMENT_CORNER_NORMAL : ccl::ATTR_ELEMENT_VERTEX_NORMAL;
+	}
+
 	// Create attribute. Cycles will allocate a buffer based on `attributeElement` and the information
 	// `attributes.geometry` contains.
 
@@ -167,7 +174,29 @@ ccl::Attribute *convertTypedPrimitiveVariable( const std::string &name, const Pr
 
 	// Copy data into buffer.
 
-	if constexpr( std::is_same_v<T, V3fVectorData> || std::is_same_v<T, Color3fVectorData> )
+	if( isNormal )
+	{
+		if constexpr( std::is_same_v<T, V3fVectorData> )
+		{
+			ccl::packed_normal *pn = attribute->data_normal();
+			for( const auto &v : data->readable() )
+			{
+				*pn++ = ccl::packed_normal( ccl::make_float3( v.x, v.y, v.z ) );
+			}
+		}
+		else
+		{
+			msg(
+				Msg::Warning, "IECoreCyles::GeometryAlgo::convertPrimitiveVariable",
+				fmt::format(
+					"Primitive variable \"{}\" has unsupported type \"{}\" (expected V3fVectorData).",
+					name, primitiveVariable.data->typeName()
+				)
+			);
+			return nullptr;
+		}
+	}
+	else if constexpr( std::is_same_v<T, V3fVectorData> || std::is_same_v<T, Color3fVectorData> )
 	{
 		// Special case for arrays of `float3`, where each element actually contains 4 floats for alignment purposes.
 		ccl::float3 *f3 = attribute->data_float3();
@@ -374,9 +403,13 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	/// use `convertPrimitiveVariable()` for most data, instead of having
 	/// custom code paths for `P`, `uv` etc?
 
-	if( name == "N" && attr->element == ccl::ATTR_ELEMENT_VERTEX && attr->type == ccl::TypeNormal )
+	if( name == "N" && attr->element == ccl::ATTR_ELEMENT_VERTEX_NORMAL && attr->type == ccl::TypeNormal )
 	{
 		attr->std = ccl::ATTR_STD_VERTEX_NORMAL;
+	}
+	else if( name == "N" && attr->element == ccl::ATTR_ELEMENT_CORNER_NORMAL && attr->type == ccl::TypeNormal )
+	{
+		attr->std = ccl::ATTR_STD_CORNER_NORMAL;
 	}
 	else if( name == "uv" && attr->type == ccl::TypeFloat2 )
 	{

--- a/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
@@ -146,9 +146,9 @@ IECore::CompoundDataPtr nodeData()
 	IECore::CompoundDataPtr result = new IECore::CompoundData();
 	IECore::CompoundDataMap &nodes = result->writable();
 
-	for( const auto& nodeType : ccl::NodeType::types() )
+	for( const auto& nodeType : ccl::NodeType::type_names() )
 	{
-		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType.first );
+		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType );
 		if( cNodeType )
 		{
 			// We skip "ShaderNode" types here
@@ -156,14 +156,14 @@ IECore::CompoundDataPtr nodeData()
 				continue;
 
 			// The shader node we skip
-			if( nodeType.first == "shader" )
+			if( nodeType == "shader" )
 				continue;
 
 			IECore::CompoundDataPtr node = new IECore::CompoundData();
 			IECore::CompoundDataMap &n = node->writable();
 			n["in"] = getSockets( cNodeType, false );
 			n["out"] = getSockets( cNodeType, true );
-			nodes[nodeType.first.c_str()] = std::move( node );
+			nodes[nodeType.c_str()] = std::move( node );
 		}
 	}
 	return result;
@@ -174,14 +174,14 @@ IECore::CompoundDataPtr shaderData()
 	IECore::CompoundDataPtr result = new IECore::CompoundData();
 	IECore::CompoundDataMap &shaders = result->writable();
 
-	for( const auto& nodeType : ccl::NodeType::types() )
+	for( const auto& nodeType : ccl::NodeType::type_names() )
 	{
 		// Skip over the "output" ShaderNode, as this is a part of the main
 		// "shader" node.
-		if( std::string( nodeType.first.c_str() ) == "output" )
+		if( std::string( nodeType.c_str() ) == "output" )
 			continue;
 
-		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType.first );
+		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType );
 		if( cNodeType )
 		{
 			if( cNodeType->type == ccl::NodeType::SHADER )
@@ -191,7 +191,7 @@ IECore::CompoundDataPtr shaderData()
 				s["in"] = getSockets( cNodeType, false );
 				s["out"] = getSockets( cNodeType, true );
 
-				std::string type( nodeType.first.c_str() );
+				std::string type( nodeType.c_str() );
 
 				if( boost::ends_with( type, "bsdf" ) )
 				{

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -70,10 +70,16 @@ namespace
 // - Which normal is actually used for shading is determined on a
 //  triangle-by-triangle basis using the `smooth` flag passed
 //  to `Mesh::add_triangle()`.
-// - Cycles does not support facevarying normals.
+// - Cycles as of 5.1 now supports face-varying normals as
+//  ("N", ATTR_STD_CORNER_NORMAL)
+// - And both vertex and face-varying now need to be packed as octahedral
+//  normals via the `ccl::packed_normal()` utility function.
 //
 // Also see `GeometryAlgo::convertPrimitiveVariable()` where we handle the
-// tagging of normal attributes with ATTR_STD_VERTEX_NORMAL.
+// tagging of normal attributes with ATTR_STD_VERTEX_NORMAL or
+// ATTR_STD_CORNER_NORMAL as well as pack them, where that packing decision
+// is made with ATTR_ELEMENT_VERTEX_NORMAL or ATTR_ELEMENT_CORNER_NORMAL as
+// curves also use this encoding not just meshes.
 bool hasSmoothNormals( const IECoreScene::MeshPrimitive *mesh )
 {
 	auto it = mesh->variables.find( "N" );
@@ -87,12 +93,6 @@ bool hasSmoothNormals( const IECoreScene::MeshPrimitive *mesh )
 		case PrimitiveVariable::Constant :
 		case PrimitiveVariable::Uniform :
 			// These are definitely intended to be faceted.
-			return false;
-		case PrimitiveVariable::FaceVarying :
-			// Could be a mix of faceted and non-faceted triangles, including
-			// triangles with a mix of soft and hard edges, which aren't
-			// representable in Cycles. Plump for faceted, among other things
-			// because the native Cortex cube geometry has FaceVarying normals.
 			return false;
 		default :
 			return true;

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -66,7 +66,8 @@ namespace
 // - Cycles meshes store vertex normals as ("N", ATTR_STD_VERTEX_NORMAL)
 // - If we don't specify vertex normals, they are computed for us
 //   and added to the mesh by Cycles itself by `Mesh::add_vertex_normals()`
-// - Face normals are computed on demand in the Cycles kernel.
+// - Face normals are always computed on demand in the Cycles kernel, so we
+//   resample custom uniform normals to face-varying.
 // - Which normal is actually used for shading is determined on a
 //  triangle-by-triangle basis using the `smooth` flag passed
 //  to `Mesh::add_triangle()`.
@@ -215,6 +216,14 @@ ccl::Mesh *convertPrimary( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *s
 		if( name == "P" )
 		{
 			// Converted above already
+			continue;
+		}
+		if( name == "N" && variable.interpolation == PrimitiveVariable::Uniform )
+		{
+			// Resample "N" to FaceVarying as Cycles doesn't accept custom uniform normals.
+			PrimitiveVariable resampledN = variable;
+			IECoreScene::MeshAlgo::resamplePrimitiveVariable( mesh, resampledN, PrimitiveVariable::FaceVarying );
+			GeometryAlgo::convertPrimitiveVariable( name, resampledN, attributes, ccl::ATTR_ELEMENT_CORNER );
 			continue;
 		}
 		switch( variable.interpolation )

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -70,10 +70,13 @@ namespace
 // - Which normal is actually used for shading is determined on a
 //  triangle-by-triangle basis using the `smooth` flag passed
 //  to `Mesh::add_triangle()`.
-// - Cycles does not support facevarying normals.
+// - Cycles as of 5.1 now supports face-varying normals as
+//  ("N", ATTR_STD_CORNER_NORMAL)
 //
 // Also see `GeometryAlgo::convertPrimitiveVariable()` where we handle the
-// tagging of normal attributes with ATTR_STD_VERTEX_NORMAL.
+// tagging of normal attributes with ATTR_STD_VERTEX_NORMAL or
+// ATTR_STD_CORNER_NORMAL. This also handles octahedral packing of normals
+// via the `ccl::packed_normal()` utility function.
 bool hasSmoothNormals( const IECoreScene::MeshPrimitive *mesh )
 {
 	auto it = mesh->variables.find( "N" );
@@ -87,12 +90,6 @@ bool hasSmoothNormals( const IECoreScene::MeshPrimitive *mesh )
 		case PrimitiveVariable::Constant :
 		case PrimitiveVariable::Uniform :
 			// These are definitely intended to be faceted.
-			return false;
-		case PrimitiveVariable::FaceVarying :
-			// Could be a mix of faceted and non-faceted triangles, including
-			// triangles with a mix of soft and hard edges, which aren't
-			// representable in Cycles. Plump for faceted, among other things
-			// because the native Cortex cube geometry has FaceVarying normals.
 			return false;
 		default :
 			return true;

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -39,15 +39,10 @@
 #include "IECoreScene/MeshPrimitive.h"
 #include "IECoreScene/MeshAlgo.h"
 
-#include "IECore/Interpolator.h"
-#include "IECore/SimpleTypedData.h"
-
 // Cycles
 #include "kernel/types.h"
 #include "scene/geometry.h"
 #include "scene/mesh.h"
-#include "subd/dice.h"
-#include "util/param.h"
 #include "util/types.h"
 
 #include "fmt/format.h"

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1454,8 +1454,8 @@ class GeometryCache
 
 	public :
 
-		GeometryCache( ccl::Session *session, NodeDeleter *nodeDeleter )
-			: m_session( session ), m_nodeDeleter( nodeDeleter )
+		GeometryCache( ccl::Scene *scene, NodeDeleter *nodeDeleter )
+			: m_scene( scene ), m_nodeDeleter( nodeDeleter )
 		{
 		}
 
@@ -1527,7 +1527,7 @@ class GeometryCache
 			const std::string &nodeName
 		)
 		{
-			auto geometry = SharedGeometryPtr( GeometryAlgo::convert( samples, times, m_session ), NodeDeleter::GeometryDeleter( m_nodeDeleter ) );
+			auto geometry = SharedGeometryPtr( GeometryAlgo::convert( samples, times, m_scene ), NodeDeleter::GeometryDeleter( m_nodeDeleter ) );
 			if( geometry )
 			{
 				geometry->name = ccl::ustring( nodeName.c_str() );
@@ -1536,13 +1536,13 @@ class GeometryCache
 			if( auto vdb = IECore::runTimeCast<const IECoreVDB::VDBObject>( samples.front().get() ) )
 			{
 				assert( geometry->is_volume() );
-				GeometryAlgo::convertVoxelGrids( vdb, static_cast<ccl::Volume*>( geometry.get() ), m_session->scene.get(), attributes->getVolumePrecision(), attributes->getVolumeClipping() );
+				GeometryAlgo::convertVoxelGrids( vdb, static_cast<ccl::Volume*>( geometry.get() ), m_scene, attributes->getVolumePrecision(), attributes->getVolumeClipping() );
 			}
 
 			return geometry;
 		}
 
-		ccl::Session *m_session;
+		ccl::Scene *m_scene;
 		NodeDeleter *m_nodeDeleter;
 		using Geometry = tbb::concurrent_hash_map<IECore::MurmurHash, SharedGeometryPtr>;
 		Geometry m_geometry;
@@ -2790,7 +2790,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			}
 
 			m_shaderCache = std::make_unique<ShaderCache>( m_scene );
-			m_geometryCache = std::make_unique<GeometryCache>( m_session.get(), m_nodeDeleter.get() );
+			m_geometryCache = std::make_unique<GeometryCache>( m_scene, m_nodeDeleter.get() );
 			m_attributesCache = std::make_unique<AttributesCache>( m_shaderCache.get() );
 		}
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Support for Cycles 5.1.0

### Related issues ###

- N/A

### Dependencies ###

- https://github.com/GafferHQ/dependencies/pull/298

### Breaking changes ###

- FaceVarying normals now correctly translate while before it would revert to hard-surfaced normals
- I didn't remove the workaround for even motion samples, I can do this in this PR if you'd like

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
