### PR TITLE
Wrapper : Don't add GAFFEROSL_CODE_DIRECTORY to OSL_SHADER_PATHS

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 - Metadata : Fixed handling of exceptions thrown from value functions implemented in Python. These are now correctly translated into C++ exceptions.
 - Cycles, OSLObject, OSLImage, Expression : Fixed crashes when using OSL on macOS.
 - Dispatcher : Removed `dispatcher:scriptFileName` from labels for isolated tasks.
+- NodeMenu : Fixed slow operation when many OSLCode shaders have been generated.
 
 1.6.16.0 (relative to 1.6.15.0)
 ========

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -149,7 +149,6 @@ prependToPath( pathlib.Path.home() / "gaffer" / "shaders", "OSL_SHADER_PATHS" )
 
 if "GAFFEROSL_CODE_DIRECTORY" not in os.environ :
 	os.environ["GAFFEROSL_CODE_DIRECTORY"] = str( pathlib.Path.home() / "gaffer" / "oslCode" )
-	appendToPath( os.environ["GAFFEROSL_CODE_DIRECTORY"], "OSL_SHADER_PATHS" )
 
 if sys.platform == "win32" and "OSL_LOAD_DLLS_FROM_PATH" not in os.environ :
 	# Prevent OSL from adding entries from `PATH` to Python binary search paths.

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -467,27 +467,6 @@ if moduleSearchPath.find( "GafferOSL" ) :
 		os.environ["OSL_SHADER_PATHS"].split( os.path.pathsep ),
 		[ "oso" ],
 		__shaderNodeCreator,
-		# The OSLCode node also generates a great many shaders behind
-		# the scenes that we don't want to place in the menus. Typically
-		# these aren't on the OSL_SHADER_PATHS anyway because they are
-		# given to the renderer via absolute paths, but at the time of
-		# writing it is necessary to place them on the OSL_SHADER_PATHS
-		# in order to use them in Arnold. We don't enable this by default
-		# because it causes Arnold to potentially load a huge number of
-		# shader plugins at startup, but we hide any oslCode shaders here
-		# in case someone else enables it.
-		#
-		# This match expression filters these categories of shader out
-		# as follows :
-		#
-		# - (^|.*/) matches any number (including zero) of directory
-		#   names preceding the shader name.
-		# - (?!oslCode) is a negative lookahead, asserting that the shader
-		#   name does not start "oslCode", the prefix for all OSLCode
-		#   shaders.
-		# - [^/]*$ matches the rest of the shader name, ensuring it
-		#   doesn't include any directory separators.
-		matchExpression = re.compile( "(^|.*/)(?!oslCode)[^/]*$"),
 		searchTextPrefix = "osl",
 	)
 


### PR DESCRIPTION
When we've generated a lot of shaders, this can make the OSL submenu of the NodeMenu unnecessarily slow. We don't need the directory on the path because we always reference OSLCode shaders by absolute path anyway.

This change was motivated by the discussion at https://groups.google.com/g/gaffer-dev/c/W-A3jVxfKj4/m/kAAOPRD5AAAJ.

I can't think of any reason this would break anything, but if we wanted to be cautious we could target it to `main` rather than `1.6_maintenance`.