### PR TITLE
Cycles : Use ccl::DeviceInfo's 'num' entry instead of typeIndex for the index representation of the GPU device number.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 - Plug : Fixed bug which meant nodes would fail to update if a newly created plug was renamed before being parented to the node.
 - Metadata : Fixed handling of exceptions thrown from value functions implemented in Python. These are now correctly translated into C++ exceptions.
 - Cycles, OSLObject, OSLImage, Expression : Fixed crashes when using OSL on macOS.
+- Cycles : Use ccl::DeviceInfo's 'num' entry instead of typeIndex for the index representation of the GPU device number.
 
 1.6.16.0 (relative to 1.6.15.0)
 ========

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -239,10 +239,10 @@ def __registerDevicePresets() :
 		typeIndices[device["type"]] += 1
 
 		presetNames.append( "{}/{}".format( device["type"], device["description"] ) )
-		presetValues.append( "{}:{:02}".format( device["type"], typeIndex ) )
+		presetValues.append( "{}:{:02}".format( device["type"], device["num"].value ) )
 
 		presetNames.append( "{}/{} + CPU".format( device["type"], device["description"] ) )
-		presetValues.append( "CPU {}:{:02}".format( device["type"], typeIndex ) )
+		presetValues.append( "CPU {}:{:02}".format( device["type"], device["num"].value ) )
 
 	for deviceType, count in typeIndices.items() :
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2358,7 +2358,7 @@ ccl::DeviceInfo matchingDevices( const std::string &pattern, int threads, bool b
 	{
 		const string typeString = ccl::Device::string_from_type( device.type );
 		const int typeIndex = typeIndices[device.type]++;
-		const string name = fmt::format( "{}:{:02}", typeString, typeIndex );
+		const string name = fmt::format( "{}:{:02}", typeString, device.num );
 		if(
 			// e.g. "CPU" matches the first CPU device.
 			( typeIndex == 0 && StringAlgo::matchMultiple( typeString, pattern ) ) ||


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- So I wanted to try building HIP/HIPRT support with Cycles again as I have a laptop with 2x RDNA2 GPUs in it (integrated and RX 6800M) - it turns out the typeIndex isn't guaranteed to be the device number order, where the integrated graphics comes first and the discrete GPU comes second, however their index number ordering is in reverse.
<img width="762" height="622" alt="Screenshot 2026-04-14 213608" src="https://github.com/user-attachments/assets/96b7ae80-4901-4780-95e5-a42c19d5a35f" />

In the above image, `HIP:00` is the discrete GPU but `HIP:01` is the integrated graphics.

```
CPU: IECore.CompoundData({'type':IECore.StringData( 'CPU' ),'description':IECore.StringData( 'AMD Ryzen 7 6800HS' ),'denoisers':IECore.IntData( 4 ),'cpu_threads':IECore.IntData( 0 ),'has_gpu_queue':IECore.BoolData( 0 ),'has_peer_memory':IECore.BoolData( 0 ),'has_profiling':IECore.BoolData( 1 ),'has_osl':IECore.BoolData( 1 ),'has_nanovdb':IECore.BoolData( 1 ),'display_device':IECore.BoolData( 0 ),'num':IECore.IntData( 0 ),'id':IECore.StringData( 'CPU' )})
HIP_AMD Radeon(TM) Graphics_0000:68:00: IECore.CompoundData({'type':IECore.StringData( 'HIP' ),'description':IECore.StringData( 'AMD Radeon(TM) Graphics' ),'denoisers':IECore.IntData( 4 ),'cpu_threads':IECore.IntData( 0 ),'has_gpu_queue':IECore.BoolData( 1 ),'has_peer_memory':IECore.BoolData( 0 ),'has_profiling':IECore.BoolData( 0 ),'has_osl':IECore.BoolData( 0 ),'has_nanovdb':IECore.BoolData( 1 ),'display_device':IECore.BoolData( 0 ),'num':IECore.IntData( 1 ),'id':IECore.StringData( 'HIP_AMD Radeon(TM) Graphics_0000:68:00' )})
HIP_AMD Radeon RX 6800M_0000:03:00: IECore.CompoundData({'type':IECore.StringData( 'HIP' ),'description':IECore.StringData( 'AMD Radeon RX 6800M' ),'denoisers':IECore.IntData( 4 ),'cpu_threads':IECore.IntData( 0 ),'has_gpu_queue':IECore.BoolData( 1 ),'has_peer_memory':IECore.BoolData( 0 ),'has_profiling':IECore.BoolData( 0 ),'has_osl':IECore.BoolData( 0 ),'has_nanovdb':IECore.BoolData( 1 ),'display_device':IECore.BoolData( 0 ),'num':IECore.IntData( 0 ),'id':IECore.StringData( 'HIP_AMD Radeon RX 6800M_0000:03:00' )})
```

Instead I use the `DeviceInfo`'s "num" entry for the index numbering in both the UI and the backend renderer code. Now when I select them I get the results I'm expecting.

### Related issues ###

- NA

### Dependencies ###

- NA

### Breaking changes ###

- Not related to current builds as it isn't compiled with HIP, however I expect current Cuda/OptiX setups to work like they did before, granted the "num" value matches "typeIndex" for those.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
