### PR TITLE
SConstruct : Change GafferCycles OSL linking order

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 
 - Plug : Fixed bug which meant nodes would fail to update if a newly created plug was renamed before being parented to the node.
 - Metadata : Fixed handling of exceptions thrown from value functions implemented in Python. These are now correctly translated into C++ exceptions.
+- Cycles, OSLObject, OSLImage, Expression : Fixed crashes when using OSL on macOS.
 
 1.6.16.0 (relative to 1.6.15.0)
 ========

--- a/SConstruct
+++ b/SConstruct
@@ -1370,7 +1370,7 @@ libraries = {
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferOSL",
 				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
 				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky", "extern_cuew",
-				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslcomp$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
+				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslcomp$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
 				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl", "zstd",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],


### PR DESCRIPTION
Linking GafferCycles to oslcomp before oslexec leads to `EXC_BAD_ACCESS (SIGSEGV) KERN_INVALID_ADDRESS (possible pointer authentication failure)` related crashes in `llvm::AnalysisManager` when Cycles calls `ShadingSystem::optimize_all_groups()` at the start of a render using OSL shading on macOS.

Interestingly, this was also causing GafferOSL to crash in `llvm::AnalysisManager` when OSL optimises shader groups on macOS, but only when GafferCycles was loaded before GafferOSL. All the tests in GafferOSLTest would pass as GafferCycles is not imported there, but OSLImage, OSLObject and OSL expressions would crash interactively as GafferCycles is imported before GafferOSL during startup. Importing GafferOSL before GafferCycles would prevent the crashes in GafferOSL nodes, but still crash in Cycles OSL renders.

I can't say specifically why this fixes things, but it results in GafferCycles matching the oslexec and oslcomp linking order of GafferOSL and the Cycles standalone executable, so it seems a reasonable thing to do?