### PR TITLE
ShaderTweaksTest : Ensure "simpleShader" is deliberately loaded

### DIFF
--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -735,6 +735,7 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 	def testShadertypeFilter( self ) :
 
 		shaderA = GafferSceneTest.TestShader( "A" )
+		shaderA.loadShader( "simpleShader" )
 		shaderB = GafferSceneTest.TestShader( "B" )
 		shaderB.loadShader( "mix" )
 		shaderB["parameters"]["a"].setInput( shaderA["out"]["c"] )


### PR DESCRIPTION
This test passes on `1.6_maintenance` but with the recent 73d9fc5edba838903c76072c961e115b8b1c6e69 change on `main`, this is now erroring due to "simpleShader" no longer being loaded in TestShader's constructor.