### PR TITLE
Dispatcher : Omit `dispatcher:scriptFileName` from isolated batch names

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 - Plug : Fixed bug which meant nodes would fail to update if a newly created plug was renamed before being parented to the node.
 - Metadata : Fixed handling of exceptions thrown from value functions implemented in Python. These are now correctly translated into C++ exceptions.
 - Cycles, OSLObject, OSLImage, Expression : Fixed crashes when using OSL on macOS.
+- Dispatcher : Removed `dispatcher:scriptFileName` from labels for isolated tasks.
 
 1.6.16.0 (relative to 1.6.15.0)
 ========

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -3189,5 +3189,24 @@ class DispatcherTest( GafferTest.TestCase ) :
 				)
 			)
 
+	def testIsolatedBatchNamesDontIncludeScriptFileName( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["command"] = GafferDispatch.SystemCommand()
+		script["command"]["command"].setValue( "echo Hello World" )
+		script["command"]["dispatcher"]["isolated"].setValue( True )
+
+		script["dispatcher"] = self.NullDispatcher()
+		script["dispatcher"]["tasks"][0].setInput( script["command"]["task"] )
+		script["dispatcher"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		script["dispatcher"]["task"].execute()
+		rootBatch = script["dispatcher"].lastDispatch
+
+		self.assertEqual(
+			rootBatch.preTasks()[0].blindData()["name"].value,
+			"command 1"
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -638,6 +638,17 @@ class Dispatcher::TaskBatch::Namer
 
 			for( const auto &name : names )
 			{
+				if( name == g_scriptFileNameContextEntry )
+				{
+					// When we isolate batches, we give them a new script filename,
+					// but that information would only clutter up the batch names,
+					// so we omit it here.
+					/// \todo A smarter method of naming might be to include only
+					/// context variables that differ between batches for the same
+					/// node. That would automatically take care of this omission
+					/// too.
+					continue;
+				}
 				if( context->variableHash( name ) == m_baseContext.variableHash( name ) )
 				{
 					continue;


### PR DESCRIPTION
It tends to have very long values that would clutter up the name, and don't add much value for the user. The isolated script filename is more of an implementation detail, and can be seen in the `gaffer execute` command line anyway.
