### PR TITLE
Renderer : Remove single-sample virtual methods (with renderer tests)

### DIFF
--- a/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
 #include "GafferCycles/IECoreCyclesPreview/Export.h"
 
 #include "IECoreScene/Primitive.h"
@@ -63,7 +65,7 @@ namespace GeometryAlgo
 IECORECYCLES_API ccl::Geometry *convert( const IECore::Object *object, ccl::Scene *scene );
 /// As above, but converting a moving object. If no motion converter
 /// is available, the first sample is converted instead.
-IECORECYCLES_API ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, ccl::Session *session );
+IECORECYCLES_API ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Session *session );
 
 /// Converts a primitive variable to a `ccl::Attribute` inside of a `ccl::AttributeSet`.
 IECORECYCLES_API void convertPrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, ccl::AttributeSet &attributes, ccl::AttributeElement attributeElement );
@@ -81,7 +83,7 @@ using Converter = ccl::Geometry *(*)( const IECore::Object *, ccl::Scene * );
 /// argument indicates which sample should be used for the main conversion, and
 /// the converter should defer to `convertMotion()` to convert the positions of
 /// the remaining motion samples to ATTR_STD_MOTION_VERTEX_POSITION.
-using MotionConverter = ccl::Geometry *(*)( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, size_t primarySampleIndex, ccl::Scene *scene );
+using MotionConverter = ccl::Geometry *(*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -98,7 +100,7 @@ class ConverterDescription
 
 		/// Type-specific conversion functions.
 		using Converter = ccl::Geometry *(*)( const T *, ccl::Scene * );
-		using MotionConverter = ccl::Geometry *(*)( const std::vector<const T *> &, const std::vector<float> &, size_t, ccl::Scene * );
+		using MotionConverter = ccl::Geometry *(*)( const std::vector<const T *> &, const IECoreScenePreview::Renderer::SampleTimes &, size_t, ccl::Scene * );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{

--- a/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
@@ -61,10 +61,7 @@ namespace IECoreCycles
 namespace GeometryAlgo
 {
 
-/// Converts the specified `IECore::Object` into `ccl::Geometry`.
-IECORECYCLES_API ccl::Geometry *convert( const IECore::Object *object, ccl::Scene *scene );
-/// As above, but converting a moving object. If no motion converter
-/// is available, the first sample is converted instead.
+/// Converts animated samples of an `IECore::Object` into an equivalent `ccl::Geometry` object.
 IECORECYCLES_API ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Session *session );
 
 /// Converts a primitive variable to a `ccl::Attribute` inside of a `ccl::AttributeSet`.
@@ -76,19 +73,17 @@ IECORECYCLES_API void convertMotion( const IECoreScenePreview::Renderer::Samples
 /// Converts voxel grids from a VDB object.
 IECORECYCLES_API void convertVoxelGrids( const IECoreVDB::VDBObject *vdbObject, ccl::Volume *geometry, ccl::Scene *scene, int precision, float clipping );
 
-/// Signature of a function which can convert to `ccl:Geometry`.
-using Converter = std::function<ccl::Geometry *( const IECore::Object *, ccl::Scene * )>;
 /// Signature of a function which can convert a series of `IECore::Object`
 /// samples into a moving `ccl:Geometry` object. The `primarySampleIndex`
 /// argument indicates which sample should be used for the main conversion, and
 /// the converter should defer to `convertMotion()` to convert the positions of
 /// the remaining motion samples to ATTR_STD_MOTION_VERTEX_POSITION.
-using MotionConverter = std::function<ccl::Geometry *( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )>;
+using Converter = std::function<ccl::Geometry *( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )>;
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
 /// this, since it provides additional type safety.
-IECORECYCLES_API void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter = nullptr );
+IECORECYCLES_API void registerConverter( IECore::TypeId fromType, Converter converter );
 
 /// Class which registers a converter for type T automatically
 /// when instantiated.
@@ -98,29 +93,18 @@ class ConverterDescription
 
 	public :
 
-		/// Type-specific conversion functions.
-		using TypedConverter = ccl::Geometry *(*)( const T *, ccl::Scene * );
+		/// Type-specific conversion function.
 		using TypedSamples = IECoreScenePreview::Renderer::Samples<const T *>;
-		using TypedMotionConverter = ccl::Geometry *(*)( const TypedSamples &, const IECoreScenePreview::Renderer::SampleTimes &, size_t, ccl::Scene * );
+		using TypedConverter = ccl::Geometry *(*)( const TypedSamples &, const IECoreScenePreview::Renderer::SampleTimes &, size_t, ccl::Scene * );
 
-		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter )
 		{
-			MotionConverter motionConverterWrapper;
-			if( motionConverter )
-			{
-				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
-				{
-					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), times, primarySampleIndex, scene );
-				};
-			}
-
 			registerConverter(
 				T::staticTypeId(),
-				[converter] ( const IECore::Object *object, ccl::Scene *scene )
+				[converter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 				{
-					return converter( static_cast<const T *>( object ), scene );
-				},
-				motionConverterWrapper
+					return converter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), times, primarySampleIndex, scene );
+				}
 			);
 		}
 

--- a/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
@@ -71,19 +71,19 @@ IECORECYCLES_API ccl::Geometry *convert( const IECoreScenePreview::Renderer::Obj
 IECORECYCLES_API void convertPrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, ccl::AttributeSet &attributes, ccl::AttributeElement attributeElement );
 
 /// Converts motion for "P" primitive variable.
-IECORECYCLES_API void convertMotion( const std::vector<const IECoreScene::Primitive *> &samples, size_t primarySampleIndex, ccl::Geometry &geometry );
+IECORECYCLES_API void convertMotion( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &samples, size_t primarySampleIndex, ccl::Geometry &geometry );
 
 /// Converts voxel grids from a VDB object.
 IECORECYCLES_API void convertVoxelGrids( const IECoreVDB::VDBObject *vdbObject, ccl::Volume *geometry, ccl::Scene *scene, int precision, float clipping );
 
 /// Signature of a function which can convert to `ccl:Geometry`.
-using Converter = ccl::Geometry *(*)( const IECore::Object *, ccl::Scene * );
+using Converter = std::function<ccl::Geometry *( const IECore::Object *, ccl::Scene * )>;
 /// Signature of a function which can convert a series of `IECore::Object`
 /// samples into a moving `ccl:Geometry` object. The `primarySampleIndex`
 /// argument indicates which sample should be used for the main conversion, and
 /// the converter should defer to `convertMotion()` to convert the positions of
 /// the remaining motion samples to ATTR_STD_MOTION_VERTEX_POSITION.
-using MotionConverter = ccl::Geometry *(*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene );
+using MotionConverter = std::function<ccl::Geometry *( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )>;
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -99,15 +99,28 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using Converter = ccl::Geometry *(*)( const T *, ccl::Scene * );
-		using MotionConverter = ccl::Geometry *(*)( const std::vector<const T *> &, const IECoreScenePreview::Renderer::SampleTimes &, size_t, ccl::Scene * );
+		using TypedConverter = ccl::Geometry *(*)( const T *, ccl::Scene * );
+		using TypedSamples = IECoreScenePreview::Renderer::Samples<const T *>;
+		using TypedMotionConverter = ccl::Geometry *(*)( const TypedSamples &, const IECoreScenePreview::Renderer::SampleTimes &, size_t, ccl::Scene * );
 
-		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
 		{
+			MotionConverter motionConverterWrapper;
+			if( motionConverter )
+			{
+				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
+				{
+					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), times, primarySampleIndex, scene );
+				};
+			}
+
 			registerConverter(
 				T::staticTypeId(),
-				reinterpret_cast<GeometryAlgo::Converter>( converter ),
-				reinterpret_cast<GeometryAlgo::MotionConverter>( motionConverter )
+				[converter] ( const IECore::Object *object, ccl::Scene *scene )
+				{
+					return converter( static_cast<const T *>( object ), scene );
+				},
+				motionConverterWrapper
 			);
 		}
 

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -108,7 +108,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 
 				const std::string &capturedName() const;
 
-				const std::vector<IECore::ConstObjectPtr> &capturedSamples() const;
+				const ObjectSamples &capturedSamples() const;
 				const SampleTimes &capturedSampleTimes() const;
 
 				const TransformSamples &capturedTransforms() const;
@@ -142,7 +142,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 
 				CapturingRenderer *m_renderer;
 				const std::string m_name;
-				std::vector<IECore::ConstObjectPtr> m_capturedSamples;
+				ObjectSamples m_capturedSamples;
 				SampleTimes m_capturedSampleTimes;
 				TransformSamples m_capturedTransforms;
 				SampleTimes m_capturedTransformTimes;

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -166,7 +166,6 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 		void option( const IECore::InternedString &name, const IECore::Object *value ) override;
 		void output( const IECore::InternedString &name, const IECoreScene::Output *output ) override;
 		AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -109,10 +109,10 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				const std::string &capturedName() const;
 
 				const std::vector<IECore::ConstObjectPtr> &capturedSamples() const;
-				const std::vector<float> &capturedSampleTimes() const;
+				const SampleTimes &capturedSampleTimes() const;
 
-				const std::vector<Imath::M44f> &capturedTransforms() const;
-				const std::vector<float> &capturedTransformTimes() const;
+				const TransformSamples &capturedTransforms() const;
+				const SampleTimes &capturedTransformTimes() const;
 
 				const CapturedAttributes *capturedAttributes() const;
 				std::vector<IECore::InternedString> capturedLinkTypes() const;
@@ -128,7 +128,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				/// ==================
 
 				void transform( const Imath::M44f &transform ) override;
-				void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+				void transform( const TransformSamples &samples, const SampleTimes &times ) override;
 				bool attributes( const AttributesInterface *attributes ) override;
 				void link( const IECore::InternedString &type, const ConstObjectSetPtr &objects ) override;
 				void assignID( uint32_t id ) override;
@@ -136,16 +136,16 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 
 			private :
 
-				CapturedObject( CapturingRenderer *renderer, const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times );
+				CapturedObject( CapturingRenderer *renderer, const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times );
 
 				friend class CapturingRenderer;
 
 				CapturingRenderer *m_renderer;
 				const std::string m_name;
-				const std::vector<IECore::ConstObjectPtr> m_capturedSamples;
-				const std::vector<float> m_capturedSampleTimes;
-				std::vector<Imath::M44f> m_capturedTransforms;
-				std::vector<float> m_capturedTransformTimes;
+				std::vector<IECore::ConstObjectPtr> m_capturedSamples;
+				SampleTimes m_capturedSampleTimes;
+				TransformSamples m_capturedTransforms;
+				SampleTimes m_capturedTransformTimes;
 				ConstCapturedAttributesPtr m_capturedAttributes;
 				int m_numAttributeEdits;
 				std::unordered_map<IECore::InternedString, std::pair<ConstObjectSetPtr, int>> m_capturedLinks;
@@ -167,11 +167,11 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 		void output( const IECore::InternedString &name, const IECoreScene::Output *output ) override;
 		AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;
 

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -127,7 +127,6 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				/// Renderer interface
 				/// ==================
 
-				void transform( const Imath::M44f &transform ) override;
 				void transform( const TransformSamples &samples, const SampleTimes &times ) override;
 				bool attributes( const AttributesInterface *attributes ) override;
 				void link( const IECore::InternedString &type, const ConstObjectSetPtr &objects ) override;

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -170,7 +170,6 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;

--- a/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
@@ -63,7 +63,7 @@ class GAFFERSCENE_API CompoundRenderer final : public IECoreScenePreview::Render
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;
 		IECore::DataPtr command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters ) override;

--- a/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
@@ -62,7 +62,6 @@ class GAFFERSCENE_API CompoundRenderer final : public IECoreScenePreview::Render
 		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
-		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;

--- a/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
@@ -59,7 +59,7 @@ class GAFFERSCENE_API CompoundRenderer final : public IECoreScenePreview::Render
 		void option( const IECore::InternedString &name, const IECore::Object *value ) override;
 		void output( const IECore::InternedString &name, const IECoreScene::Output *output ) override;
 		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -204,14 +204,9 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 				/// Assigns a transform to the object, replacing any previously
 				/// assigned transform. For Interactive renders transforms may be
 				/// modified at any time the renderer is paused.
-				/// \todo Should we introduce a TransformInterface that can be
-				/// passed directly to `Renderer::object()` etc in the same
-				/// way that attributes are? This might be a way of supporting
-				/// renderers with more complex transform models than just flattened
-				/// matrices.
-				virtual void transform( const Imath::M44f &transform ) = 0;
-				/// As above, but specifying a moving transform.
 				virtual void transform( const TransformSamples &samples, const SampleTimes &times ) = 0;
+				/// Convenience overload for when there is only a single transform sample.
+				void transform( const Imath::M44f &transform );
 				/// Assigns a new block of attributes to the object, replacing any
 				/// previously assigned attributes. This may only be used in Interactive
 				/// mode, and then only when the renderer is paused. Returns true on

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -287,12 +287,9 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		/// times passed to motionBegin() to specify motion blur. Defaults to 0,0 if unspecified.
 		///
 		/// May return a nullptr if the camera definition is not supported by the renderer.
-		virtual ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes = nullptr ) = 0;
-		/// As above, but allowing animated camera parameters to be specified. A default implementation
-		/// that calls `camera( name, samples[0], attributes )` is provided for renderers which don't
-		/// support animated cameras. Renderers that do support animated cameras should implement a suitable
-		/// override.
-		virtual ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes = nullptr );
+		virtual ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes = nullptr ) = 0;
+		/// Convenience wrapper for the above when there is only a single sample.
+		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes = nullptr );
 
 		/// Adds a named light with the initially supplied set of attributes, which are expected
 		/// to provide at least a light shader. Object may be non-null to specify arbitrary geometry

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -314,9 +314,9 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		/// \todo Rejig class hierarchy so we can have something less generic than
 		/// Object here, but still pass CoordinateSystems. Or should
 		/// coordinate systems have their own dedicated calls?
-		virtual ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) = 0;
-		/// As above, but specifying a deforming object.
 		virtual ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) = 0;
+		/// Convenience overload for when there is only a single object sample.
+		ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes );
 
 		/// Performs the render - should be called after the
 		/// entire scene has been specified using the methods

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -158,8 +158,8 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		using ObjectSetPtr = std::shared_ptr<ObjectSet>;
 		using ConstObjectSetPtr = std::shared_ptr<const ObjectSet>;
 		using TransformSamples = std::vector<Imath::M44f>;
-		using CameraSamples = std::vector<const IECoreScene::Camera *>;
-		using ObjectSamples = std::vector<const IECore::Object *>;
+		using CameraSamples = std::vector<IECoreScene::ConstCameraPtr>;
+		using ObjectSamples = std::vector<IECore::ConstObjectPtr>;
 		using SampleTimes = std::vector<float>;
 
 		/// A handle to an object in the renderer. The reference counting semantics of an

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -44,6 +44,7 @@
 #include "IECore/CompoundObject.h"
 #include "IECore/MessageHandler.h"
 
+#include "boost/container/small_vector.hpp"
 #include "boost/unordered_set.hpp"
 
 namespace IECoreScenePreview
@@ -157,10 +158,23 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		using ObjectSet = boost::unordered_set<ObjectInterfacePtr>;
 		using ObjectSetPtr = std::shared_ptr<ObjectSet>;
 		using ConstObjectSetPtr = std::shared_ptr<const ObjectSet>;
-		using TransformSamples = std::vector<Imath::M44f>;
-		using CameraSamples = std::vector<IECoreScene::ConstCameraPtr>;
-		using ObjectSamples = std::vector<IECore::ConstObjectPtr>;
-		using SampleTimes = std::vector<float>;
+
+		/// Types for storing animation samples to be passed to the
+		/// Renderer. We use `small_vector` to avoid allocations in the
+		/// common case of static objects or single-segment motion blur.
+
+		template<typename T>
+		using Samples = boost::container::small_vector<T, 2>;
+		using TransformSamples = Samples<Imath::M44f>;
+		using CameraSamples = Samples<IECoreScene::ConstCameraPtr>;
+		using ObjectSamples = Samples<IECore::ConstObjectPtr>;
+		using SampleTimes = Samples<float>;
+
+		/// Convenience function for casting between sample types. Typically
+		/// used by implementations to downcast from ObjectSamples to a more
+		/// specific type.
+		template<typename T, typename S>
+		static Samples<T> staticSamplesCast( const Samples<S> &samples );
 
 		/// A handle to an object in the renderer. The reference counting semantics of an
 		/// ObjectInterfacePtr are as follows :
@@ -354,3 +368,5 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 IE_CORE_DECLAREPTR( Renderer )
 
 } // namespace IECoreScenePreview
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.inl"

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -157,6 +157,10 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		using ObjectSet = boost::unordered_set<ObjectInterfacePtr>;
 		using ObjectSetPtr = std::shared_ptr<ObjectSet>;
 		using ConstObjectSetPtr = std::shared_ptr<const ObjectSet>;
+		using TransformSamples = std::vector<Imath::M44f>;
+		using CameraSamples = std::vector<const IECoreScene::Camera *>;
+		using ObjectSamples = std::vector<const IECore::Object *>;
+		using SampleTimes = std::vector<float>;
 
 		/// A handle to an object in the renderer. The reference counting semantics of an
 		/// ObjectInterfacePtr are as follows :
@@ -193,7 +197,7 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 				/// matrices.
 				virtual void transform( const Imath::M44f &transform ) = 0;
 				/// As above, but specifying a moving transform.
-				virtual void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) = 0;
+				virtual void transform( const TransformSamples &samples, const SampleTimes &times ) = 0;
 				/// Assigns a new block of attributes to the object, replacing any
 				/// previously assigned attributes. This may only be used in Interactive
 				/// mode, and then only when the renderer is paused. Returns true on
@@ -274,7 +278,7 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		/// that calls `camera( name, samples[0], attributes )` is provided for renderers which don't
 		/// support animated cameras. Renderers that do support animated cameras should implement a suitable
 		/// override.
-		virtual ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes = nullptr );
+		virtual ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes = nullptr );
 
 		/// Adds a named light with the initially supplied set of attributes, which are expected
 		/// to provide at least a light shader. Object may be non-null to specify arbitrary geometry
@@ -298,7 +302,7 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		/// coordinate systems have their own dedicated calls?
 		virtual ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) = 0;
 		/// As above, but specifying a deforming object.
-		virtual ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) = 0;
+		virtual ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) = 0;
 
 		/// Performs the render - should be called after the
 		/// entire scene has been specified using the methods

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.inl
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.inl
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,29 +34,27 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GeometryAlgo.h"
-#include "Loader.h"
-
-#include "IECoreScene/PointsPrimitive.h"
-
-using namespace IECoreScene;
-using namespace IECoreRenderMan;
-
-namespace
+namespace IECoreScenePreview
 {
 
-RtUString convertStaticPoints( const IECoreScene::PointsPrimitive *points, RtPrimVarList &primVars, const std::string &messageContext )
+template<typename T, typename S>
+Renderer::Samples<T> Renderer::staticSamplesCast( const Renderer::Samples<S> &samples )
 {
-	GeometryAlgo::convertPrimitive( points, primVars, messageContext );
-	return Loader::strings().k_Ri_Points;
+	Renderer::Samples<T> result;
+	result.reserve( samples.size() );
+	for( const auto &s : samples )
+	{
+		if constexpr( std::is_pointer_v<S> )
+		{
+			result.push_back( static_cast<T>( s ) );
+		}
+		else
+		{
+			// Assume we're casting from `intrusive_ptr`.
+			result.push_back( static_cast<T>( s.get() ) );
+		}
+	}
+	return result;
 }
 
-RtUString convertAnimatedPoints( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
-{
-	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );
-	return Loader::strings().k_Ri_Points;
-}
-
-GeometryAlgo::ConverterDescription<PointsPrimitive> g_pointsConverterDescription( convertStaticPoints, convertAnimatedPoints );
-
-} // namespace
+} // namespace IECoreScenePreview

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -108,18 +108,44 @@ GAFFERSCENE_API std::string renderManifestFilePath( const IECore::CompoundObject
 GAFFERSCENE_API bool transformMotionTimes( const RenderOptions &renderOptions, const IECore::CompoundObject *attributes, IECoreScenePreview::Renderer::SampleTimes &times );
 GAFFERSCENE_API bool deformationMotionTimes( const RenderOptions &renderOptions, const IECore::CompoundObject *attributes, IECoreScenePreview::Renderer::SampleTimes &times );
 
+struct GAFFERSCENE_API SampledTransform
+{
+	IECoreScenePreview::Renderer::TransformSamples samples;
+	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
+	Imath::M44f transformAtTime( float time ) const;
+	void concatenate( const SampledTransform &child );
+};
 /// Samples the local transform from the current location in preparation for output to the renderer.
-/// "samples" will be set to contain one sample for each sampleTime, unless the samples are all identical,
-/// in which case just one sample is output.
-/// If "hash" is passed in, then the hash will be set a value characterizing the samples.  If "hash" is
-/// already at this value, this function will do nothing and return false.  Returns true if hash is not
-/// passed in or the hash does not match.
-GAFFERSCENE_API bool transformSamples( const Gaffer::M44fPlug *transformPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::TransformSamples &samples, IECore::MurmurHash *hash = nullptr );
+/// `sampleTimes` should have been obtained from `transformMotionTimes()` and the current context should
+/// match the frame being output.
+///
+/// If `hash` is provided, then it will be set to a value characterising the samples. If `hash` is already
+/// at the right value, then no samples are taken and `std::nullopt` is returned, indicating that an
+/// interactive render requires no update.
+///
+/// Note that if all samples are identical, a single sample will be returned. Therefore the returned
+/// `sampleTimes` may differ from the `samplesTimes` passed in. It is the _returned_ `sampleTimes` that
+/// should be passed to the Renderer.
+GAFFERSCENE_API std::optional<SampledTransform> transformSamples( const Gaffer::M44fPlug *transformPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECore::MurmurHash *hash = nullptr );
 
-/// Samples the object from the current location in preparation for output to the renderer. Sample times and
-/// hash behave the same as for the transformSamples() method. Multiple samples will only be generated for
-/// Primitives and Cameras, since other object types cannot be interpolated anyway.
-GAFFERSCENE_API bool objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::ObjectSamples &samples, IECore::MurmurHash *hash = nullptr );
+struct SampledObject
+{
+	IECoreScenePreview::Renderer::ObjectSamples samples;
+	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
+};
+/// Samples the object from the current location in preparation for output to the renderer. The
+/// `sampleTimes` should have been obtained from `deformationMotionTimes()` and the current context should
+/// match the frame being output.
+///
+/// If `hash` is provided, then it will be set to a value characterising the samples. If `hash` is already
+/// at the right value, then no samples are taken and `std::nullopt` is returned, indicating that an
+/// interactive render requires no update.
+///
+/// Note that non-interpolable objects (such as Procedural or CoordinateSystem) will only receive a single
+/// sample from the current frame, no matter the values in `sampleTimes`. Therefore the returned `sampleTimes`
+/// may differ from the `sampleTimes` passed in. It is the _returned_ `sampleTimes` that should be passed to
+/// the Renderer.
+GAFFERSCENE_API std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECore::MurmurHash *hash = nullptr );
 
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, IECoreScenePreview::Renderer *renderer );
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -105,8 +105,8 @@ GAFFERSCENE_API std::string renderManifestFilePath( const IECore::CompoundObject
 /// Sets `times` to a list of times to sample the transform or deformation of a
 /// location at, based on the render options and location attributes. Returns `true`
 /// if `times` was altered and `false` if it was already set correctly.
-GAFFERSCENE_API bool transformMotionTimes( const RenderOptions &renderOptions, const IECore::CompoundObject *attributes, std::vector<float> &times );
-GAFFERSCENE_API bool deformationMotionTimes( const RenderOptions &renderOptions, const IECore::CompoundObject *attributes, std::vector<float> &times );
+GAFFERSCENE_API bool transformMotionTimes( const RenderOptions &renderOptions, const IECore::CompoundObject *attributes, IECoreScenePreview::Renderer::SampleTimes &times );
+GAFFERSCENE_API bool deformationMotionTimes( const RenderOptions &renderOptions, const IECore::CompoundObject *attributes, IECoreScenePreview::Renderer::SampleTimes &times );
 
 /// Samples the local transform from the current location in preparation for output to the renderer.
 /// "samples" will be set to contain one sample for each sampleTime, unless the samples are all identical,
@@ -114,12 +114,12 @@ GAFFERSCENE_API bool deformationMotionTimes( const RenderOptions &renderOptions,
 /// If "hash" is passed in, then the hash will be set a value characterizing the samples.  If "hash" is
 /// already at this value, this function will do nothing and return false.  Returns true if hash is not
 /// passed in or the hash does not match.
-GAFFERSCENE_API bool transformSamples( const Gaffer::M44fPlug *transformPlug, const std::vector<float> &sampleTimes, std::vector<Imath::M44f> &samples, IECore::MurmurHash *hash = nullptr );
+GAFFERSCENE_API bool transformSamples( const Gaffer::M44fPlug *transformPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::TransformSamples &samples, IECore::MurmurHash *hash = nullptr );
 
 /// Samples the object from the current location in preparation for output to the renderer. Sample times and
 /// hash behave the same as for the transformSamples() method. Multiple samples will only be generated for
 /// Primitives and Cameras, since other object types cannot be interpolated anyway.
-GAFFERSCENE_API bool objectSamples( const Gaffer::ObjectPlug *objectPlug, const std::vector<float> &sampleTimes, std::vector<IECore::ConstObjectPtr> &samples, IECore::MurmurHash *hash = nullptr );
+GAFFERSCENE_API bool objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, std::vector<IECore::ConstObjectPtr> &samples, IECore::MurmurHash *hash = nullptr );
 
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, IECoreScenePreview::Renderer *renderer );
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -119,7 +119,7 @@ GAFFERSCENE_API bool transformSamples( const Gaffer::M44fPlug *transformPlug, co
 /// Samples the object from the current location in preparation for output to the renderer. Sample times and
 /// hash behave the same as for the transformSamples() method. Multiple samples will only be generated for
 /// Primitives and Cameras, since other object types cannot be interpolated anyway.
-GAFFERSCENE_API bool objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, std::vector<IECore::ConstObjectPtr> &samples, IECore::MurmurHash *hash = nullptr );
+GAFFERSCENE_API bool objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::ObjectSamples &samples, IECore::MurmurHash *hash = nullptr );
 
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, IECoreScenePreview::Renderer *renderer );
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );

--- a/include/IECoreArnold/CameraAlgo.h
+++ b/include/IECoreArnold/CameraAlgo.h
@@ -49,8 +49,6 @@ namespace CameraAlgo
 {
 
 using CameraSamples = IECoreScenePreview::Renderer::Samples<const IECoreScene::Camera *>;
-
-IECOREARNOLD_API AtNode *convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "CameraAlgo::convert" );
 IECOREARNOLD_API AtNode *convert( const CameraSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "CameraAlgo::convert" );
 
 } // namespace CameraAlgo

--- a/include/IECoreArnold/CameraAlgo.h
+++ b/include/IECoreArnold/CameraAlgo.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
 #include "IECoreArnold/Export.h"
 
 #include "IECoreScene/Camera.h"
@@ -46,8 +48,10 @@ namespace IECoreArnold
 namespace CameraAlgo
 {
 
+using CameraSamples = IECoreScenePreview::Renderer::Samples<const IECoreScene::Camera *>;
+
 IECOREARNOLD_API AtNode *convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "CameraAlgo::convert" );
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "CameraAlgo::convert" );
+IECOREARNOLD_API AtNode *convert( const CameraSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "CameraAlgo::convert" );
 
 } // namespace CameraAlgo
 

--- a/include/IECoreArnold/NodeAlgo.h
+++ b/include/IECoreArnold/NodeAlgo.h
@@ -48,27 +48,22 @@ namespace IECoreArnold
 namespace NodeAlgo
 {
 
-/// Converts the specified IECore::Object into an equivalent
-/// Arnold object, returning nullptr if no conversion is
-/// available.
-IECOREARNOLD_API AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "NodeAlgo::convert" );
 /// Converts the specified IECore::Object samples into an
 /// equivalent moving Arnold object. If no motion converter
 /// is available, then returns a standard conversion of the
 /// first sample.
 IECOREARNOLD_API AtNode *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "NodeAlgo::convert" );
+/// Convenience function for the case of a single sample.
+IECOREARNOLD_API AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "NodeAlgo::convert" );
 
-/// Signature of a function which can convert an IECore::Object
-/// into an Arnold object.
-using Converter = std::function<AtNode *( const IECore::Object *sample, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )>;
-/// Signature of a function which can convert a series of IECore::Object
-/// samples into a moving Arnold object.
-using MotionConverter = std::function<AtNode *( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )>;
+/// Signature of a function which can convert a `IECore::Objects`
+/// into Arnold nodes.
+using Converter = std::function<AtNode *( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )>;
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
 /// this, since it provides additional type safety.
-IECOREARNOLD_API void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter = nullptr );
+IECOREARNOLD_API void registerConverter( IECore::TypeId fromType, Converter converter );
 
 /// Class which registers a converter for type T automatically
 /// when instantiated.
@@ -79,28 +74,17 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using TypedConverter = AtNode *(*)( const T *, AtUniverse *, const std::string &, const AtNode *, const std::string & );
 		using TypedObjectSamples = IECoreScenePreview::Renderer::Samples<const T *>;
-		using TypedMotionConverter = AtNode *(*)( const TypedObjectSamples &, float, float, AtUniverse *, const std::string &, const AtNode *, const std::string & );
+		using TypedConverter = AtNode *(*)( const TypedObjectSamples &, float, float, AtUniverse *, const std::string &, const AtNode *, const std::string & );
 
-		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter )
 		{
-			MotionConverter motionConverterWrapper;
-			if( motionConverter )
-			{
-				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )
-				{
-					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), motionStart, motionEnd, universe, nodeName, parent, messageContext );
-				};
-			}
-
 			registerConverter(
 				T::staticTypeId(),
-				[converter] ( const IECore::Object *sample, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )
+				[converter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )
 				{
-					return converter( static_cast<const T *>( sample ), universe, nodeName, parent, messageContext );
-				},
-				motionConverterWrapper
+					return converter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), motionStart, motionEnd, universe, nodeName, parent, messageContext );
+				}
 			);
 		}
 

--- a/include/IECoreArnold/NodeAlgo.h
+++ b/include/IECoreArnold/NodeAlgo.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
 #include "IECoreArnold/Export.h"
 
 #include "IECore/Object.h"
@@ -54,14 +56,14 @@ IECOREARNOLD_API AtNode *convert( const IECore::Object *object, AtUniverse *univ
 /// equivalent moving Arnold object. If no motion converter
 /// is available, then returns a standard conversion of the
 /// first sample.
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "NodeAlgo::convert" );
+IECOREARNOLD_API AtNode *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "NodeAlgo::convert" );
 
 /// Signature of a function which can convert an IECore::Object
 /// into an Arnold object.
 using Converter = AtNode *(*)( const IECore::Object *sample, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext );
 /// Signature of a function which can convert a series of IECore::Object
 /// samples into a moving Arnold object.
-using MotionConverter = AtNode *(*)( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext );
+using MotionConverter = AtNode *(*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to

--- a/include/IECoreArnold/NodeAlgo.h
+++ b/include/IECoreArnold/NodeAlgo.h
@@ -60,10 +60,10 @@ IECOREARNOLD_API AtNode *convert( const IECoreScenePreview::Renderer::ObjectSamp
 
 /// Signature of a function which can convert an IECore::Object
 /// into an Arnold object.
-using Converter = AtNode *(*)( const IECore::Object *sample, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext );
+using Converter = std::function<AtNode *( const IECore::Object *sample, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )>;
 /// Signature of a function which can convert a series of IECore::Object
 /// samples into a moving Arnold object.
-using MotionConverter = AtNode *(*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext );
+using MotionConverter = std::function<AtNode *( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )>;
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -79,15 +79,28 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using Converter = AtNode *(*)( const T *, AtUniverse *, const std::string &, const AtNode *, const std::string & );
-		using MotionConverter = AtNode *(*)( const std::vector<const T *> &, float, float, AtUniverse *, const std::string &, const AtNode *, const std::string & );
+		using TypedConverter = AtNode *(*)( const T *, AtUniverse *, const std::string &, const AtNode *, const std::string & );
+		using TypedObjectSamples = IECoreScenePreview::Renderer::Samples<const T *>;
+		using TypedMotionConverter = AtNode *(*)( const TypedObjectSamples &, float, float, AtUniverse *, const std::string &, const AtNode *, const std::string & );
 
-		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
 		{
+			MotionConverter motionConverterWrapper;
+			if( motionConverter )
+			{
+				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )
+				{
+					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), motionStart, motionEnd, universe, nodeName, parent, messageContext );
+				};
+			}
+
 			registerConverter(
 				T::staticTypeId(),
-				reinterpret_cast<NodeAlgo::Converter>( converter ),
-				reinterpret_cast<NodeAlgo::MotionConverter>( motionConverter )
+				[converter] ( const IECore::Object *sample, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext )
+				{
+					return converter( static_cast<const T *>( sample ), universe, nodeName, parent, messageContext );
+				},
+				motionConverterWrapper
 			);
 		}
 

--- a/include/IECoreArnold/ParameterAlgo.h
+++ b/include/IECoreArnold/ParameterAlgo.h
@@ -36,6 +36,8 @@
 
 #include "IECoreArnold/Export.h"
 
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
 #include "IECore/CompoundData.h"
 
 #include "ai_nodes.h"
@@ -67,7 +69,8 @@ IECOREARNOLD_API int parameterType( const IECore::Data *data, bool &array );
 /// If the equivalent Arnold type for the data is already known, then it may be passed directly.
 /// If not it will be inferred using parameterType().
 IECOREARNOLD_API AtArray *dataToArray( const IECore::Data *data, int aiType = AI_TYPE_NONE );
-IECOREARNOLD_API AtArray *dataToArray( const std::vector<const IECore::Data *> &samples, int aiType = AI_TYPE_NONE );
+using DataSamples = IECoreScenePreview::Renderer::Samples<const IECore::Data *>;
+IECOREARNOLD_API AtArray *dataToArray( const DataSamples &samples, int aiType = AI_TYPE_NONE );
 
 } // namespace ParameterAlgo
 

--- a/include/IECoreArnold/ProceduralAlgo.h
+++ b/include/IECoreArnold/ProceduralAlgo.h
@@ -34,9 +34,11 @@
 
 #pragma once
 
-#include "IECoreArnold/Export.h"
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 
 #include "IECoreScene/ExternalProcedural.h"
+
+#include "IECoreArnold/Export.h"
 
 #include "ai_nodes.h"
 
@@ -46,7 +48,8 @@ namespace IECoreArnold
 namespace ProceduralAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::ExternalProcedural *procedural, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext = "ProceduralAlgo::convert" );
+using ProceduralSamples = IECoreScenePreview::Renderer::Samples<const IECoreScene::ExternalProcedural *>;
+IECOREARNOLD_API AtNode *convert( const ProceduralSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext = "ProceduralAlgo::convert" );
 
 } // namespace ProceduralAlgo
 

--- a/include/IECoreArnold/ShapeAlgo.h
+++ b/include/IECoreArnold/ShapeAlgo.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
 #include "IECoreArnold/Export.h"
 
 #include "IECoreScene/Primitive.h"
@@ -46,11 +48,13 @@ namespace IECoreArnold
 namespace ShapeAlgo
 {
 
+using PrimitiveSamples = IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *>;
+
 IECOREARNOLD_API bool convertP( const IECoreScene::Primitive *primitive, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
-IECOREARNOLD_API bool convertP( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
+IECOREARNOLD_API bool convertP( const PrimitiveSamples &samples, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
 
 IECOREARNOLD_API void convertRadius( const IECoreScene::Primitive *primitive, AtNode *shape, const std::string &messageContext = "ShapeAlgo::convertRadius" );
-IECOREARNOLD_API void convertRadius( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const std::string &messageContext = "ShapeAlgo::convertRadius" );
+IECOREARNOLD_API void convertRadius( const PrimitiveSamples &samples, AtNode *shape, const std::string &messageContext = "ShapeAlgo::convertRadius" );
 
 IECOREARNOLD_API void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const IECoreScene::PrimitiveVariable &primitiveVariable, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertPrimitiveVariable" );
 /// Converts primitive variables from primitive into user parameters on shape, ignoring any variables

--- a/include/IECoreDelight/NodeAlgo.h
+++ b/include/IECoreDelight/NodeAlgo.h
@@ -55,23 +55,19 @@ class ParameterList;
 namespace NodeAlgo
 {
 
-/// Converts the specified IECore::Object into an equivalent
+/// Converts the specified `IECore::Object` samples into an equivalent
 /// NSI node with the specified handle, returning true on
 /// success and false on failure.
-IECOREDELIGHT_API bool convert( const IECore::Object *object, NSIContext_t context, const char *handle );
-/// As above, but converting a moving object. If no motion converter
-/// is available, the first sample is converted instead.
 IECOREDELIGHT_API bool convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle );
 
-/// Signature of a function which can convert an IECore::Object
-/// into an NSI node.
-using Converter = std::function<bool ( const IECore::Object *, NSIContext_t, const char * )>;
-using MotionConverter = std::function<bool ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )>;
+/// Signature of a function which can convert `IECore::Object` samples into an
+/// NSI node.
+using Converter = std::function<bool ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )>;
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
 /// this, since it provides additional type safety.
-IECOREDELIGHT_API void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter = nullptr );
+IECOREDELIGHT_API void registerConverter( IECore::TypeId fromType, Converter converter );
 
 /// Class which registers a converter for type T automatically
 /// when instantiated.
@@ -82,37 +78,25 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using TypedConverter = bool (*)( const T *, NSIContext_t, const char * );
 		using TypedSamples = IECoreScenePreview::Renderer::Samples<const T *>;
-		using TypedMotionConverter = bool (*)( const TypedSamples &, const IECoreScenePreview::Renderer::SampleTimes &, NSIContext_t, const char * );
+		using TypedConverter = bool (*)( const TypedSamples &, const IECoreScenePreview::Renderer::SampleTimes &, NSIContext_t, const char * );
 
-		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter )
 		{
-			MotionConverter motionConverterWrapper;
-			if( motionConverter )
-			{
-				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
-				{
-					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), times, context, handle );
-				};
-			}
-
 			registerConverter(
 				T::staticTypeId(),
-				[converter] ( const IECore::Object *object, NSIContext_t context, const char *handle )
+				[converter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
 				{
-					return converter( static_cast<const T *>( object ), context, handle );
-				},
-				motionConverterWrapper
+					return converter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), times, context, handle );
+				}
 			);
 		}
 
 };
 
-/// Adds all PrimitiveVariables into a ParameterList for use with NSISetAttribute.
-IECOREDELIGHT_API void primitiveVariableParameterList( const IECoreScene::Primitive *primitive, ParameterList &parameters, const IECore::IntVectorData *vertexIndices = nullptr );
-/// As above, but splits out animated primitive variables into a separate vector of ParameterLists
-/// for use with NSISetAttributeAtTime.
+/// Adds all static PrimitiveVariables into a ParameterList for use with
+/// `NSISetAttribute()`, and all animated PrimitiveVariables into a separate vector
+/// of ParameterLists for use with `NSISetAttributeAtTime()`.
 IECOREDELIGHT_API void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices = nullptr );
 
 } // namespace NodeAlgo

--- a/include/IECoreDelight/NodeAlgo.h
+++ b/include/IECoreDelight/NodeAlgo.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
 #include "IECoreDelight/Export.h"
 
 #include "IECoreScene/Primitive.h"
@@ -59,12 +61,12 @@ namespace NodeAlgo
 IECOREDELIGHT_API bool convert( const IECore::Object *object, NSIContext_t context, const char *handle );
 /// As above, but converting a moving object. If no motion converter
 /// is available, the first sample is converted instead.
-IECOREDELIGHT_API bool convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, NSIContext_t context, const char *handle );
+IECOREDELIGHT_API bool convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle );
 
 /// Signature of a function which can convert an IECore::Object
 /// into an NSI node.
 using Converter = bool (*)( const IECore::Object *, NSIContext_t, const char * );
-using MotionConverter = bool (*)( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, NSIContext_t constant, const char * );
+using MotionConverter = bool (*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t constant, const char * );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to

--- a/include/IECoreDelight/NodeAlgo.h
+++ b/include/IECoreDelight/NodeAlgo.h
@@ -97,7 +97,7 @@ class ConverterDescription
 /// Adds all static PrimitiveVariables into a ParameterList for use with
 /// `NSISetAttribute()`, and all animated PrimitiveVariables into a separate vector
 /// of ParameterLists for use with `NSISetAttributeAtTime()`.
-IECOREDELIGHT_API void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices = nullptr );
+IECOREDELIGHT_API void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, IECoreScenePreview::Renderer::Samples<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices = nullptr );
 
 } // namespace NodeAlgo
 

--- a/include/IECoreDelight/NodeAlgo.h
+++ b/include/IECoreDelight/NodeAlgo.h
@@ -65,8 +65,8 @@ IECOREDELIGHT_API bool convert( const IECoreScenePreview::Renderer::ObjectSample
 
 /// Signature of a function which can convert an IECore::Object
 /// into an NSI node.
-using Converter = bool (*)( const IECore::Object *, NSIContext_t, const char * );
-using MotionConverter = bool (*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t constant, const char * );
+using Converter = std::function<bool ( const IECore::Object *, NSIContext_t, const char * )>;
+using MotionConverter = std::function<bool ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )>;
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -82,15 +82,28 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using Converter = bool (*)( const T *, NSIContext_t, const char * );
-		using MotionConverter = bool (*)( const std::vector<const T *> &, const std::vector<float> &, NSIContext_t, const char * );
+		using TypedConverter = bool (*)( const T *, NSIContext_t, const char * );
+		using TypedSamples = IECoreScenePreview::Renderer::Samples<const T *>;
+		using TypedMotionConverter = bool (*)( const TypedSamples &, const IECoreScenePreview::Renderer::SampleTimes &, NSIContext_t, const char * );
 
-		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
 		{
+			MotionConverter motionConverterWrapper;
+			if( motionConverter )
+			{
+				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
+				{
+					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), times, context, handle );
+				};
+			}
+
 			registerConverter(
 				T::staticTypeId(),
-				reinterpret_cast<NodeAlgo::Converter>( converter ),
-				reinterpret_cast<NodeAlgo::MotionConverter>( motionConverter )
+				[converter] ( const IECore::Object *object, NSIContext_t context, const char *handle )
+				{
+					return converter( static_cast<const T *>( object ), context, handle );
+				},
+				motionConverterWrapper
 			);
 		}
 
@@ -100,7 +113,7 @@ class ConverterDescription
 IECOREDELIGHT_API void primitiveVariableParameterList( const IECoreScene::Primitive *primitive, ParameterList &parameters, const IECore::IntVectorData *vertexIndices = nullptr );
 /// As above, but splits out animated primitive variables into a separate vector of ParameterLists
 /// for use with NSISetAttributeAtTime.
-IECOREDELIGHT_API void primitiveVariableParameterLists( const std::vector<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices = nullptr );
+IECOREDELIGHT_API void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices = nullptr );
 
 } // namespace NodeAlgo
 

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -77,7 +77,7 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		self.assertIsInstance( o, renderer.CapturedObject )
 		self.assertTrue( o.isSame( renderer.capturedObject( "o" ) ) )
 		self.assertEqual( o.capturedSamples(), [ IECoreScene.SpherePrimitive() ] )
-		self.assertEqual( o.capturedSampleTimes(), [] )
+		self.assertEqual( o.capturedSampleTimes(), [ 0.0 ] )
 		self.assertEqual( o.capturedAttributes(), attributes1 )
 		self.assertEqual( o.capturedLinks( "lights" ), None )
 		self.assertEqual( o.numAttributeEdits(), 1 )
@@ -396,7 +396,7 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		del oA
 		oA = rendererA.object( "/o", [ sphere1, sphere1 ], [ 0, 1 ], rendererA.attributes( attrs ) )
 
-		with self.assertRaisesRegex( AssertionError, r"Mismatched samples times at path '/o' : \[0.0, 1.0\] != \[\]" ):
+		with self.assertRaisesRegex( AssertionError, r"Mismatched samples times at path '/o' : \[0.0, 1.0\] != \[0.0\]" ):
 			CapturingRendererTest.assertRendersMatch( rendererA, rendererB )
 
 		del oB

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -245,37 +245,17 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 				for a, val in subObject.capturedAttributes.items():
 					newAttrs[a] = val
 
-				parentTransformSampleTimes = capturedObject.capturedTransformSampleTimes
-				newTransformTimes = subObject.capturedTransformSampleTimes
-				if newTransformTimes != parentTransformSampleTimes:
-					if parentTransformSampleTimes == []:
-						# Combining a static transform with an animated transform results in an animated transform
-						pass
-					elif newTransformTimes == []:
-						newTransformTimes = parentTransformSampleTimes
-					else:
-						raise IECore.Exception( "Incompatible transform sample times when expanding procedural at location '%s' : %s != %s" % ( newName, parentTransformSampleTimes, newTransformTimes ) )
+				newSampledTransform = GafferScene.Private.RendererAlgo.SampledTransform(
+					capturedObject.capturedTransforms,
+					capturedObject.capturedTransformSampleTimes
+				)
 
-				parentTransforms = capturedObject.capturedTransforms
-				newTransforms = subObject.capturedTransforms
-				if parentTransforms == []:
-					pass
-				elif newTransforms == []:
-					newTransforms = parentTransforms
-				else:
-					effectiveParentTransforms = parentTransforms
-					if len( effectiveParentTransforms ) != len( newTransforms ):
-						if len( effectiveParentTransforms ) == 1:
-							effectiveParentTransforms = [ parentTransforms[0] ] * len( newTransforms )
-						elif len( newTransforms ) == 1:
-							newTransforms = [ newTransforms[0] ] * len( effectiveParentTransforms )
-						else:
-							raise IECore.Exception( "Incompatible transform sample lengths when expanding procedural at location '%s' : %s != %s" % ( newName, len( parentTransforms ), len( newTransforms ) ) )
-
-					newTransforms = [
-						newTransforms[i] * effectiveParentTransforms[i]
-						for i in range( len( newTransforms ) )
-					]
+				newSampledTransform.concatenate(
+					GafferScene.Private.RendererAlgo.SampledTransform(
+						subObject.capturedTransforms,
+						subObject.capturedTransformSampleTimes
+					)
+				)
 
 				# \todo - If we want to test links properly, that would need better support ... passing
 				# object references from `procRenderer` doesn't feel reliable ... it's probably reasonable
@@ -283,9 +263,8 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 				# the names in the list, the same way we do the new object name?
 				# I don't think we currently really support light linking inside procedurals much, so I haven't
 				# worried about it yet.
-
 				result[ newName ] = CapturingRendererTest.__ExpandedCapture(
-					subObject.capturedSamples, subObject.capturedSampleTimes, newTransforms, newTransformTimes,
+					subObject.capturedSamples, subObject.capturedSampleTimes, newSampledTransform.samples, newSampledTransform.sampleTimes,
 					newAttrs, subObject.capturedLinks
 				)
 
@@ -400,7 +379,10 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 			CapturingRendererTest.assertRendersMatch( rendererA, rendererB )
 
 		del oB
-		oB = rendererB.object( "/o", [ sphere1 ], [ 0, 1 ], rendererB.attributes( attrs ) )
+		with IECore.CapturingMessageHandler() as mh :
+			oB = rendererB.object( "/o", [ sphere1 ], [ 0, 1 ], rendererB.attributes( attrs ) )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].message, '''Number of object samples (1) doesn't match number of time samples (2) for object "/o"''' )
 
 		with self.assertRaisesRegex( AssertionError, r"Mismatched samples counts at path '/o' : 2 != 1" ):
 			CapturingRendererTest.assertRendersMatch( rendererA, rendererB )
@@ -441,7 +423,7 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 
 		oA.transform( imath.M44f( 1 ) )
 
-		with self.assertRaisesRegex( AssertionError, re.escape( r"Mismatched transforms at path '/o' : [M44f((1, 1, 1, 1), (1, 1, 1, 1), (1, 1, 1, 1), (1, 1, 1, 1))] != []" ) ):
+		with self.assertRaisesRegex( AssertionError, r"Mismatched transform times at path '/o' : \[0.0\] != \[\]" ):
 			CapturingRendererTest.assertRendersMatch( rendererA, rendererB )
 
 		oB.transform( imath.M44f( 1 ) )
@@ -449,7 +431,7 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 
 		oA.transform( [ imath.M44f( 1 ), imath.M44f( 2 ) ], [ 0, 1 ] )
 
-		with self.assertRaisesRegex( AssertionError, r"Mismatched transform times at path '/o' : \[0.0, 1.0\] != \[\]" ):
+		with self.assertRaisesRegex( AssertionError, r"Mismatched transform times at path '/o' : \[0.0, 1.0\] != \[0.0\]" ):
 			CapturingRendererTest.assertRendersMatch( rendererA, rendererB )
 
 		oB.transform( [ imath.M44f( 1 ), imath.M44f( 2 ) ], [ 0, 1 ] )
@@ -549,17 +531,6 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		)
 
 		CapturingRendererTest.assertRendersMatch( rendererA, rendererB, expandProcedurals = True )
-
-		# Test transform mismatch errors
-		oA.transform( [ imath.M44f(), imath.M44f(), imath.M44f() ], [] )
-
-		with self.assertRaisesRegex( RuntimeError, r"Incompatible transform sample lengths when expanding procedural at location '/c/b/a' : 3 != 2" ):
-			CapturingRendererTest.assertRendersMatch( rendererA, rendererB, expandProcedurals = True )
-
-		oA.transform( [ imath.M44f() ], [1,2,3] )
-
-		with self.assertRaisesRegex( RuntimeError, r"Incompatible transform sample times when expanding procedural at location '/c/b/a' : \[1.0, 2.0, 3.0\] != \[0.0, 1.0\]" ):
-			CapturingRendererTest.assertRendersMatch( rendererA, rendererB, expandProcedurals = True )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
@@ -68,7 +68,7 @@ class CompoundRendererTest( GafferTest.TestCase ) :
 			o = r.capturedObject( "o" )
 			self.assertIsNotNone( o )
 			self.assertEqual( o.capturedSamples(), [ IECoreScene.SpherePrimitive() ] )
-			self.assertEqual( o.capturedSampleTimes(), [] )
+			self.assertEqual( o.capturedSampleTimes(), [ 0.0 ] )
 			self.assertEqual( o.capturedAttributes().attributes(), coreAttributes1 )
 			self.assertEqual( o.id(), 0 )
 			self.assertEqual( o.instanceID(), 0 )

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
@@ -98,7 +98,7 @@ class CompoundRendererTest( GafferTest.TestCase ) :
 		for r in renderers :
 			o = r.capturedObject( "o" )
 			self.assertEqual( o.capturedTransforms(), [ transform ] )
-			self.assertEqual( o.capturedTransformTimes(), [] )
+			self.assertEqual( o.capturedTransformTimes(), [ 0.0 ] )
 
 		# Light linking
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -2571,7 +2571,6 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 
 		instancer["id"].setToDefault()
 
-
 		# Now turn on time offset as well and play with everything together
 		instancer["seeds"].setValue( 10 )
 		instancer["timeOffset"]["enabled"].setValue( True )

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -2579,8 +2579,6 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		testAttributes( frameAttr = [ 1 + 2 * math.sin( i ) for i in range(0, 100) ], floatAttr = floatExpected, color4fAttr = color4fExpected, seedAttr_seedCount = 10 )
 		self.assertEqual( uniqueCounts(), { "floatVar" : 5, "color4fVar" : 4, "seed" : 10, "frame" : 100, "" : 100 } )
 
-		self.assertEncapsulatedRendersSame( instancer )
-
 		instancer["timeOffset"]["quantize"].setValue( 0.5 )
 		self.assertEqual( uniqueCounts(), { "floatVar" : 5, "color4fVar" : 4, "seed" : 10, "frame" : 9, "" : 82 } )
 
@@ -2592,15 +2590,11 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		with c:
 			testAttributes( frameAttr = [ i + 42 for i in floatExpected ], floatAttr = floatExpected, color4fAttr = color4fExpected, seedAttr_seedCount = 10 )
 			self.assertEqual( uniqueCounts(), { "floatVar" : 5, "color4fVar" : 4, "seed" : 10, "frame" : 5, "" : 69 } )
-			self.assertEncapsulatedRendersSame( instancer )
-
 
 		# Now reduce back down the variations to test different cumulative combinations
 		instancer["seedEnabled"].setValue( False )
 		testAttributes( frameAttr = [ i + 1 for i in floatExpected ], floatAttr = floatExpected, color4fAttr = color4fExpected )
 		self.assertEqual( uniqueCounts(), { "floatVar" : 5, "color4fVar" : 4, "frame" : 5, "" : 20 } )
-
-		self.assertEncapsulatedRendersSame( instancer )
 
 		# With just one context var, driven by the same prim var as frame, with the same quantization,
 		# the variations don't multiply
@@ -2608,22 +2602,15 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		testAttributes( frameAttr = [ i + 1 for i in floatExpected ], floatAttr = floatExpected )
 		self.assertEqual( uniqueCounts(), { "floatVar" : 5, "frame" : 5, "" : 5 } )
 
-		self.assertEncapsulatedRendersSame( instancer )
-
 		# Using a different source primVar means the variations will multiply
 		instancer["timeOffset"]["name"].setValue( 'intVar' )
 		instancer["timeOffset"]["quantize"].setValue( 0 )
 		testAttributes( frameAttr = [ i + 1 for i in range(100) ], floatAttr = floatExpected )
 		self.assertEqual( uniqueCounts(), { "floatVar" : 5, "frame" : 100, "" : 100 } )
 
-		self.assertEncapsulatedRendersSame( instancer )
-
 		instancer["timeOffset"]["quantize"].setValue( 20 )
 		testAttributes( frameAttr = [ ((i+10)//20)*20 + 1 for i in range(100) ], floatAttr = floatExpected )
 		self.assertEqual( uniqueCounts(), { "floatVar" : 5, "frame" : 6, "" : 30 } )
-
-		self.assertEncapsulatedRendersSame( instancer )
-
 
 		# Test with multiple point sources
 		pointSources = []
@@ -2677,6 +2664,32 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		# Test passthrough when disabled
 		instancer["enabled"].setValue( False )
 		self.assertScenesEqual( instancer["in"], instancer["out"] )
+
+	# Fails because we pass the offset times as `sampleTimes` to the renderer,
+	# when sample times should always match the shutter.
+	@unittest.expectedFailure
+	def testEncapsulateTimeOffsets( self ) :
+
+		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 0, 4 ) ] ) )
+		points["timeOffset"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( range( 0, 4 ) ) )
+
+		objectSource = GafferScene.ObjectToScene()
+		objectSource["object"].setValue( points )
+		objectSource["name"].setValue( "points" )
+
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths"].setValue( IECore.StringVectorData( [ "/points" ] ) )
+
+		sphere = GafferScene.Sphere()
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( objectSource["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
+		instancer["filter"].setInput( pointsFilter["out"] )
+		instancer["timeOffset"]["name"].setValue( "timeOffset" )
+		instancer["timeOffset"]["enabled"].setValue( True )
+
+		self.assertEncapsulatedRendersSame( instancer )
 
 	def testContextSet( self ):
 

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -733,7 +733,7 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 				for (i,j) in zip( times, expectedSamples ):
 					self.assertAlmostEqual( i, j, places = 6 )
 			else :
-				self.assertEqual( times, [] )
+				self.assertEqual( times, [ 0.0 ] if deform else [] )
 
 		# INITIAL TRANSFORM TESTS
 

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -712,7 +712,7 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		controller.setMinimumExpansionDepth( 2 )
 		controller.update()
 
-		def assertMotionSamples( expectedSamples, deform ) :
+		def assertMotionSamples( expectedSamples, expectedSampleTimes, deform) :
 
 			capturedSphere = renderer.capturedObject( "/group/sphere" )
 			self.assertIsNotNone( capturedSphere )
@@ -728,64 +728,61 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 			for (i,j) in zip( samples, expectedSamples ):
 				self.assertAlmostEqual( i, j, places = 6 )
 
-			if len( expectedSamples ) > 1 :
-				self.assertEqual( len( times ), len( expectedSamples ) )
-				for (i,j) in zip( times, expectedSamples ):
-					self.assertAlmostEqual( i, j, places = 6 )
-			else :
-				self.assertEqual( times, [ 0.0 ] if deform else [] )
+			self.assertEqual( len( times ), len( expectedSampleTimes ) )
+			for (i,j) in zip( times, expectedSampleTimes ):
+				self.assertAlmostEqual( i, j, places = 6 )
 
 		# INITIAL TRANSFORM TESTS
 
-		assertMotionSamples( [ 0 ], False )
+		assertMotionSamples( [ 0 ], [ 1 ], False )
 		sphere["transform"]["translate"]["x"].setValue( 2 )
 		controller.update()
-		assertMotionSamples( [ 2 ], False )
+		assertMotionSamples( [ 2 ], [ 1 ], False )
 
 		# Hook up animated value, but blur not turned on yet
 		sphere["transform"]["translate"]["x"].setInput( frame["output"] )
 		controller.update()
-		assertMotionSamples( [ 1 ], False )
+		assertMotionSamples( [ 1 ], [ 1 ], False )
 
 		# Test blur.
 		options["options"]["render:transformBlur"]["enabled"].setValue( True )
 		options["options"]["render:transformBlur"]["value"].setValue( True )
 		controller.update()
-		assertMotionSamples( [ 0.75, 1.25 ], False )
+		assertMotionSamples( [ 0.75, 1.25 ], [ 0.75, 1.25 ], False )
 
 		# Test blur on but no movement
 		sphere["transform"]["translate"]["x"].setInput( None )
 		controller.update()
-		assertMotionSamples( [ 2 ], False )
+		assertMotionSamples( [ 2 ], [ 1 ], False )
 
 		# We get a single sample out even if the transform hash is changing but the transform isn't
 		sphere["transform"]["translate"]["x"].setInput( dummyFrame["output"] )
 		controller.update()
-		assertMotionSamples( [ 3 ], False )
+		assertMotionSamples( [ 3 ], [ 1 ], False )
 
 		# INITIAL DEFORMATION TESTS
 		# Test non-blurred updates.
 
-		assertMotionSamples( [ 1 ], True )
+		assertMotionSamples( [ 1 ], [ 1 ], True )
 		sphere["radius"].setValue( 2 )
 		controller.update()
-		assertMotionSamples( [ 2 ], True )
+		assertMotionSamples( [ 2 ], [ 1 ], True )
 
 		# Hook up animated value, but blur not turned on yet
 		sphere["radius"].setInput( frame["output"] )
 		controller.update()
-		assertMotionSamples( [ 1 ], True )
+		assertMotionSamples( [ 1 ], [ 1 ], True )
 
 		# Test deformation blur.
 		options["options"]["render:deformationBlur"]["enabled"].setValue( True )
 		options["options"]["render:deformationBlur"]["value"].setValue( True )
 		controller.update()
-		assertMotionSamples( [ 0.75, 1.25 ], True )
+		assertMotionSamples( [ 0.75, 1.25 ], [ 0.75, 1.25 ], True )
 
 		# Test deformation blur on but no deformation
 		sphere["radius"].setInput( None )
 		controller.update()
-		assertMotionSamples( [ 2 ], True )
+		assertMotionSamples( [ 2 ], [ 0.75 ], True )
 
 
 		# Test shutter
@@ -794,8 +791,8 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		options["options"]["render:shutter"]["enabled"].setValue( True )
 		options["options"]["render:shutter"]["value"].setValue( imath.V2f( -0.7, 0.4 ) )
 		controller.update()
-		assertMotionSamples( [ 0.3, 1.4 ], False )
-		assertMotionSamples( [ 0.3, 1.4 ], True )
+		assertMotionSamples( [ 0.3, 1.4 ], [ 0.3, 1.4 ], False )
+		assertMotionSamples( [ 0.3, 1.4 ], [ 0.3, 1.4 ], True )
 
 		# Test with camera shutter
 		camera = GafferScene.Camera()
@@ -806,61 +803,61 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		options["options"]["render:camera"]["enabled"].setValue( True )
 		options["options"]["render:camera"]["value"].setValue( "/group/camera" )
 		controller.update()
-		assertMotionSamples( [ 0.3, 1.4 ], False )
-		assertMotionSamples( [ 0.3, 1.4 ], True )
+		assertMotionSamples( [ 0.3, 1.4 ], [ 0.3, 1.4 ], False )
+		assertMotionSamples( [ 0.3, 1.4 ], [ 0.3, 1.4 ], True )
 		camera['renderSettingOverrides']['shutter']["enabled"].setValue( True )
 		camera['renderSettingOverrides']['shutter']["value"].setValue( imath.V2f( -0.5, 0.5 ) )
 		controller.update()
-		assertMotionSamples( [ 0.5, 1.5 ], False )
-		assertMotionSamples( [ 0.5, 1.5 ], True )
+		assertMotionSamples( [ 0.5, 1.5 ], [ 0.5, 1.5 ], False )
+		assertMotionSamples( [ 0.5, 1.5 ], [ 0.5, 1.5 ], True )
 		self.assertEqual( renderer.capturedObject( "/group/camera" ).capturedSamples()[0].getShutter(), imath.V2f( 0.5, 1.5 ) )
 
 		# Test attribute controls
 		camera['renderSettingOverrides']['shutter']["enabled"].setValue( False )
 		options["options"]["render:shutter"]["value"].setValue( imath.V2f( -0.4, 0.4 ) )
 		controller.update()
-		assertMotionSamples( [ 0.6, 1.4 ], False )
-		assertMotionSamples( [ 0.6, 1.4 ], True )
+		assertMotionSamples( [ 0.6, 1.4 ], [ 0.6, 1.4 ], False )
+		assertMotionSamples( [ 0.6, 1.4 ], [ 0.6, 1.4 ], True )
 
 		groupAttributes["attributes"]["gaffer:transformBlur"]["enabled"].setValue( True )
 		groupAttributes["attributes"]["gaffer:transformBlur"]["value"].setValue( False )
 		controller.update()
-		assertMotionSamples( [ 1 ], False )
+		assertMotionSamples( [ 1 ], [ 1 ], False )
 		sphereAttributes["attributes"]["gaffer:transformBlur"]["enabled"].setValue( True )
 		controller.update()
-		assertMotionSamples( [ 0.6, 1.4 ], False )
+		assertMotionSamples( [ 0.6, 1.4 ], [ 0.6, 1.4 ], False )
 
 		groupAttributes["attributes"]["gaffer:deformationBlur"]["enabled"].setValue( True )
 		groupAttributes["attributes"]["gaffer:deformationBlur"]["value"].setValue( False )
 		controller.update()
-		assertMotionSamples( [ 1 ], True )
+		assertMotionSamples( [ 1 ], [ 1 ], True )
 		sphereAttributes["attributes"]["gaffer:deformationBlur"]["enabled"].setValue( True )
 		controller.update()
-		assertMotionSamples( [ 0.6, 1.4 ], True )
+		assertMotionSamples( [ 0.6, 1.4 ], [ 0.6, 1.4 ], True )
 
 		groupAttributes["attributes"]["gaffer:transformBlurSegments"]["enabled"].setValue( True )
 		groupAttributes["attributes"]["gaffer:transformBlurSegments"]["value"].setValue( 4 )
 		groupAttributes["attributes"]["gaffer:deformationBlurSegments"]["enabled"].setValue( True )
 		groupAttributes["attributes"]["gaffer:deformationBlurSegments"]["value"].setValue( 2 )
 		controller.update()
-		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], False )
-		assertMotionSamples( [ 0.6, 1.0, 1.4 ], True )
+		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], [ 0.6, 0.8, 1.0, 1.2, 1.4 ], False )
+		assertMotionSamples( [ 0.6, 1.0, 1.4 ], [ 0.6, 1.0, 1.4 ], True )
 
 		sphereAttributes["attributes"]["gaffer:transformBlurSegments"]["enabled"].setValue( True )
 		sphereAttributes["attributes"]["gaffer:transformBlurSegments"]["value"].setValue( 2 )
 		sphereAttributes["attributes"]["gaffer:deformationBlurSegments"]["enabled"].setValue( True )
 		sphereAttributes["attributes"]["gaffer:deformationBlurSegments"]["value"].setValue( 4 )
 		controller.update()
-		assertMotionSamples( [ 0.6, 1.0, 1.4 ], False )
-		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], True )
+		assertMotionSamples( [ 0.6, 1.0, 1.4 ], [ 0.6, 1.0, 1.4 ], False )
+		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], [ 0.6, 0.8, 1.0, 1.2, 1.4 ], True )
 
 		groupAttributes["attributes"]["gaffer:transformBlur"]["value"].setValue( True )
 		groupAttributes["attributes"]["gaffer:deformationBlur"]["value"].setValue( True )
 		sphereAttributes["attributes"]["gaffer:transformBlur"]["value"].setValue( False )
 		sphereAttributes["attributes"]["gaffer:deformationBlur"]["value"].setValue( False )
 		controller.update()
-		assertMotionSamples( [ 1.0 ], False )
-		assertMotionSamples( [ 1.0 ], True )
+		assertMotionSamples( [ 1.0 ], [ 1.0 ], False )
+		assertMotionSamples( [ 1.0 ], [ 1.0 ], True )
 
 		# Apply transformation to group instead of sphere, giving the same results
 		sphere["transform"]["translate"]["x"].setInput( None )
@@ -871,7 +868,7 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		sphereAttributes["attributes"]["gaffer:transformBlur"]["value"].setValue( False )
 		sphereAttributes["attributes"]["gaffer:transformBlurSegments"]["enabled"].setValue( False )
 		controller.update()
-		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], False )
+		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], [ 0.6, 0.8, 1.0, 1.2, 1.4 ], False )
 
 		# Override transform segments on sphere
 		sphereAttributes["attributes"]["gaffer:transformBlur"]["value"].setValue( True )
@@ -879,12 +876,12 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		sphereAttributes["attributes"]["gaffer:transformBlurSegments"]["value"].setValue( 1 )
 		controller.update()
 		# Very counter-intuitively, this does nothing, because the sphere is not moving
-		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], False )
+		assertMotionSamples( [ 0.6, 0.8, 1.0, 1.2, 1.4 ], [ 0.6, 0.8, 1.0, 1.2, 1.4 ], False )
 
 		# But then if the sphere moves, the sample count does take affect
 		sphere["transform"]["translate"]["y"].setInput( frame["output"] )
 		controller.update()
-		assertMotionSamples( [ 0.6, 1.4 ], False )
+		assertMotionSamples( [ 0.6, 1.4 ], [ 0.6, 1.4 ], False )
 
 	def testCoordinateSystem( self ) :
 

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -861,7 +861,7 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 				objectTimes = [ Gaffer.Context.current().getFrame() ]
 
 			self.assertEqual( len( sphere.capturedSamples() ), len( objectTimes ) )
-			self.assertEqual( sphere.capturedSampleTimes(), objectTimes if len( objectTimes ) > 1 else [] )
+			self.assertEqual( sphere.capturedSampleTimes(), objectTimes if len( objectTimes ) > 1 else [ 0.0 ] )
 			for index, time in enumerate( objectTimes ) :
 				with Gaffer.Context() as context :
 					context.setFrame( time )

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -57,9 +57,9 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		with Gaffer.Context() as c :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "sphere" ] )
-			samples = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 0.75, 1.25 ] )
+			sampledObject = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 0.75, 1.25 ] )
 
-		self.assertEqual( [ s.radius() for s in samples ], [ 0.75, 1.25 ] )
+		self.assertEqual( [ s.radius() for s in sampledObject.samples ], [ 0.75, 1.25 ] )
 
 	def testNonInterpolableObjectSamples( self ) :
 
@@ -71,10 +71,11 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		with Gaffer.Context() as c :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "procedural" ] )
-			samples = GafferScene.Private.RendererAlgo.objectSamples( procedural["out"]["object"], [ 0.75, 1.25 ] )
+			sampledObject = GafferScene.Private.RendererAlgo.objectSamples( procedural["out"]["object"], [ 0.75, 1.25 ] )
 
-		self.assertEqual( len( samples ), 1 )
-		self.assertEqual( samples[0].parameters()["frame"].value, 1.0 )
+		self.assertEqual( len( sampledObject.samples ), 1 )
+		self.assertEqual( sampledObject.samples[0].parameters()["frame"].value, 1.0 )
+		self.assertEqual( sampledObject.sampleTimes, [ 1.0 ] )
 
 	def testObjectSamplesForCameras( self ) :
 
@@ -85,9 +86,10 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		with Gaffer.Context() as c :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "camera" ] )
-			samples = GafferScene.Private.RendererAlgo.objectSamples( camera["out"]["object"], [ 0.75, 1.25 ] )
+			sampledObject = GafferScene.Private.RendererAlgo.objectSamples( camera["out"]["object"], [ 0.75, 1.25 ] )
 
-		self.assertEqual( [ s.parameters()["focalLength"].value for s in samples ], [ 0.75, 1.25 ] )
+		self.assertEqual( [ s.parameters()["focalLength"].value for s in sampledObject.samples ], [ 0.75, 1.25 ] )
+		self.assertEqual( sampledObject.sampleTimes, [ 0.75, 1.25 ] )
 
 	def testOutputCameras( self ) :
 
@@ -121,7 +123,7 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 		capturedCamera = renderer.capturedObject( "/camera" )
 
 		self.assertEqual( capturedCamera.capturedSamples(), [ expectedCamera( 1 ) ] )
-		self.assertEqual( capturedCamera.capturedSampleTimes(), [ 0.0 ] )
+		self.assertEqual( capturedCamera.capturedSampleTimes(), [ 1 ] )
 
 		# Animated case
 
@@ -168,9 +170,10 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 		coordinateSystem = GafferScene.CoordinateSystem()
 		with Gaffer.Context() as c :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "coordinateSystem" ] )
-			samples = GafferScene.Private.RendererAlgo.objectSamples( coordinateSystem["out"]["object"], [ 0.75, 1.25 ] )
-			self.assertEqual( len( samples ), 1 )
-			self.assertEqual( samples[0], coordinateSystem["out"].object( "/coordinateSystem" ) )
+			sampledObject = GafferScene.Private.RendererAlgo.objectSamples( coordinateSystem["out"]["object"], [ 0.75, 1.25 ] )
+			self.assertEqual( len( sampledObject.samples ), 1 )
+			self.assertEqual( sampledObject.samples[0], coordinateSystem["out"].object( "/coordinateSystem" ) )
+			self.assertEqual( sampledObject.sampleTimes, [ 0.75 ] )
 
 	def testLightSolo( self ) :
 
@@ -503,20 +506,22 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "sphere" ] )
 
 			h1 = IECore.MurmurHash()
-			samples1 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h1 )
-			self.assertEqual( samples1[0].radius(), 1 )
+			sampledObject1 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h1 )
+			self.assertEqual( sampledObject1.samples[0].radius(), 1 )
+			self.assertEqual( sampledObject1.sampleTimes, [ 1.0 ] )
 			self.assertNotEqual( h1, IECore.MurmurHash() )
 
 			sphere["radius"].setValue( 2 )
 			h2 = IECore.MurmurHash( h1 )
-			samples2 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h2 )
-			self.assertEqual( samples2[0].radius(), 2 )
+			sampledObject2 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h2 )
+			self.assertEqual( sampledObject2.samples[0].radius(), 2 )
+			self.assertEqual( sampledObject2.sampleTimes, [ 1.0 ] )
 			self.assertNotEqual( h2, IECore.MurmurHash() )
 			self.assertNotEqual( h2, h1 )
 
 			h3 = IECore.MurmurHash( h2 )
-			samples3 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h3 )
-			self.assertIsNone( samples3 ) # Hash matched, so no samples generated
+			sampledObject3 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h3 )
+			self.assertIsNone( sampledObject3 ) # Hash matched, so no samples generated
 			self.assertEqual( h3, h2 )
 
 	def testTransformSamplesHash( self ) :
@@ -528,20 +533,20 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "sphere" ] )
 
 			h1 = IECore.MurmurHash()
-			samples1 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h1 )
-			self.assertEqual( samples1[0].translation().x, 0 )
+			sampledTransform1 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h1 )
+			self.assertEqual( sampledTransform1.samples[0].translation().x, 0 )
 			self.assertNotEqual( h1, IECore.MurmurHash() )
 
 			sphere["transform"]["translate"]["x"].setValue( 2 )
 			h2 = IECore.MurmurHash( h1 )
-			samples2 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h2 )
-			self.assertEqual( samples2[0].translation().x, 2 )
+			sampledTransform2 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h2 )
+			self.assertEqual( sampledTransform2.samples[0].translation().x, 2 )
 			self.assertNotEqual( h2, IECore.MurmurHash() )
 			self.assertNotEqual( h2, h1 )
 
 			h3 = IECore.MurmurHash( h2 )
-			samples3 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h3 )
-			self.assertIsNone( samples3 ) # Hash matched, so no samples generated
+			sampledTransform3 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h3 )
+			self.assertIsNone( sampledTransform3 ) # Hash matched, so no samples generated
 			self.assertEqual( h3, h2 )
 
 	def testObjectSamplesCancellation( self ) :
@@ -575,8 +580,9 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		with context :
 
-			samples = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h )
-			self.assertEqual( [ s.radius() for s in samples ], [ 1.0 ] )
+			sampledObject = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h )
+			self.assertEqual( [ s.radius() for s in sampledObject.samples ], [ 1.0 ] )
+			self.assertEqual( sampledObject.sampleTimes, [ 1.0 ] )
 			self.assertNotEqual( h, IECore.MurmurHash() )
 
 	def testTransformSamplesCancellation( self ) :
@@ -609,8 +615,8 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		with context :
 
-			samples = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h )
-			self.assertEqual( [ s.translation().x for s in samples ], [ 0.0 ] )
+			sampledTransform = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h )
+			self.assertEqual( [ s.translation().x for s in sampledTransform.samples ], [ 0.0 ] )
 			self.assertNotEqual( h, IECore.MurmurHash() )
 
 	def testPurposes( self ) :
@@ -847,7 +853,7 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 				transformTimes = [ Gaffer.Context.current().getFrame() ]
 
 			self.assertEqual( len( sphere.capturedTransforms() ), len( transformTimes ) )
-			self.assertEqual( sphere.capturedTransformTimes(), transformTimes if len( transformTimes ) > 1 else [] )
+			self.assertEqual( sphere.capturedTransformTimes(), transformTimes )
 			for index, time in enumerate( transformTimes ) :
 				with Gaffer.Context() as context :
 					context.setFrame( time )
@@ -861,7 +867,7 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 				objectTimes = [ Gaffer.Context.current().getFrame() ]
 
 			self.assertEqual( len( sphere.capturedSamples() ), len( objectTimes ) )
-			self.assertEqual( sphere.capturedSampleTimes(), objectTimes if len( objectTimes ) > 1 else [ 0.0 ] )
+			self.assertEqual( sphere.capturedSampleTimes(), objectTimes )
 			for index, time in enumerate( objectTimes ) :
 				with Gaffer.Context() as context :
 					context.setFrame( time )

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -121,7 +121,7 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 		capturedCamera = renderer.capturedObject( "/camera" )
 
 		self.assertEqual( capturedCamera.capturedSamples(), [ expectedCamera( 1 ) ] )
-		self.assertEqual( capturedCamera.capturedSampleTimes(), [] )
+		self.assertEqual( capturedCamera.capturedSampleTimes(), [ 0.0 ] )
 
 		# Animated case
 

--- a/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
@@ -149,7 +149,7 @@ ccl::Geometry *convert( const IECoreScene::CurvesPrimitive *curve, ccl::Scene *s
 	return hair;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves, const std::vector<float> &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	ccl::Hair *result = convertCommon( curves[primarySampleIndex], scene );
 	GeometryAlgo::convertMotion( vector<const IECoreScene::Primitive *>( curves.begin(), curves.end() ), primarySampleIndex, *result );

--- a/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
@@ -57,7 +57,7 @@ using namespace IECoreCycles;
 namespace
 {
 
-ccl::Hair *convertCommon( const IECoreScene::CurvesPrimitive *curve, ccl::Scene *scene )
+ccl::Hair *convertPrimary( const IECoreScene::CurvesPrimitive *curve, ccl::Scene *scene )
 {
 	assert( curve->typeId() == IECoreScene::CurvesPrimitive::staticTypeId() );
 	ccl::Hair *hair = SceneAlgo::createNodeWithLock<ccl::Hair>( scene );
@@ -143,19 +143,13 @@ ccl::Hair *convertCommon( const IECoreScene::CurvesPrimitive *curve, ccl::Scene 
 	return hair;
 }
 
-ccl::Geometry *convert( const IECoreScene::CurvesPrimitive *curve, ccl::Scene *scene )
-{
-	ccl::Hair *hair = convertCommon( curve, scene );
-	return hair;
-}
-
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &curves, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::Hair *result = convertCommon( curves[primarySampleIndex], scene );
+	ccl::Hair *result = convertPrimary( curves[primarySampleIndex], scene );
 	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( curves ), primarySampleIndex, *result );
 	return result;
 }
 
-GeometryAlgo::ConverterDescription<CurvesPrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<CurvesPrimitive> g_description( convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
@@ -149,10 +149,10 @@ ccl::Geometry *convert( const IECoreScene::CurvesPrimitive *curve, ccl::Scene *s
 	return hair;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &curves, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	ccl::Hair *result = convertCommon( curves[primarySampleIndex], scene );
-	GeometryAlgo::convertMotion( vector<const IECoreScene::Primitive *>( curves.begin(), curves.end() ), primarySampleIndex, *result );
+	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( curves ), primarySampleIndex, *result );
 	return result;
 }
 

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -83,15 +83,7 @@ namespace
 
 using namespace IECoreCycles;
 
-struct Converters
-{
-
-	GeometryAlgo::Converter converter;
-	GeometryAlgo::MotionConverter motionConverter;
-
-};
-
-using Registry = std::unordered_map<IECore::TypeId, Converters>;
+using Registry = std::unordered_map<IECore::TypeId, IECoreCycles::GeometryAlgo::Converter>;
 
 Registry &registry()
 {
@@ -219,17 +211,6 @@ namespace IECoreCycles
 namespace GeometryAlgo
 {
 
-ccl::Geometry *convert( const IECore::Object *object, ccl::Scene *scene )
-{
-	const Registry &r = registry();
-	Registry::const_iterator it = r.find( object->typeId() );
-	if( it == r.end() )
-	{
-		return nullptr;
-	}
-	return it->second.converter( object, scene );
-}
-
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Session *session )
 {
 	if( samples.empty() )
@@ -277,22 +258,15 @@ ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &sampl
 	{
 		return nullptr;
 	}
-	if( it->second.motionConverter )
-	{
-		// Cycles expects the middle sample (rounding down for even numbers of
-		// samples) to be specified as the main sample, and the other samples to
-		// be provided via ATTR_STD_MOTION_VERTEX_POSITION.
-		return it->second.motionConverter( samples, times, (samples.size() - 1) / 2, session->scene.get() );
-	}
-	else
-	{
-		return it->second.converter( samples.front().get(), session->scene.get() );
-	}
+	// Cycles expects the middle sample (rounding down for even numbers of
+	// samples) to be specified as the main sample, and the other samples to
+	// be provided via ATTR_STD_MOTION_VERTEX_POSITION.
+	return it->second( samples, times, (samples.size() - 1) / 2, session->scene.get() );
 }
 
-void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter )
+void registerConverter( IECore::TypeId fromType, Converter converter )
 {
-	registry()[fromType] = { converter, motionConverter };
+	registry()[fromType] = converter;
 }
 
 void convertPrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, ccl::AttributeSet &attributes, ccl::AttributeElement attributeElement )

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -230,7 +230,7 @@ ccl::Geometry *convert( const IECore::Object *object, ccl::Scene *scene )
 	return it->second.converter( object, scene );
 }
 
-ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, ccl::Session *session )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, ccl::Session *session )
 {
 	if( samples.empty() )
 	{

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -246,7 +246,7 @@ ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &sampl
 		// in every gap.
 		IECoreScenePreview::Renderer::ObjectSamples processedSamples;
 		processedSamples.reserve( samples.size() * 2 - 1 );
-		vector<float> processedTimes;
+		IECoreScenePreview::Renderer::SampleTimes processedTimes;
 		processedTimes.reserve( samples.size() * 2 - 1 );
 		for( size_t i = 0; i < samples.size(); ++i )
 		{
@@ -418,7 +418,7 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	}
 }
 
-void convertMotion( const std::vector<const IECoreScene::Primitive *> &samples, size_t primarySampleIndex, ccl::Geometry &geometry )
+void convertMotion( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &samples, size_t primarySampleIndex, ccl::Geometry &geometry )
 {
 	if( samples.size() < 2 )
 	{

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -244,31 +244,28 @@ ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &sampl
 		// Make memory-wasting redundant samples to work around this. Samples are
 		// expected to be spaced evenly in time, so we have to insert a redundant sample
 		// in every gap.
-		vector<ConstObjectPtr> interpolatedSamples;
-		interpolatedSamples.reserve( samples.size() - 1 );
-		vector<const IECore::Object *> processedSamples;
+		IECoreScenePreview::Renderer::ObjectSamples processedSamples;
+		processedSamples.reserve( samples.size() * 2 - 1 );
 		vector<float> processedTimes;
-		processedSamples.reserve( samples.size() + interpolatedSamples.size() );
-		processedTimes.reserve( times.size() + interpolatedSamples.size() );
+		processedTimes.reserve( samples.size() * 2 - 1 );
 		for( size_t i = 0; i < samples.size(); ++i )
 		{
 			processedSamples.push_back( samples[i] );
 			processedTimes.push_back( times[i] );
 			if( i + 1 < samples.size() )
 			{
-				interpolatedSamples.push_back( linearObjectInterpolation( samples[i], samples[i+1], 0.5f ) );
-				processedSamples.push_back( interpolatedSamples.back().get() );
+				processedSamples.push_back( linearObjectInterpolation( samples[i].get(), samples[i+1].get(), 0.5f ) );
 				processedTimes.push_back( Imath::lerp( times[i], times[i+1], 0.5f ) );
 			}
 		}
 		return convert( processedSamples, processedTimes, session );
 	}
 
-	const IECore::Object *firstSample = samples.front();
+	const IECore::Object *firstSample = samples.front().get();
 	const IECore::TypeId firstSampleTypeId = firstSample->typeId();
-	for( std::vector<const IECore::Object *>::const_iterator it = samples.begin()+1, eIt = samples.end(); it != eIt; ++it )
+	for( const auto &sample : samples )
 	{
-		if( (*it)->typeId() != firstSampleTypeId )
+		if( sample->typeId() != firstSampleTypeId )
 		{
 			throw IECore::Exception( "Inconsistent object types." );
 		}
@@ -289,7 +286,7 @@ ccl::Geometry *convert( const IECoreScenePreview::Renderer::ObjectSamples &sampl
 	}
 	else
 	{
-		return it->second.converter( samples.front(), session->scene.get() );
+		return it->second.converter( samples.front().get(), session->scene.get() );
 	}
 }
 

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -250,10 +250,10 @@ ccl::Geometry *convert( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *scen
 	return cmesh;
 }
 
-ccl::Geometry *convert( const std::vector<const IECoreScene::MeshPrimitive *> &meshes, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::Mesh *result = convertCommon( meshes[primarySampleIndex], scene );
-	GeometryAlgo::convertMotion( vector<const IECoreScene::Primitive *>( meshes.begin(), meshes.end() ), primarySampleIndex, *result );
+	ccl::Mesh *result = convertCommon( samples[primarySampleIndex], scene );
+	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
 	return result;
 }
 

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -99,7 +99,7 @@ bool hasSmoothNormals( const IECoreScene::MeshPrimitive *mesh )
 	}
 }
 
-ccl::Mesh *convertCommon( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *scene )
+ccl::Mesh *convertPrimary( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *scene )
 {
 	assert( mesh->typeId() == IECoreScene::MeshPrimitive::staticTypeId() );
 
@@ -244,19 +244,13 @@ ccl::Mesh *convertCommon( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *sc
 	return cmesh;
 }
 
-ccl::Geometry *convert( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *scene )
-{
-	ccl::Mesh *cmesh = convertCommon( mesh, scene );
-	return cmesh;
-}
-
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::Mesh *result = convertCommon( samples[primarySampleIndex], scene );
+	ccl::Mesh *result = convertPrimary( samples[primarySampleIndex], scene );
 	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
 	return result;
 }
 
-GeometryAlgo::ConverterDescription<MeshPrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<MeshPrimitive> g_description( convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -250,7 +250,7 @@ ccl::Geometry *convert( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *scen
 	return cmesh;
 }
 
-ccl::Geometry *convert( const std::vector<const IECoreScene::MeshPrimitive *> &meshes, const std::vector<float> &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const std::vector<const IECoreScene::MeshPrimitive *> &meshes, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	ccl::Mesh *result = convertCommon( meshes[primarySampleIndex], scene );
 	GeometryAlgo::convertMotion( vector<const IECoreScene::Primitive *>( meshes.begin(), meshes.end() ), primarySampleIndex, *result );

--- a/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
@@ -143,7 +143,7 @@ ccl::Geometry *convert( const IECoreScene::PointsPrimitive *points, ccl::Scene *
 	return pointCloud;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::PointsPrimitive *> &points, const std::vector<float> &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::PointsPrimitive *> &points, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	ccl::PointCloud *result = convertCommon( points[primarySampleIndex], scene );
 	GeometryAlgo::convertMotion( vector<const IECoreScene::Primitive *>( points.begin(), points.end() ), primarySampleIndex, *result );

--- a/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
@@ -58,7 +58,7 @@ using namespace IECoreCycles;
 namespace
 {
 
-ccl::PointCloud *convertCommon( const IECoreScene::PointsPrimitive *points, ccl::Scene *scene )
+ccl::PointCloud *convertPrimary( const IECoreScene::PointsPrimitive *points, ccl::Scene *scene )
 {
 	assert( points->typeId() == IECoreScene::PointsPrimitive::staticTypeId() );
 	ccl::PointCloud *pointcloud = SceneAlgo::createNodeWithLock<ccl::PointCloud>( scene );
@@ -137,19 +137,13 @@ ccl::PointCloud *convertCommon( const IECoreScene::PointsPrimitive *points, ccl:
 	return pointcloud;
 }
 
-ccl::Geometry *convert( const IECoreScene::PointsPrimitive *points, ccl::Scene *scene )
-{
-	ccl::PointCloud *pointCloud = convertCommon( points, scene );
-	return pointCloud;
-}
-
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::PointCloud *result = convertCommon( samples[primarySampleIndex], scene );
+	ccl::PointCloud *result = convertPrimary( samples[primarySampleIndex], scene );
 	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
 	return result;
 }
 
-GeometryAlgo::ConverterDescription<PointsPrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<PointsPrimitive> g_description( convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
@@ -143,10 +143,10 @@ ccl::Geometry *convert( const IECoreScene::PointsPrimitive *points, ccl::Scene *
 	return pointCloud;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::PointsPrimitive *> &points, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::PointCloud *result = convertCommon( points[primarySampleIndex], scene );
-	GeometryAlgo::convertMotion( vector<const IECoreScene::Primitive *>( points.begin(), points.end() ), primarySampleIndex, *result );
+	ccl::PointCloud *result = convertCommon( samples[primarySampleIndex], scene );
+	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
 	return result;
 }
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1460,35 +1460,6 @@ class GeometryCache
 		}
 
 		// Can be called concurrently with other get() calls.
-		SharedGeometryPtr get( const IECore::Object *object, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &nodeName )
-		{
-			const CyclesAttributes *cyclesAttributes = static_cast<const CyclesAttributes *>( attributes );
-
-			if( !cyclesAttributes->canInstanceGeometry( object ) )
-			{
-				return convert( object, cyclesAttributes, nodeName );
-			}
-
-			IECore::MurmurHash h = object->hash();
-			cyclesAttributes->hashGeometry( object, h );
-
-			Geometry::const_accessor readAccessor;
-			if( m_geometry.find( readAccessor, h ) )
-			{
-				return readAccessor->second;
-			}
-			else
-			{
-				Geometry::accessor writeAccessor;
-				if( m_geometry.insert( writeAccessor, h ) )
-				{
-					writeAccessor->second = convert( object, cyclesAttributes, nodeName );
-				}
-				return writeAccessor->second;
-			}
-		}
-
-		// Can be called concurrently with other get() calls.
 		SharedGeometryPtr get(
 			const IECoreScenePreview::Renderer::ObjectSamples &samples,
 			const IECoreScenePreview::Renderer::SampleTimes &times,
@@ -1548,25 +1519,6 @@ class GeometryCache
 		}
 
 	private :
-
-		SharedGeometryPtr convert( const IECore::Object *object, const CyclesAttributes *attributes, const std::string &nodeName )
-		{
-			auto geometry = SharedGeometryPtr( GeometryAlgo::convert( object, m_session->scene.get() ), NodeDeleter::GeometryDeleter( m_nodeDeleter ) );
-			if( geometry )
-			{
-				geometry->name = ccl::ustring( nodeName.c_str() );
-			}
-			if( auto vdb = IECore::runTimeCast<const IECoreVDB::VDBObject>( object ) )
-			{
-				// It's a pity we can't do this in VolumeAlgo in the first place. It is here instead because
-				// the precision is provided by the attributes, and we don't want to pass attributes
-				// to `GeometryAlgo`.
-				assert( geometry->is_volume() );
-				GeometryAlgo::convertVoxelGrids( vdb, static_cast<ccl::Volume*>( geometry.get() ), m_session->scene.get(), attributes->getVolumePrecision(), attributes->getVolumeClipping() );
-			}
-
-			return geometry;
-		}
 
 		SharedGeometryPtr convert(
 			const IECoreScenePreview::Renderer::ObjectSamples &samples,
@@ -2653,22 +2605,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 
 			IECore::msg( IECore::Msg::Warning, "CyclesRenderer", "lightFilter() unimplemented" );
 			return nullptr;
-		}
-
-		ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
-		{
-			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
-			acquireSession();
-
-			SharedGeometryPtr geometry = m_geometryCache->get( object, attributes, name );
-			if( !geometry )
-			{
-				return nullptr;
-			}
-
-			ObjectInterfacePtr result = new CyclesObject( m_scene, geometry, name, frame(), &m_lightLinker, m_nodeDeleter.get() );
-			result->attributes( attributes );
-			return result;
 		}
 
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1498,18 +1498,18 @@ class GeometryCache
 		{
 			const CyclesAttributes *cyclesAttributes = static_cast<const CyclesAttributes *>( attributes );
 
-			if( !cyclesAttributes->canInstanceGeometry( samples.front() ) )
+			if( !cyclesAttributes->canInstanceGeometry( samples.front().get() ) )
 			{
 				return convert( samples, times, cyclesAttributes, nodeName );
 			}
 
 			IECore::MurmurHash h;
-			for( std::vector<const IECore::Object *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
+			for( const auto &sample : samples )
 			{
-				(*it)->hash( h );
+				sample->hash( h );
 			}
 			h.append( times.data(), times.size() );
-			cyclesAttributes->hashGeometry( samples.front(), h );
+			cyclesAttributes->hashGeometry( samples.front().get(), h );
 
 			Geometry::const_accessor readAccessor;
 			if( m_geometry.find( readAccessor, h ) )
@@ -1581,7 +1581,7 @@ class GeometryCache
 				geometry->name = ccl::ustring( nodeName.c_str() );
 			}
 
-			if( auto vdb = IECore::runTimeCast<const IECoreVDB::VDBObject>( samples.front() ) )
+			if( auto vdb = IECore::runTimeCast<const IECoreVDB::VDBObject>( samples.front().get() ) )
 			{
 				assert( geometry->is_volume() );
 				GeometryAlgo::convertVoxelGrids( vdb, static_cast<ccl::Volume*>( geometry.get() ), m_session->scene.get(), attributes->getVolumePrecision(), attributes->getVolumeClipping() );

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1490,8 +1490,8 @@ class GeometryCache
 
 		// Can be called concurrently with other get() calls.
 		SharedGeometryPtr get(
-			const std::vector<const IECore::Object *> &samples,
-			const std::vector<float> &times,
+			const IECoreScenePreview::Renderer::ObjectSamples &samples,
+			const IECoreScenePreview::Renderer::SampleTimes &times,
 			const IECoreScenePreview::Renderer::AttributesInterface *attributes,
 			const std::string &nodeName
 		)
@@ -1508,10 +1508,7 @@ class GeometryCache
 			{
 				(*it)->hash( h );
 			}
-			for( std::vector<float>::const_iterator it = times.begin(), eIt = times.end(); it != eIt; ++it )
-			{
-				h.append( *it );
-			}
+			h.append( times.data(), times.size() );
 			cyclesAttributes->hashGeometry( samples.front(), h );
 
 			Geometry::const_accessor readAccessor;
@@ -1572,8 +1569,8 @@ class GeometryCache
 		}
 
 		SharedGeometryPtr convert(
-			const std::vector<const IECore::Object *> &samples,
-			const std::vector<float> &times,
+			const IECoreScenePreview::Renderer::ObjectSamples &samples,
+			const IECoreScenePreview::Renderer::SampleTimes &times,
 			const CyclesAttributes *attributes,
 			const std::string &nodeName
 		)
@@ -1771,7 +1768,7 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 			SceneAlgo::tagUpdateWithLock( m_object.get(), m_scene );
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			ccl::array<ccl::Transform> motion;
 			ccl::Geometry *geo = m_object->get_geometry();
@@ -1996,7 +1993,7 @@ class CyclesLight : public IECoreScenePreview::Renderer::ObjectInterface
 			SceneAlgo::tagUpdateWithLock( m_object.get(), m_scene );
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			// Cycles doesn't support motion samples on lights (yet)
 			transform( samples[0] );
@@ -2201,7 +2198,7 @@ class CyclesCamera : public IECoreScenePreview::Renderer::ObjectInterface
 			m_transformSamples = { transform };
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			m_transformSamples = samples;
 		}
@@ -2295,7 +2292,7 @@ class CyclesCamera : public IECoreScenePreview::Renderer::ObjectInterface
 	private :
 
 		IECoreScene::ConstCameraPtr m_camera;
-		std::vector<Imath::M44f> m_transformSamples;
+		IECoreScenePreview::Renderer::TransformSamples m_transformSamples;
 
 };
 
@@ -2674,7 +2671,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 			acquireSession();

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1693,33 +1693,6 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 			SceneAlgo::tagUpdateWithLock( m_object.get(), m_scene );
 		}
 
-		void transform( const Imath::M44f &transform ) override
-		{
-			m_object->set_tfm( SocketAlgo::setTransform( transform ) );
-			if( m_object->get_geometry()->is_mesh() )
-			{
-				auto mesh = static_cast<ccl::Mesh *>( m_object->get_geometry() );
-				if( mesh->get_num_subd_faces() )
-				{
-					mesh->set_subd_objecttoworld( m_object->get_tfm() );
-				}
-			}
-
-			ccl::array<ccl::Transform> motion;
-			if( m_object->get_geometry()->get_use_motion_blur() )
-			{
-				motion.resize( m_object->get_geometry()->get_motion_steps(), ccl::transform_empty() );
-				for( size_t i = 0; i < motion.size(); ++i )
-				{
-					motion[i] = m_object->get_tfm();
-				}
-			}
-
-			m_object->set_motion( motion );
-
-			SceneAlgo::tagUpdateWithLock( m_object.get(), m_scene );
-		}
-
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			ccl::array<ccl::Transform> motion;
@@ -1915,7 +1888,7 @@ class CyclesLight : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 		}
 
-		void transform( const Imath::M44f &transform ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			// Set environment map rotation
 			/// \todo There are a few problems here :
@@ -1933,7 +1906,7 @@ class CyclesLight : public IECoreScenePreview::Renderer::ObjectInterface
 					if( node->type == ccl::EnvironmentTextureNode::get_node_type() )
 					{
 						ccl::EnvironmentTextureNode *env = (ccl::EnvironmentTextureNode *)node;
-						Imath::Eulerf euler( transform, Imath::Eulerf::Order::XZY );
+						Imath::Eulerf euler( samples[0], Imath::Eulerf::Order::XZY );
 						env->tex_mapping.rotation = ccl::make_float3( -euler.x, -euler.y, -euler.z );
 						shader->tag_update( m_scene );
 						break;
@@ -1941,14 +1914,8 @@ class CyclesLight : public IECoreScenePreview::Renderer::ObjectInterface
 				}
 			}
 
-			m_object->set_tfm( SocketAlgo::setTransform( transform ) );
+			m_object->set_tfm( SocketAlgo::setTransform( samples[0] ) );
 			SceneAlgo::tagUpdateWithLock( m_object.get(), m_scene );
-		}
-
-		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
-		{
-			// Cycles doesn't support motion samples on lights (yet)
-			transform( samples[0] );
 		}
 
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
@@ -2143,11 +2110,6 @@ class CyclesCamera : public IECoreScenePreview::Renderer::ObjectInterface
 
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override
 		{
-		}
-
-		void transform( const Imath::M44f &transform ) override
-		{
-			m_transformSamples = { transform };
 		}
 
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2573,13 +2573,13 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			return m_attributesCache->get( attributes );
 		}
 
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 			// No need to acquire session because we don't need it to make a camera.
 			// This is important for certain clients (SceneGadget and RenderController)
 			// because they make a camera before calling `option()` to set the device.
-			CyclesCameraPtr result = new CyclesCamera( camera );
+			CyclesCameraPtr result = new CyclesCamera( samples[0] );
 			m_cameras[name] = result;
 			if( attributes )
 			{

--- a/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
@@ -74,13 +74,13 @@ void warnIfUnsupported( const IECoreScene::SpherePrimitive *sphere )
 	}
 }
 
-ccl::PointCloud *convertCommon( const IECoreScene::SpherePrimitive *sphere, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::SpherePrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
+	auto *sphere = samples[primarySampleIndex];
 	assert( sphere->typeId() == IECoreScene::SpherePrimitive::staticTypeId() );
 	warnIfUnsupported( sphere );
 	ccl::PointCloud *pointcloud = SceneAlgo::createNodeWithLock<ccl::PointCloud>( scene );
 
-	//pointcloud->set_point_style( ccl::POINT_CLOUD_POINT_SPHERE );
 	pointcloud->reserve( 1 );
 	pointcloud->add_point( ccl::make_float3( 0.0f, 0.0f, 0.0f ), sphere->radius(), 0);
 
@@ -101,18 +101,6 @@ ccl::PointCloud *convertCommon( const IECoreScene::SpherePrimitive *sphere, ccl:
 	return pointcloud;
 }
 
-ccl::Geometry *convert( const IECoreScene::SpherePrimitive *sphere, ccl::Scene *scene )
-{
-	ccl::Geometry *result = convertCommon( sphere, scene );
-	return result;
-}
-
-ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::SpherePrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
-{
-	ccl::Geometry *result = convertCommon( samples[primarySampleIndex], scene );
-	return result;
-}
-
-GeometryAlgo::ConverterDescription<SpherePrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<SpherePrimitive> g_description( convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
@@ -107,7 +107,7 @@ ccl::Geometry *convert( const IECoreScene::SpherePrimitive *sphere, ccl::Scene *
 	return result;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::SpherePrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	ccl::Geometry *result = convertCommon( samples[primarySampleIndex], scene );
 	return result;

--- a/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
@@ -107,7 +107,7 @@ ccl::Geometry *convert( const IECoreScene::SpherePrimitive *sphere, ccl::Scene *
 	return result;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const std::vector<float> &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	ccl::Geometry *result = convertCommon( samples[primarySampleIndex], scene );
 	return result;

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -66,7 +66,7 @@ ccl::Geometry *convert( const IECoreVDB::VDBObject *vdbObject, ccl::Scene *scene
 	return volume;
 }
 
-ccl::Geometry *convert( const std::vector<const IECoreVDB::VDBObject *> &samples, const std::vector<float> &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const std::vector<const IECoreVDB::VDBObject *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	return convert( samples[primarySampleIndex], scene );
 }

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -66,7 +66,7 @@ ccl::Geometry *convert( const IECoreVDB::VDBObject *vdbObject, ccl::Scene *scene
 	return volume;
 }
 
-ccl::Geometry *convert( const std::vector<const IECoreVDB::VDBObject *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreVDB::VDBObject *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
 	return convert( samples[primarySampleIndex], scene );
 }

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -60,17 +60,11 @@ using namespace IECoreCycles;
 namespace
 {
 
-ccl::Geometry *convert( const IECoreVDB::VDBObject *vdbObject, ccl::Scene *scene )
-{
-	ccl::Volume *volume = SceneAlgo::createNodeWithLock<ccl::Volume>( scene );
-	return volume;
-}
-
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreVDB::VDBObject *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	return convert( samples[primarySampleIndex], scene );
+	return SceneAlgo::createNodeWithLock<ccl::Volume>( scene );
 }
 
-GeometryAlgo::ConverterDescription<IECoreVDB::VDBObject> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<IECoreVDB::VDBObject> g_description( convert );
 
 } // namespace

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -981,8 +981,9 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
+			const IECore::Object *object = samples.front().get();
 			if( !m_renderObjects && !runTimeCast<const IECoreScenePreview::Placeholder>( object ) )
 			{
 				return nullptr;
@@ -993,11 +994,6 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			OpenGLObjectPtr result = new OpenGLObject( name, object, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
 			m_editQueue.push( [this, result]() { m_objects.push_back( result ); } );
 			return result;
-		}
-
-		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
-		{
-			return object( name, samples.front().get(), attributes );
 		}
 
 		void render() override

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -526,17 +526,12 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 			}
 		}
 
-		void transform( const Imath::M44f &transform ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
-			m_editQueue.push( [this, transform]() {
+			m_editQueue.push( [this, transform=samples.front()]() {
 				m_transform = transform;
 				m_transformSansScale = sansScalingAndShear( transform, false );
 			} );
-		}
-
-		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
-		{
-			transform( samples.front() );
 		}
 
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
@@ -759,10 +754,10 @@ class OpenGLCamera : public OpenGLObject
 			}
 		}
 
-		void transform( const Imath::M44f &transform ) override
+		void transform(const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times) override
 		{
-			OpenGLObject::transform( transform );
-			editQueue().push( [this, transform]() {
+			OpenGLObject::transform( samples, times );
+			editQueue().push( [this, transform=samples.front()]() {
 				m_camera->setTransform( transform );
 			} );
 		}

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -944,7 +944,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
@@ -955,7 +955,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 				openGLAttributes = new OpenGLAttributes( emptyAttributes.get() );
 			}
 
-			OpenGLCameraPtr result = new OpenGLCamera( name, camera, openGLAttributes, m_editQueue );
+			OpenGLCameraPtr result = new OpenGLCamera( name, samples.front().get(), openGLAttributes, m_editQueue );
 			m_editQueue.push( [this, result, name]() {
 				m_objects.push_back( result );
 				m_cameras[name] = result;

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -534,7 +534,7 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 			} );
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			transform( samples.front() );
 		}
@@ -995,7 +995,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			return object( name, samples.front(), attributes );
 		}

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -997,7 +997,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
-			return object( name, samples.front(), attributes );
+			return object( name, samples.front().get(), attributes );
 		}
 
 		void render() override

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -257,7 +257,7 @@ const std::string &CapturingRenderer::CapturedObject::capturedName() const
 	return m_name;
 }
 
-const std::vector<IECore::ConstObjectPtr> &CapturingRenderer::CapturedObject::capturedSamples() const
+const IECoreScenePreview::Renderer::ObjectSamples &CapturingRenderer::CapturedObject::capturedSamples() const
 {
 	return m_capturedSamples;
 }

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -122,12 +122,12 @@ Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name,
 
 Renderer::ObjectInterfacePtr CapturingRenderer::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
-	return this->object( name, { object }, {}, attributes );
+	return this->object( name, { object }, { 0.0 }, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
-	return this->object( name, { object }, {}, attributes );
+	return this->object( name, { object }, { 0.0 }, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -136,6 +136,15 @@ Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name,
 
 	checkPaused();
 
+	if( samples.size() != times.size() )
+	{
+		IECore::msg(
+			IECore::Msg::Warning, "CapturingRenderer::object",
+			"Number of object samples ({}) doesn't match number of time samples ({}) for object \"{}\"",
+			samples.size(), times.size(), name
+		);
+	}
+
 	// To facilitate the testing of code that handles the return from the various object methods of
 	// a renderer, we return null if the `cr:unrenderable` attribute is set to true.
 	if( CapturedAttributes::unrenderableAttributeValue( static_cast<const CapturedAttributes *>( attributes ) ) )
@@ -322,6 +331,14 @@ uint32_t CapturingRenderer::CapturedObject::instanceID() const
 void CapturingRenderer::CapturedObject::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const SampleTimes &times )
 {
 	m_renderer->checkPaused();
+	if( samples.size() != times.size() )
+	{
+		IECore::msg(
+			IECore::Msg::Warning, "CapturingRenderer::CapturedObject::transform",
+			"Number of transform samples ({}) doesn't match number of time samples ({}) for object \"{}\"",
+			samples.size(), times.size(), m_name
+		);
+	}
 	m_capturedTransforms = samples;
 	m_capturedTransformTimes = times;
 }

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -117,7 +117,7 @@ Renderer::AttributesInterfacePtr CapturingRenderer::attributes( const IECore::Co
 
 Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes )
 {
-	return this->object( name, camera, attributes );
+	return this->object( name, { camera }, {}, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
@@ -127,15 +127,10 @@ Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name,
 
 Renderer::ObjectInterfacePtr CapturingRenderer::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
-	return this->object( name, object, attributes );
+	return this->object( name, { object }, {}, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
-{
-	return this->object( name, object, attributes );
-}
-
-Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
 	return this->object( name, { object }, {}, attributes );
 }

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -319,14 +319,6 @@ uint32_t CapturingRenderer::CapturedObject::instanceID() const
 	return m_instanceID;
 }
 
-void CapturingRenderer::CapturedObject::transform( const Imath::M44f &transform )
-{
-	m_renderer->checkPaused();
-	m_capturedTransforms.clear();
-	m_capturedTransforms.push_back( transform );
-	m_capturedTransformTimes.clear();
-}
-
 void CapturingRenderer::CapturedObject::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const SampleTimes &times )
 {
 	m_renderer->checkPaused();

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -115,11 +115,6 @@ Renderer::AttributesInterfacePtr CapturingRenderer::attributes( const IECore::Co
 	return new CapturedAttributes( ConstCompoundObjectPtr( attributes ) );
 }
 
-Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes )
-{
-	return this->object( name, { camera }, {}, attributes );
-}
-
 Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	return this->object( name, ObjectSamples( samples.begin(), samples.end() ), times, attributes );

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -120,9 +120,9 @@ Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name,
 	return this->object( name, camera, attributes );
 }
 
-Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
-	return this->object( name, vector<const Object *>( samples.begin(), samples.end() ), times, attributes );
+	return this->object( name, ObjectSamples( samples.begin(), samples.end() ), times, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
@@ -140,7 +140,7 @@ Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name,
 	return this->object( name, { object }, {}, attributes );
 }
 
-Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
@@ -237,7 +237,7 @@ bool CapturingRenderer::CapturedAttributes::unrenderableAttributeValue( const Ca
 // CapturedObject
 //////////////////////////////////////////////////////////////////////////
 
-CapturingRenderer::CapturedObject::CapturedObject( CapturingRenderer *renderer, const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times )
+CapturingRenderer::CapturedObject::CapturedObject( CapturingRenderer *renderer, const std::string &name, const ObjectSamples &samples, const SampleTimes &times )
 	:	m_renderer( renderer ), m_name( name ), m_capturedSamples( samples.begin(), samples.end() ), m_capturedSampleTimes( times ), m_numAttributeEdits( 0 ), m_id( 0 ), m_instanceID( 0 )
 {
 }
@@ -262,17 +262,17 @@ const std::vector<IECore::ConstObjectPtr> &CapturingRenderer::CapturedObject::ca
 	return m_capturedSamples;
 }
 
-const std::vector<float> &CapturingRenderer::CapturedObject::capturedSampleTimes() const
+const IECoreScenePreview::Renderer::SampleTimes &CapturingRenderer::CapturedObject::capturedSampleTimes() const
 {
 	return m_capturedSampleTimes;
 }
 
-const std::vector<Imath::M44f> &CapturingRenderer::CapturedObject::capturedTransforms() const
+const IECoreScenePreview::Renderer::TransformSamples &CapturingRenderer::CapturedObject::capturedTransforms() const
 {
 	return m_capturedTransforms;
 }
 
-const std::vector<float> &CapturingRenderer::CapturedObject::capturedTransformTimes() const
+const IECoreScenePreview::Renderer::SampleTimes &CapturingRenderer::CapturedObject::capturedTransformTimes() const
 {
 	return m_capturedTransformTimes;
 }
@@ -337,7 +337,7 @@ void CapturingRenderer::CapturedObject::transform( const Imath::M44f &transform 
 	m_capturedTransformTimes.clear();
 }
 
-void CapturingRenderer::CapturedObject::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+void CapturingRenderer::CapturedObject::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const SampleTimes &times )
 {
 	m_renderer->checkPaused();
 	m_capturedTransforms = samples;

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -150,7 +150,7 @@ struct CompoundObjectInterface : public IECoreScenePreview::Renderer::ObjectInte
 		}
 	}
 
-	void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+	void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 	{
 		for( auto &o : objects )
 		{
@@ -396,7 +396,7 @@ Renderer::ObjectInterfacePtr CompoundRenderer::object( const std::string &name, 
 	return result;
 }
 
-Renderer::ObjectInterfacePtr CompoundRenderer::object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CompoundRenderer::object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	auto compoundAttributes = static_cast<const CompoundAttributesInterface *>( attributes );
 	CompoundObjectInterfacePtr result = new CompoundObjectInterface;

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -139,17 +139,6 @@ struct CompoundObjectInterface : public IECoreScenePreview::Renderer::ObjectInte
 		}
 	}
 
-	void transform( const Imath::M44f &transform ) override
-	{
-		for( auto &o : objects )
-		{
-			if( o )
-			{
-				o->transform( transform );
-			}
-		}
-	}
-
 	void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 	{
 		for( auto &o : objects )

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -352,13 +352,13 @@ Renderer::AttributesInterfacePtr CompoundRenderer::attributes( const IECore::Com
 	return new CompoundAttributesInterface( m_renderers, attributes );
 }
 
-Renderer::ObjectInterfacePtr CompoundRenderer::camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CompoundRenderer::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	auto compoundAttributes = static_cast<const CompoundAttributesInterface *>( attributes );
 	CompoundObjectInterfacePtr result = new CompoundObjectInterface;
 	for( size_t i = 0; i < m_renderers.size(); ++i )
 	{
-		result->objects[i] = m_renderers[i]->camera( name, camera, compoundAttributes ? compoundAttributes->attributes[i].get() : nullptr );
+		result->objects[i] = m_renderers[i]->camera( name, samples, times, compoundAttributes ? compoundAttributes->attributes[i].get() : nullptr );
 	}
 	return result;
 }

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -385,17 +385,6 @@ Renderer::ObjectInterfacePtr CompoundRenderer::lightFilter( const std::string &n
 	return result;
 }
 
-Renderer::ObjectInterfacePtr CompoundRenderer::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
-{
-	auto compoundAttributes = static_cast<const CompoundAttributesInterface *>( attributes );
-	CompoundObjectInterfacePtr result = new CompoundObjectInterface;
-	for( size_t i = 0; i < m_renderers.size(); ++i )
-	{
-		result->objects[i] = m_renderers[i]->object( name, object, compoundAttributes->attributes[i].get() );
-	}
-	return result;
-}
-
 Renderer::ObjectInterfacePtr CompoundRenderer::object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	auto compoundAttributes = static_cast<const CompoundAttributesInterface *>( attributes );

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -82,6 +82,11 @@ Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name, const Ca
 	return camera( name, samples[0].get(), attributes );
 }
 
+Renderer::ObjectInterfacePtr Renderer::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+{
+	return this->object( name, { object }, { 0.0f }, attributes );
+}
+
 IECore::DataPtr Renderer::command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters )
 {
 	throw IECore::NotImplementedException( "Renderer::command" );

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -102,6 +102,11 @@ Renderer::ObjectInterface::~ObjectInterface()
 
 }
 
+void Renderer::ObjectInterface::transform( const Imath::M44f &transform )
+{
+	this->transform( { transform }, { 0.0f } );
+}
+
 const std::vector<IECore::InternedString> &Renderer::types()
 {
 	return ::types();

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -79,7 +79,7 @@ Renderer::~Renderer()
 
 Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
-	return camera( name, samples[0], attributes );
+	return camera( name, samples[0].get(), attributes );
 }
 
 IECore::DataPtr Renderer::command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters )

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -77,9 +77,9 @@ Renderer::~Renderer()
 
 }
 
-Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes )
 {
-	return camera( name, samples[0].get(), attributes );
+	return this->camera( name, { camera }, { 0.0f }, attributes );
 }
 
 Renderer::ObjectInterfacePtr Renderer::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -77,7 +77,7 @@ Renderer::~Renderer()
 
 }
 
-Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name,  const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	return camera( name, samples[0], attributes );
 }

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -3115,7 +3115,7 @@ struct Prototype : public IECore::RefCounted
 {
 	Prototype(
 		const ScenePlug *prototypesPlug, const ScenePlug::ScenePath *prototypeRoot,
-		const std::vector<float> &sampleTimes, const IECore::MurmurHash &hash,
+		const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, const IECore::MurmurHash &hash,
 		const GafferScene::Private::RendererAlgo::RenderOptions &renderOptions,
 		const Context *prototypeContext,
 		IECoreScenePreview::Renderer *renderer,
@@ -3193,10 +3193,10 @@ struct Prototype : public IECore::RefCounted
 	// Rather awkwardly, we need to store the objects as raw pointers as well, because Renderer::object
 	// requires a vector of pointers for the animated case.
 	std::vector<const Object *> m_objectPointers;
-	std::vector<float> m_objectSampleTimes;
+	IECoreScenePreview::Renderer::SampleTimes m_objectSampleTimes;
 	ConstCompoundObjectPtr m_attributes;
 	IECoreScenePreview::Renderer::AttributesInterfacePtr m_rendererAttributes;
-	std::vector<M44f> m_transforms;
+	IECoreScenePreview::Renderer::TransformSamples m_transforms;
 };
 
 using ConstPrototypePtr = boost::intrusive_ptr<const Prototype>;
@@ -3246,9 +3246,9 @@ void Instancer::InstancerCapsule::render( IECoreScenePreview::Renderer *renderer
 	// This is a bit of a weird convention for using a const variable with an initialization that doesn't
 	// fit in one line ... not sure how I feel about it. In this case, it's crucial that sampleTimes is
 	// const, because it is used from multiple threads simultaneously.
-	const vector<float> sampleTimes = [this, &enginePath, &renderOpts]()
+	const IECoreScenePreview::Renderer::SampleTimes sampleTimes = [this, &enginePath, &renderOpts]()
 	{
-		vector<float> result;
+		IECoreScenePreview::Renderer::SampleTimes result;
 		const ConstCompoundObjectPtr sceneAttributes = m_instancer->inPlug()->fullAttributes( enginePath );
 		GafferScene::Private::RendererAlgo::transformMotionTimes( renderOpts, sceneAttributes.get(), result );
 
@@ -3358,7 +3358,7 @@ void Instancer::InstancerCapsule::render( IECoreScenePreview::Renderer *renderer
 		{
 			Context::EditableScope prototypeScope( threadState );
 
-			vector<M44f> pointTransforms( sampleTimes.size() );
+			IECoreScenePreview::Renderer::TransformSamples pointTransforms( sampleTimes.size() );
 			IECoreScenePreview::Renderer::AttributesInterfacePtr attribsStorage;
 
 			// Storage for names, indexed by prototype id ( each instance of the same prototype

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -3159,9 +3159,9 @@ struct Prototype : public IECore::RefCounted
 				// This prototype is not included. Leave m_object empty, which means this prototype will be skipped.
 				return;
 			}
-
-			GafferScene::Private::RendererAlgo::deformationMotionTimes( renderOptions, m_attributes.get(), m_objectSampleTimes );
-			GafferScene::Private::RendererAlgo::objectSamples( prototypesPlug->objectPlug(), m_objectSampleTimes, m_object );
+			IECoreScenePreview::Renderer::SampleTimes objectSampleTimes;
+			GafferScene::Private::RendererAlgo::deformationMotionTimes( renderOptions, m_attributes.get(), objectSampleTimes );
+			m_object = *GafferScene::Private::RendererAlgo::objectSamples( prototypesPlug->objectPlug(), objectSampleTimes );
 		}
 		else
 		{
@@ -3178,12 +3178,12 @@ struct Prototype : public IECore::RefCounted
 
 			// Pass through our render options to the sub-capsules
 			newCapsule->setRenderOptions( renderOptions );
-			m_object.push_back( std::move( newCapsule ) );
+			m_object.samples.push_back( std::move( newCapsule ) );
+			m_object.sampleTimes.push_back( onFrameTime );
 		}
 	}
 
-	IECoreScenePreview::Renderer::ObjectSamples m_object;
-	IECoreScenePreview::Renderer::SampleTimes m_objectSampleTimes;
+	Private::RendererAlgo::SampledObject m_object;
 	ConstCompoundObjectPtr m_attributes;
 	IECoreScenePreview::Renderer::AttributesInterfacePtr m_rendererAttributes;
 	IECoreScenePreview::Renderer::TransformSamples m_transforms;
@@ -3391,7 +3391,7 @@ void Instancer::InstancerCapsule::render( IECoreScenePreview::Renderer *renderer
 					proto = prototypeCache.get( PrototypeCacheGetterKey( protoIndex, prototypeScope.context() ) ).get();
 				}
 
-				if( !proto->m_object.size() )
+				if( !proto->m_object.samples.size() )
 				{
 					// No object to render. This could happen if the protype didn't meet the
 					// RenderOptions::purposeIncluded test.
@@ -3442,19 +3442,9 @@ void Instancer::InstancerCapsule::render( IECoreScenePreview::Renderer *renderer
 				name.resize( namePrefixLengths[protoIndex] + std::numeric_limits< int64_t >::digits10 + 1 );
 				name.resize( std::to_chars( &name[prefixLen], &(*name.end()), instanceId ).ptr - &name[0] );
 
-				IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface;
-				if( proto->m_objectSampleTimes.size() )
-				{
-					objectInterface = renderer->object(
-						name, proto->m_object, proto->m_objectSampleTimes, attribs
-					);
-				}
-				else
-				{
-					objectInterface = renderer->object(
-						name, proto->m_object[0].get(), attribs
-					);
-				}
+				IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface = renderer->object(
+					name, proto->m_object.samples, proto->m_object.sampleTimes, attribs
+				);
 
 				if( sampleTimes.size() == 1 )
 				{

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -3162,12 +3162,6 @@ struct Prototype : public IECore::RefCounted
 
 			GafferScene::Private::RendererAlgo::deformationMotionTimes( renderOptions, m_attributes.get(), m_objectSampleTimes );
 			GafferScene::Private::RendererAlgo::objectSamples( prototypesPlug->objectPlug(), m_objectSampleTimes, m_object );
-
-			m_objectPointers.reserve( m_object.size() );
-			for( ConstObjectPtr &i : m_object )
-			{
-				m_objectPointers.push_back( i.get() );
-			}
 		}
 		else
 		{
@@ -3188,11 +3182,7 @@ struct Prototype : public IECore::RefCounted
 		}
 	}
 
-	std::vector<ConstObjectPtr> m_object;
-
-	// Rather awkwardly, we need to store the objects as raw pointers as well, because Renderer::object
-	// requires a vector of pointers for the animated case.
-	std::vector<const Object *> m_objectPointers;
+	IECoreScenePreview::Renderer::ObjectSamples m_object;
 	IECoreScenePreview::Renderer::SampleTimes m_objectSampleTimes;
 	ConstCompoundObjectPtr m_attributes;
 	IECoreScenePreview::Renderer::AttributesInterfacePtr m_rendererAttributes;
@@ -3456,7 +3446,7 @@ void Instancer::InstancerCapsule::render( IECoreScenePreview::Renderer *renderer
 				if( proto->m_objectSampleTimes.size() )
 				{
 					objectInterface = renderer->object(
-						name, proto->m_objectPointers, proto->m_objectSampleTimes, attribs
+						name, proto->m_object, proto->m_objectSampleTimes, attribs
 					);
 				}
 				else

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -908,7 +908,7 @@ class RenderController::SceneGraph
 				return true;
 			}
 
-			vector<ConstObjectPtr> samples;
+			IECoreScenePreview::Renderer::ObjectSamples samples;
 			if( !Private::RendererAlgo::objectSamples( objectPlug, m_deformationTimes, samples, &m_objectHash ) )
 			{
 				return false;
@@ -951,7 +951,7 @@ class RenderController::SceneGraph
 			ScenePlug::pathToString( Context::current()->get<vector<InternedString> >( ScenePlug::scenePathContextName ), name );
 			if( type == CameraType )
 			{
-				vector<ConstCameraPtr> cameraSamples; cameraSamples.reserve( samples.size() );
+				IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( samples.size() );
 				for( const auto &sample : samples )
 				{
 					if( auto cameraSample = runTimeCast<const Camera>( sample.get() ) )
@@ -987,14 +987,9 @@ class RenderController::SceneGraph
 					}
 					else
 					{
-						IECoreScenePreview::Renderer::CameraSamples rawCameraSamples; rawCameraSamples.reserve( cameraSamples.size() );
-						for( auto &c : cameraSamples )
-						{
-							rawCameraSamples.push_back( c.get() );
-						}
 						m_objectInterface = renderer->camera(
 							name,
-							rawCameraSamples,
+							cameraSamples,
 							m_deformationTimes,
 							attributesInterface( renderer )
 						);
@@ -1025,13 +1020,7 @@ class RenderController::SceneGraph
 				}
 				else
 				{
-					/// \todo Can we rejig things so this conversion isn't necessary?
-					vector<const Object *> objectsVector; objectsVector.reserve( samples.size() );
-					for( const auto &sample : samples )
-					{
-						objectsVector.push_back( sample.get() );
-					}
-					m_objectInterface = renderer->object( name, objectsVector, m_deformationTimes, attributesInterface( renderer ) );
+					m_objectInterface = renderer->object( name, samples, m_deformationTimes, attributesInterface( renderer ) );
 				}
 			}
 

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -801,7 +801,7 @@ class RenderController::SceneGraph
 				m_transformHash = IECore::MurmurHash();
 			}
 
-			vector<M44f> samples;
+			IECoreScenePreview::Renderer::TransformSamples samples;
 			if( !Private::RendererAlgo::transformSamples( transformPlug, m_transformTimes, samples, &m_transformHash ) )
 			{
 				return false;
@@ -987,7 +987,7 @@ class RenderController::SceneGraph
 					}
 					else
 					{
-						vector<const Camera *> rawCameraSamples; rawCameraSamples.reserve( cameraSamples.size() );
+						IECoreScenePreview::Renderer::CameraSamples rawCameraSamples; rawCameraSamples.reserve( cameraSamples.size() );
 						for( auto &c : cameraSamples )
 						{
 							rawCameraSamples.push_back( c.get() );
@@ -1150,14 +1150,14 @@ class RenderController::SceneGraph
 				return m_fullTransform[0];
 			}
 
-			vector<float>::const_iterator t1 = lower_bound( m_transformTimesOutput->begin(), m_transformTimesOutput->end(), time );
+			auto t1 = lower_bound( m_transformTimesOutput->begin(), m_transformTimesOutput->end(), time );
 			if( t1 == m_transformTimesOutput->begin() || *t1 == time )
 			{
 				return m_fullTransform[t1 - m_transformTimesOutput->begin()];
 			}
 			else
 			{
-				vector<float>::const_iterator t0 = t1 - 1;
+				auto t0 = t1 - 1;
 				const float l = lerpfactor( time, *t0, *t1 );
 				const M44f &s0 = m_fullTransform[t0 - m_transformTimesOutput->begin()];
 				const M44f &s1 = m_fullTransform[t1 - m_transformTimesOutput->begin()];
@@ -1202,7 +1202,7 @@ class RenderController::SceneGraph
 
 		IECore::MurmurHash m_objectHash;
 		ObjectInterfaceHandle m_objectInterface;
-		std::vector<float> m_deformationTimes;
+		IECoreScenePreview::Renderer::SampleTimes m_deformationTimes;
 
 		IECore::MurmurHash m_attributesHash;
 		IECore::CompoundObjectPtr m_fullAttributes;
@@ -1211,13 +1211,13 @@ class RenderController::SceneGraph
 		bool m_purposeIncluded;
 
 		IECore::MurmurHash m_transformHash;
-		std::vector<Imath::M44f> m_fullTransform;
-		std::vector<float> m_transformTimes;
+		IECoreScenePreview::Renderer::TransformSamples m_fullTransform;
+		IECoreScenePreview::Renderer::SampleTimes m_transformTimes;
 
 		// The m_transformTimes represents what times we sample the transform at.  The actual
 		// times we output at may differ due to the transform samples turning out to not vary,
 		// or inheriting parent samples
-		std::vector<float> *m_transformTimesOutput;
+		IECoreScenePreview::Renderer::SampleTimes *m_transformTimesOutput;
 
 		IECore::MurmurHash m_childNamesHash;
 		std::vector<std::unique_ptr<SceneGraph>> m_children;

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -615,15 +615,8 @@ class RenderController::SceneGraph
 				// the apply the transform.
 				if( m_changedComponents & ( ObjectComponent | TransformComponent ) )
 				{
-					assert( m_fullTransform.size() );
-					if( !m_transformTimesOutput )
-					{
-						m_objectInterface->transform( m_fullTransform[0] );
-					}
-					else
-					{
-						m_objectInterface->transform( m_fullTransform, *m_transformTimesOutput );
-					}
+					assert( m_fullTransform.samples.size() );
+					m_objectInterface->transform( m_fullTransform.samples, m_fullTransform.sampleTimes );
 				}
 
 				// Assign an ID
@@ -687,7 +680,7 @@ class RenderController::SceneGraph
 						m_boundInterface = nullptr;
 					}
 
-					m_boundInterface = controller->m_renderer->object( boundName, placeholder.get(), controller->m_defaultAttributes.get() );
+					m_boundInterface = controller->m_renderer->object( boundName, { placeholder.get() }, { 0.0 }, controller->m_defaultAttributes.get() );
 					if( m_boundInterface )
 					{
 						newBound = true;
@@ -702,15 +695,8 @@ class RenderController::SceneGraph
 			if( newBound || ( m_boundInterface && ( m_changedComponents & TransformComponent ) ) )
 			{
 				// Apply transform to bounding box
-				assert( m_fullTransform.size() );
-				if( !m_transformTimesOutput )
-				{
-					m_boundInterface->transform( m_fullTransform[0] );
-				}
-				else
-				{
-					m_boundInterface->transform( m_fullTransform, *m_transformTimesOutput );
-				}
+				assert( m_fullTransform.samples.size() );
+				m_boundInterface->transform( m_fullTransform.samples, m_fullTransform.sampleTimes );
 			}
 
 			clean( VisibleSetComponent | BoundComponent );
@@ -801,40 +787,22 @@ class RenderController::SceneGraph
 				m_transformHash = IECore::MurmurHash();
 			}
 
-			IECoreScenePreview::Renderer::TransformSamples samples;
-			if( !Private::RendererAlgo::transformSamples( transformPlug, m_transformTimes, samples, &m_transformHash ) )
+			auto sampledTransform = Private::RendererAlgo::transformSamples( transformPlug, m_transformTimes, &m_transformHash );
+			if( !sampledTransform )
 			{
 				return false;
 			}
 
 			if( !m_parent )
 			{
-				m_fullTransform = samples;
-				m_transformTimesOutput = samples.size() > 1 ? &m_transformTimes : nullptr;
+				m_fullTransform = *sampledTransform;
 			}
 			else
 			{
-				m_fullTransform.clear();
-				if( samples.size() == 1 )
-				{
-					m_fullTransform.reserve( m_parent->m_fullTransform.size() );
-					for( const M44f& it : m_parent->m_fullTransform )
-					{
-						m_fullTransform.push_back( samples.front() * it );
-					}
-					m_transformTimesOutput = m_parent->m_transformTimesOutput;
-				}
-				else
-				{
-					m_transformTimesOutput = &m_transformTimes;
-					m_fullTransform.reserve( samples.size() );
-
-					for( size_t i = 0; i < samples.size(); i++ )
-					{
-						m_fullTransform.push_back( samples[i] * m_parent->fullTransform( m_transformTimes[i] ) );
-					}
-				}
+				m_fullTransform = m_parent->m_fullTransform;
+				m_fullTransform.concatenate( *sampledTransform );
 			}
+
 			return true;
 		}
 
@@ -908,15 +876,16 @@ class RenderController::SceneGraph
 				return true;
 			}
 
-			IECoreScenePreview::Renderer::ObjectSamples samples;
-			if( !Private::RendererAlgo::objectSamples( objectPlug, m_deformationTimes, samples, &m_objectHash ) )
+			auto sampledObject = Private::RendererAlgo::objectSamples( objectPlug, m_deformationTimes, &m_objectHash );
+			if( !sampledObject )
 			{
+				// No update required.
 				return false;
 			}
 
 			if(
 				std::all_of(
-					samples.begin(), samples.end(),
+					sampledObject->samples.begin(), sampledObject->samples.end(),
 					[] ( const ConstObjectPtr &sample ) { return runTimeCast<const IECore::NullObject>( sample.get() ); }
 				)
 			)
@@ -951,8 +920,8 @@ class RenderController::SceneGraph
 			ScenePlug::pathToString( Context::current()->get<vector<InternedString> >( ScenePlug::scenePathContextName ), name );
 			if( type == CameraType )
 			{
-				IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( samples.size() );
-				for( const auto &sample : samples )
+				IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( sampledObject->samples.size() );
+				for( const auto &sample : sampledObject->samples )
 				{
 					if( auto cameraSample = runTimeCast<const Camera>( sample.get() ) )
 					{
@@ -964,7 +933,7 @@ class RenderController::SceneGraph
 
 				// Create ObjectInterface
 
-				if( !samples.size() || cameraSamples.size() != samples.size() )
+				if( !sampledObject->samples.size() || cameraSamples.size() != sampledObject->samples.size() )
 				{
 					IECore::msg(
 						IECore::Msg::Warning,
@@ -977,51 +946,38 @@ class RenderController::SceneGraph
 				}
 				else
 				{
-					if( cameraSamples.size() == 1 )
-					{
-						m_objectInterface = renderer->camera(
-							name,
-							cameraSamples[0].get(),
-							attributesInterface( renderer )
-						);
-					}
-					else
-					{
-						m_objectInterface = renderer->camera(
-							name,
-							cameraSamples,
-							m_deformationTimes,
-							attributesInterface( renderer )
-						);
-					}
+					m_objectInterface = renderer->camera(
+						name,
+						cameraSamples,
+						sampledObject->sampleTimes,
+						attributesInterface( renderer )
+					);
 				}
 			}
 			else
 			{
-				if( !samples.size() )
+				if( !sampledObject->samples.size() )
 				{
 					return true;
 				}
 
-				if( samples.size() == 1 )
+				bool isCapsule = false;
+				if( sampledObject->samples.size() == 1 )
 				{
-					ConstObjectPtr sample = samples[0];
-					if( auto capsule = runTimeCast<const Capsule>( sample.get() ) )
+					if( auto capsule = runTimeCast<const Capsule>( sampledObject->samples[0].get() ) )
 					{
 						CapsulePtr capsuleCopy = capsule->copy();
 						capsuleCopy->setRenderOptions( renderOptions );
-						sample = capsuleCopy;
+						sampledObject->samples[0] = capsuleCopy;
+						isCapsule = true;
 					}
-					m_objectInterface.assign(
-						renderer->object( name, sample.get(), attributesInterface( renderer ) ),
-						ObjectInterfaceHandle::RemovalCallback(),
-						/* isCapsule = */ runTimeCast<const Capsule>( sample.get() )
-					);
 				}
-				else
-				{
-					m_objectInterface = renderer->object( name, samples, m_deformationTimes, attributesInterface( renderer ) );
-				}
+
+				m_objectInterface.assign(
+					renderer->object( name, sampledObject->samples, sampledObject->sampleTimes, attributesInterface( renderer ) ),
+					ObjectInterfaceHandle::RemovalCallback(),
+					isCapsule
+				);
 			}
 
 			return true;
@@ -1128,34 +1084,6 @@ class RenderController::SceneGraph
 			m_dirtyComponents &= ~components;
 		}
 
-		M44f fullTransform( float time ) const
-		{
-			if( m_fullTransform.empty() )
-			{
-				return M44f();
-			}
-			if( !m_transformTimesOutput )
-			{
-				return m_fullTransform[0];
-			}
-
-			auto t1 = lower_bound( m_transformTimesOutput->begin(), m_transformTimesOutput->end(), time );
-			if( t1 == m_transformTimesOutput->begin() || *t1 == time )
-			{
-				return m_fullTransform[t1 - m_transformTimesOutput->begin()];
-			}
-			else
-			{
-				auto t0 = t1 - 1;
-				const float l = lerpfactor( time, *t0, *t1 );
-				const M44f &s0 = m_fullTransform[t0 - m_transformTimesOutput->begin()];
-				const M44f &s1 = m_fullTransform[t1 - m_transformTimesOutput->begin()];
-				M44f result;
-				LinearInterpolator<M44f>()( s0, s1, l, result );
-				return result;
-			}
-		}
-
 		/// \todo Fast path for when sets were not dirtied.
 		static unsigned sceneGraphMatch( RenderController *controller, SceneGraph::Type sceneGraphType, const ScenePlug::ScenePath &scenePath )
 		{
@@ -1200,13 +1128,14 @@ class RenderController::SceneGraph
 		bool m_purposeIncluded;
 
 		IECore::MurmurHash m_transformHash;
-		IECoreScenePreview::Renderer::TransformSamples m_fullTransform;
+		// The times we sample the local transform at.
 		IECoreScenePreview::Renderer::SampleTimes m_transformTimes;
 
-		// The m_transformTimes represents what times we sample the transform at.  The actual
-		// times we output at may differ due to the transform samples turning out to not vary,
-		// or inheriting parent samples
-		IECoreScenePreview::Renderer::SampleTimes *m_transformTimesOutput;
+		// The full transform to be applied to the object. The number of samples
+		// here may differ from `m_transformTimes`, either because the transform
+		// turned out to be static, or due to inheriting from a parent with
+		// different numbers of samples.
+		Private::RendererAlgo::SampledTransform m_fullTransform;
 
 		IECore::MurmurHash m_childNamesHash;
 		std::vector<std::unique_ptr<SceneGraph>> m_children;

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -330,7 +330,7 @@ std::string renderManifestFilePath( const IECore::CompoundObject *globals )
 	return renderManifestFilePathData->readable();
 }
 
-bool motionTimes( bool motionBlur, const V2f &shutter, const CompoundObject *attributes, const InternedString &attributeName, const InternedString &segmentsAttributeName, std::vector<float> &times )
+bool motionTimes( bool motionBlur, const V2f &shutter, const CompoundObject *attributes, const InternedString &attributeName, const InternedString &segmentsAttributeName, IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	unsigned int segments = 0;
 	if( motionBlur )
@@ -368,17 +368,17 @@ bool motionTimes( bool motionBlur, const V2f &shutter, const CompoundObject *att
 	return changed;
 }
 
-bool transformMotionTimes( const RenderOptions &renderOptions, const CompoundObject *attributes, std::vector<float> &times )
+bool transformMotionTimes( const RenderOptions &renderOptions, const CompoundObject *attributes, IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	return motionTimes( renderOptions.transformBlur, renderOptions.shutter, attributes, g_transformBlurAttributeName, g_transformBlurSegmentsAttributeName, times );
 }
 
-bool deformationMotionTimes( const RenderOptions &renderOptions, const CompoundObject *attributes, std::vector<float> &times )
+bool deformationMotionTimes( const RenderOptions &renderOptions, const CompoundObject *attributes, IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	return motionTimes( renderOptions.deformationBlur, renderOptions.shutter, attributes, g_deformationBlurAttributeName, g_deformationBlurSegmentsAttributeName, times );
 }
 
-bool transformSamples( const M44fPlug *transformPlug, const std::vector<float> &sampleTimes, std::vector<Imath::M44f> &samples, IECore::MurmurHash *hash )
+bool transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::TransformSamples &samples, IECore::MurmurHash *hash )
 {
 	std::vector< IECore::MurmurHash > sampleHashes;
 	if( !sampleTimes.size() )
@@ -474,7 +474,7 @@ bool transformSamples( const M44fPlug *transformPlug, const std::vector<float> &
 	return true;
 }
 
-bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &sampleTimes, std::vector<IECore::ConstObjectPtr> &samples, IECore::MurmurHash *hash )
+bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, std::vector<IECore::ConstObjectPtr> &samples, IECore::MurmurHash *hash )
 {
 	std::vector< IECore::MurmurHash > sampleHashes;
 	if( !sampleTimes.size() )
@@ -585,7 +585,7 @@ bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &samp
 				// open time so that non-interpolable objects appear in the right
 				// position relative to non-blurred objects.
 				Context::Scope frameScope( frameContext );
-				std::vector<float> tempTimes = {};
+				IECoreScenePreview::Renderer::SampleTimes tempTimes = {};
 
 				// Use the hash from the shutter samples. This is technically incorrect, since we are going
 				// to evaluate the object on-frame, and the on-frame sample may not have been included in the
@@ -1306,7 +1306,7 @@ struct LocationOutput
 			return m_renderer;
 		}
 
-		void deformationMotionTimes( std::vector<float> &times )
+		void deformationMotionTimes( IECoreScenePreview::Renderer::SampleTimes &times )
 		{
 			GafferScene::Private::RendererAlgo::deformationMotionTimes( m_options, m_attributes.get(), times );
 		}
@@ -1372,27 +1372,27 @@ struct LocationOutput
 
 		void updateTransform( const ScenePlug *scene )
 		{
-			vector<float> sampleTimes;
+			IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 			GafferScene::Private::RendererAlgo::transformMotionTimes( m_options, m_attributes.get(), sampleTimes );
-			vector<M44f> samples;
+			IECoreScenePreview::Renderer::TransformSamples samples;
 			GafferScene::Private::RendererAlgo::transformSamples( scene->transformPlug(), sampleTimes, samples );
 
 			if( samples.size() == 1 )
 			{
-				for( vector<M44f>::iterator it = m_transformSamples.begin(), eIt = m_transformSamples.end(); it != eIt; ++it )
+				for( auto &sample : m_transformSamples )
 				{
-					*it = samples.front() * *it;
+					sample = samples.front() * sample;
 				}
 			}
 			else
 			{
-				vector<M44f> updatedTransformSamples;
+				IECoreScenePreview::Renderer::TransformSamples updatedTransformSamples;
 				updatedTransformSamples.reserve( samples.size() );
 
-				vector<float> updatedTransformTimes;
+				IECoreScenePreview::Renderer::SampleTimes updatedTransformTimes;
 				updatedTransformTimes.reserve( samples.size() );
 
-				vector<M44f>::const_iterator s = samples.begin();
+				auto s = samples.begin();
 				for( const float sampleTime : sampleTimes )
 				{
 					updatedTransformSamples.push_back( *s++ * transform( sampleTime ) );
@@ -1415,14 +1415,14 @@ struct LocationOutput
 				return m_transformSamples[0];
 			}
 
-			vector<float>::const_iterator t1 = lower_bound( m_transformTimes.begin(), m_transformTimes.end(), time );
+			auto t1 = lower_bound( m_transformTimes.begin(), m_transformTimes.end(), time );
 			if( t1 == m_transformTimes.begin() || *t1 == time )
 			{
 				return m_transformSamples[t1 - m_transformTimes.begin()];
 			}
 			else
 			{
-				vector<float>::const_iterator t0 = t1 - 1;
+				auto t0 = t1 - 1;
 				const float l = lerpfactor( time, *t0, *t1 );
 				const M44f &s0 = m_transformSamples[t0 - m_transformTimes.begin()];
 				const M44f &s1 = m_transformSamples[t1 - m_transformTimes.begin()];
@@ -1439,8 +1439,8 @@ struct LocationOutput
 		const GafferScene::Private::RendererAlgo::RenderSets &m_renderSets;
 		const ScenePlug::ScenePath &m_root;
 
-		std::vector<M44f> m_transformSamples;
-		std::vector<float> m_transformTimes;
+		IECoreScenePreview::Renderer::TransformSamples m_transformSamples;
+		IECoreScenePreview::Renderer::SampleTimes m_transformTimes;
 
 };
 
@@ -1463,10 +1463,10 @@ struct CameraOutput : public LocationOutput
 		if( ( cameraMatch & IECore::PathMatcher::ExactMatch ) && purposeIncluded() )
 		{
 			// Sample cameras and apply globals
-			vector<float> sampleTimes;
+			IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 			deformationMotionTimes( sampleTimes );
 
-			vector<ConstObjectPtr> samples;
+			std::vector<ConstObjectPtr> samples;
 			GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes, samples );
 
 			vector<ConstCameraPtr> cameraSamples; cameraSamples.reserve( samples.size() );
@@ -1506,7 +1506,7 @@ struct CameraOutput : public LocationOutput
 				}
 				else
 				{
-					vector<const Camera *> rawCameraSamples; rawCameraSamples.reserve( cameraSamples.size() );
+					IECoreScenePreview::Renderer::CameraSamples rawCameraSamples; rawCameraSamples.reserve( cameraSamples.size() );
 					for( auto &c : cameraSamples )
 					{
 						rawCameraSamples.push_back( c.get() );
@@ -1654,7 +1654,7 @@ struct ObjectOutput : public LocationOutput
 			return true;
 		}
 
-		vector<float> sampleTimes;
+		IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 		deformationMotionTimes( sampleTimes );
 
 		vector<ConstObjectPtr> samples;

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1466,7 +1466,7 @@ struct CameraOutput : public LocationOutput
 			IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 			deformationMotionTimes( sampleTimes );
 
-			std::vector<ConstObjectPtr> samples;
+			IECoreScenePreview::Renderer::ObjectSamples samples;
 			GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes, samples );
 
 			IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( samples.size() );
@@ -1652,7 +1652,7 @@ struct ObjectOutput : public LocationOutput
 		IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 		deformationMotionTimes( sampleTimes );
 
-		vector<ConstObjectPtr> samples;
+		IECoreScenePreview::Renderer::ObjectSamples samples;
 		GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes, samples );
 		if( !samples.size() )
 		{

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -474,7 +474,7 @@ bool transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::
 	return true;
 }
 
-bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, std::vector<IECore::ConstObjectPtr> &samples, IECore::MurmurHash *hash )
+bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::ObjectSamples &samples, IECore::MurmurHash *hash )
 {
 	std::vector< IECore::MurmurHash > sampleHashes;
 	if( !sampleTimes.size() )
@@ -1469,7 +1469,7 @@ struct CameraOutput : public LocationOutput
 			std::vector<ConstObjectPtr> samples;
 			GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes, samples );
 
-			vector<ConstCameraPtr> cameraSamples; cameraSamples.reserve( samples.size() );
+			IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( samples.size() );
 			for( const auto &sample : samples )
 			{
 				if( auto cameraSample = runTimeCast<const Camera>( sample.get() ) )
@@ -1506,14 +1506,9 @@ struct CameraOutput : public LocationOutput
 				}
 				else
 				{
-					IECoreScenePreview::Renderer::CameraSamples rawCameraSamples; rawCameraSamples.reserve( cameraSamples.size() );
-					for( auto &c : cameraSamples )
-					{
-						rawCameraSamples.push_back( c.get() );
-					}
 					objectInterface = renderer()->camera(
 						name( path ),
-						rawCameraSamples,
+						cameraSamples,
 						sampleTimes,
 						attributesInterface().get()
 					);
@@ -1680,13 +1675,7 @@ struct ObjectOutput : public LocationOutput
 		else
 		{
 			assert( sampleTimes.size() == samples.size() );
-			/// \todo Can we rejig things so this conversion isn't necessary?
-			vector<const Object *> objectsVector; objectsVector.reserve( samples.size() );
-			for( const auto &sample : samples )
-			{
-				objectsVector.push_back( sample.get() );
-			}
-			objectInterface = renderer()->object( name( path ), objectsVector, sampleTimes, attributesInterface.get() );
+			objectInterface = renderer()->object( name( path ), samples, sampleTimes, attributesInterface.get() );
 		}
 
 		if( objectInterface )

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -380,7 +380,7 @@ bool deformationMotionTimes( const RenderOptions &renderOptions, const CompoundO
 
 bool transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::TransformSamples &samples, IECore::MurmurHash *hash )
 {
-	std::vector< IECore::MurmurHash > sampleHashes;
+	IECoreScenePreview::Renderer::Samples<IECore::MurmurHash> sampleHashes;
 	if( !sampleTimes.size() )
 	{
 		sampleHashes.push_back( transformPlug->hash() );
@@ -476,7 +476,7 @@ bool transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::
 
 bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::ObjectSamples &samples, IECore::MurmurHash *hash )
 {
-	std::vector< IECore::MurmurHash > sampleHashes;
+	IECoreScenePreview::Renderer::Samples<IECore::MurmurHash> sampleHashes;
 	if( !sampleTimes.size() )
 	{
 		sampleHashes.push_back( objectPlug->hash() );

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -378,7 +378,75 @@ bool deformationMotionTimes( const RenderOptions &renderOptions, const CompoundO
 	return motionTimes( renderOptions.deformationBlur, renderOptions.shutter, attributes, g_deformationBlurAttributeName, g_deformationBlurSegmentsAttributeName, times );
 }
 
-bool transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::TransformSamples &samples, IECore::MurmurHash *hash )
+M44f SampledTransform::transformAtTime( float time ) const
+{
+	if( samples.empty() )
+	{
+		return M44f();
+	}
+	else if( samples.size() == 1 )
+	{
+		return samples[0];
+	}
+
+	auto t1 = lower_bound( sampleTimes.begin(), sampleTimes.end(), time );
+	if( t1 == sampleTimes.begin() || *t1 == time )
+	{
+		return samples[t1 - sampleTimes.begin()];
+	}
+	else
+	{
+		auto t0 = t1 - 1;
+		const float l = lerpfactor( time, *t0, *t1 );
+		const M44f &s0 = samples[t0 - sampleTimes.begin()];
+		const M44f &s1 = samples[t1 - sampleTimes.begin()];
+		M44f result;
+		LinearInterpolator<M44f>()( s0, s1, l, result );
+		return result;
+	}
+}
+
+void SampledTransform::concatenate( const SampledTransform &child )
+{
+	if( child.samples.empty() )
+	{
+		return;
+	}
+
+	if( samples.empty() )
+	{
+		*this = child;
+		return;
+	}
+
+	if( child.samples.size() == 1 )
+	{
+		for( auto &sample : samples )
+		{
+			sample = child.samples.front() * sample;
+		}
+	}
+	else
+	{
+		IECoreScenePreview::Renderer::TransformSamples updatedSamples;
+		updatedSamples.reserve( child.samples.size() );
+
+		IECoreScenePreview::Renderer::SampleTimes updatedSampleTimes;
+		updatedSampleTimes.reserve( child.samples.size() );
+
+		auto s = child.samples.begin();
+		for( const float sampleTime : child.sampleTimes )
+		{
+			updatedSamples.push_back( *s++ * transformAtTime( sampleTime ) );
+			updatedSampleTimes.push_back( sampleTime );
+		}
+
+		samples = updatedSamples;
+		sampleTimes = updatedSampleTimes;
+	}
+}
+
+std::optional<SampledTransform> transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECore::MurmurHash *hash )
 {
 	IECoreScenePreview::Renderer::Samples<IECore::MurmurHash> sampleHashes;
 	if( !sampleTimes.size() )
@@ -425,44 +493,49 @@ bool transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::
 
 		if( combinedHash == *hash )
 		{
-			return false;
+			return std::nullopt;
 		}
 	}
 
-	samples.clear();
+	SampledTransform result;
 
 	if( !sampleTimes.size() )
 	{
 		// No shutter to sample over
-		samples.push_back( transformPlug->getValue( &sampleHashes[0]) );
+		result.samples.push_back( transformPlug->getValue( &sampleHashes[0]) );
+		result.sampleTimes.push_back( Context::current()->getFrame() );
 	}
 	else if( sampleHashes.size() == 1 )
 	{
 		// We have a shutter, but all the samples hash the same, so just evaluate one
 		Context::EditableScope timeContext( Context::current() );
 		timeContext.setFrame( sampleTimes[0] );
-		samples.push_back( transformPlug->getValue( &sampleHashes[0]) );
+		result.samples.push_back( transformPlug->getValue( &sampleHashes[0]) );
+		result.sampleTimes.push_back( sampleTimes[0] );
 	}
 	else
 	{
 		// Motion case
 		Context::EditableScope timeContext( Context::current() );
 		bool moving = false;
-		samples.reserve( sampleTimes.size() );
+		result.samples.reserve( sampleTimes.size() );
+		result.sampleTimes.reserve( sampleTimes.size() );
 		for( size_t i = 0; i < sampleTimes.size(); i++ )
 		{
 			timeContext.setFrame( sampleTimes[i] );
 			const M44f m = transformPlug->getValue( &sampleHashes[i] );
-			if( !moving && !samples.empty() && m != samples.front() )
+			if( !moving && !result.samples.empty() && m != result.samples.front() )
 			{
 				moving = true;
 			}
-			samples.push_back( m );
+			result.samples.push_back( m );
+			result.sampleTimes.push_back( sampleTimes[i] );
 		}
 
 		if( !moving )
 		{
-			samples.resize( 1 );
+			result.samples.resize( 1 );
+			result.sampleTimes.resize( 1 );
 		}
 	}
 
@@ -471,10 +544,10 @@ bool transformSamples( const M44fPlug *transformPlug, const IECoreScenePreview::
 		*hash = combinedHash;
 	}
 
-	return true;
+	return result;
 }
 
-bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECoreScenePreview::Renderer::ObjectSamples &samples, IECore::MurmurHash *hash )
+std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECore::MurmurHash *hash )
 {
 	IECoreScenePreview::Renderer::Samples<IECore::MurmurHash> sampleHashes;
 	if( !sampleTimes.size() )
@@ -523,20 +596,22 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 
 		if( combinedHash == *hash )
 		{
-			return false;
+			return std::nullopt;
 		}
 	}
 
-	samples.clear();
+	SampledObject result;
 
 	if( sampleHashes.size() == 1 )
 	{
 		// Static case
 		ConstObjectPtr object;
+		float sampleTime;
 		if( !sampleTimes.size() )
 		{
 			// No shutter, just hash on frame
 			object = objectPlug->getValue( &sampleHashes[0]);
+			sampleTime = Context::current()->getFrame();
 		}
 		else
 		{
@@ -544,6 +619,7 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 			Context::EditableScope timeContext( Context::current() );
 			timeContext.setFrame( sampleTimes[0] );
 			object = objectPlug->getValue( &sampleHashes[0]);
+			sampleTime = sampleTimes[0];
 		}
 
 		if(
@@ -552,7 +628,8 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 			runTimeCast<const CoordinateSystem>( object.get() )
 		)
 		{
-			samples.push_back( object.get() );
+			result.samples.push_back( object.get() );
+			result.sampleTimes.push_back( sampleTime );
 		}
 	}
 	else
@@ -561,7 +638,7 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 		const Context *frameContext = Context::current();
 		Context::EditableScope timeContext( frameContext );
 
-		samples.reserve( sampleTimes.size() );
+		result.samples.reserve( sampleTimes.size() );
 		for( size_t i = 0; i < sampleTimes.size(); i++ )
 		{
 			timeContext.setFrame( sampleTimes[i] );
@@ -573,7 +650,8 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 				runTimeCast<const Camera>( object.get() )
 			)
 			{
-				samples.push_back( object.get() );
+				result.samples.push_back( object.get() );
+				result.sampleTimes.push_back( sampleTimes[i] );
 			}
 			else if(
 				runTimeCast<const VisibleRenderable>( object.get() ) ||
@@ -585,7 +663,6 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 				// open time so that non-interpolable objects appear in the right
 				// position relative to non-blurred objects.
 				Context::Scope frameScope( frameContext );
-				IECoreScenePreview::Renderer::SampleTimes tempTimes = {};
 
 				// Use the hash from the shutter samples. This is technically incorrect, since we are going
 				// to evaluate the object on-frame, and the on-frame sample may not have been included in the
@@ -604,7 +681,7 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 					*hash = combinedHash;
 				}
 
-				return objectSamples( objectPlug, tempTimes, samples );
+				return objectSamples( objectPlug, {} );
 			}
 			else
 			{
@@ -620,7 +697,7 @@ bool objectSamples( const ObjectPlug *objectPlug, const IECoreScenePreview::Rend
 		*hash = combinedHash;
 	}
 
-	return true;
+	return result;
 }
 
 } // namespace RendererAlgo
@@ -1246,7 +1323,6 @@ struct LocationOutput
 	LocationOutput( IECoreScenePreview::Renderer *renderer, const GafferScene::Private::RendererAlgo::RenderOptions &renderOptions, const GafferScene::Private::RendererAlgo::RenderSets &renderSets, const ScenePlug::ScenePath &root, const ScenePlug *scene )
 		:	m_renderer( renderer ), m_options( renderOptions ), m_attributes( root.empty() ? SceneAlgo::globalAttributes( renderOptions.globals.get() ) : new CompoundObject ), m_renderSets( renderSets ), m_root( root )
 	{
-		m_transformSamples.push_back( M44f() );
 	}
 
 	bool operator()( const ScenePlug *scene, const ScenePlug::ScenePath &path )
@@ -1329,18 +1405,11 @@ struct LocationOutput
 
 		void applyTransform( IECoreScenePreview::Renderer::ObjectInterface *objectInterface )
 		{
-			if( !m_transformSamples.size() )
+			if( !m_fullTransform.samples.size() )
 			{
 				return;
 			}
-			else if( !m_transformTimes.size() )
-			{
-				objectInterface->transform( m_transformSamples[0] );
-			}
-			else
-			{
-				objectInterface->transform( m_transformSamples, m_transformTimes );
-			}
+			objectInterface->transform( m_fullTransform.samples, m_fullTransform.sampleTimes );
 		}
 
 	private :
@@ -1374,62 +1443,8 @@ struct LocationOutput
 		{
 			IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 			GafferScene::Private::RendererAlgo::transformMotionTimes( m_options, m_attributes.get(), sampleTimes );
-			IECoreScenePreview::Renderer::TransformSamples samples;
-			GafferScene::Private::RendererAlgo::transformSamples( scene->transformPlug(), sampleTimes, samples );
-
-			if( samples.size() == 1 )
-			{
-				for( auto &sample : m_transformSamples )
-				{
-					sample = samples.front() * sample;
-				}
-			}
-			else
-			{
-				IECoreScenePreview::Renderer::TransformSamples updatedTransformSamples;
-				updatedTransformSamples.reserve( samples.size() );
-
-				IECoreScenePreview::Renderer::SampleTimes updatedTransformTimes;
-				updatedTransformTimes.reserve( samples.size() );
-
-				auto s = samples.begin();
-				for( const float sampleTime : sampleTimes )
-				{
-					updatedTransformSamples.push_back( *s++ * transform( sampleTime ) );
-					updatedTransformTimes.push_back( sampleTime );
-				}
-
-				m_transformSamples = updatedTransformSamples;
-				m_transformTimes = updatedTransformTimes;
-			}
-		}
-
-		M44f transform( float time )
-		{
-			if( m_transformSamples.empty() )
-			{
-				return M44f();
-			}
-			if( m_transformSamples.size() == 1 )
-			{
-				return m_transformSamples[0];
-			}
-
-			auto t1 = lower_bound( m_transformTimes.begin(), m_transformTimes.end(), time );
-			if( t1 == m_transformTimes.begin() || *t1 == time )
-			{
-				return m_transformSamples[t1 - m_transformTimes.begin()];
-			}
-			else
-			{
-				auto t0 = t1 - 1;
-				const float l = lerpfactor( time, *t0, *t1 );
-				const M44f &s0 = m_transformSamples[t0 - m_transformTimes.begin()];
-				const M44f &s1 = m_transformSamples[t1 - m_transformTimes.begin()];
-				M44f result;
-				LinearInterpolator<M44f>()( s0, s1, l, result );
-				return result;
-			}
+			auto sampledTransform = GafferScene::Private::RendererAlgo::transformSamples( scene->transformPlug(), sampleTimes );
+			m_fullTransform.concatenate( *sampledTransform );
 		}
 
 		IECoreScenePreview::Renderer *m_renderer;
@@ -1439,8 +1454,7 @@ struct LocationOutput
 		const GafferScene::Private::RendererAlgo::RenderSets &m_renderSets;
 		const ScenePlug::ScenePath &m_root;
 
-		IECoreScenePreview::Renderer::TransformSamples m_transformSamples;
-		IECoreScenePreview::Renderer::SampleTimes m_transformTimes;
+		Private::RendererAlgo::SampledTransform m_fullTransform;
 
 };
 
@@ -1467,10 +1481,10 @@ struct CameraOutput : public LocationOutput
 			deformationMotionTimes( sampleTimes );
 
 			IECoreScenePreview::Renderer::ObjectSamples samples;
-			GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes, samples );
+			const auto sampledObject = GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes );
 
-			IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( samples.size() );
-			for( const auto &sample : samples )
+			IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( sampledObject->samples.size() );
+			for( const auto &sample : sampledObject->samples )
 			{
 				if( auto cameraSample = runTimeCast<const Camera>( sample.get() ) )
 				{
@@ -1482,7 +1496,7 @@ struct CameraOutput : public LocationOutput
 
 			// Create ObjectInterface
 
-			if( !samples.size() || cameraSamples.size() != samples.size() )
+			if( !sampledObject->samples.size() || cameraSamples.size() != sampledObject->samples.size() )
 			{
 				IECore::msg(
 					IECore::Msg::Warning,
@@ -1495,24 +1509,9 @@ struct CameraOutput : public LocationOutput
 			}
 			else
 			{
-				IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface;
-				if( cameraSamples.size() == 1 )
-				{
-					objectInterface = renderer()->camera(
-						name( path ),
-						cameraSamples[0].get(),
-						attributesInterface().get()
-					);
-				}
-				else
-				{
-					objectInterface = renderer()->camera(
-						name( path ),
-						cameraSamples,
-						sampleTimes,
-						attributesInterface().get()
-					);
-				}
+				IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface = renderer()->camera(
+					name( path ), cameraSamples, sampledObject->sampleTimes, attributesInterface().get()
+				);
 
 				if( objectInterface )
 				{
@@ -1652,31 +1651,25 @@ struct ObjectOutput : public LocationOutput
 		IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 		deformationMotionTimes( sampleTimes );
 
-		IECoreScenePreview::Renderer::ObjectSamples samples;
-		GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes, samples );
-		if( !samples.size() )
+		auto sampledObject = GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes );
+		if( !sampledObject->samples.size() )
 		{
 			return true;
 		}
 
 		IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface;
 		IECoreScenePreview::Renderer::AttributesInterfacePtr attributesInterface = this->attributesInterface();
-		if( samples.size() == 1 )
+		if( sampledObject->samples.size() == 1 )
 		{
-			ConstObjectPtr sample = samples[0];
-			if( auto capsule = runTimeCast<const Capsule>( sample.get() ) )
+			if( auto capsule = runTimeCast<const Capsule>( sampledObject->samples[0].get() ) )
 			{
 				CapsulePtr capsuleCopy = capsule->copy();
 				capsuleCopy->setRenderOptions( renderOptions() );
-				sample = capsuleCopy;
+				sampledObject->samples[0] = capsuleCopy;
 			}
-			objectInterface = renderer()->object( name( path ), sample.get(), attributesInterface.get() );
 		}
-		else
-		{
-			assert( sampleTimes.size() == samples.size() );
-			objectInterface = renderer()->object( name( path ), samples, sampleTimes, attributesInterface.get() );
-		}
+
+		objectInterface = renderer()->object( name( path ), sampledObject->samples, sampledObject->sampleTimes, attributesInterface.get() );
 
 		if( objectInterface )
 		{

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -145,10 +145,10 @@ IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject1( Renderer &rend
 
 IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject2( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes, const Renderer::AttributesInterface *attributes )
 {
-	std::vector<const IECore::Object *> samples;
+	IECoreScenePreview::Renderer::ObjectSamples samples;
 	container_utils::extend_container( samples, pythonSamples );
 
-	std::vector<float> times;
+	IECoreScenePreview::Renderer::SampleTimes times;
 	container_utils::extend_container( times, pythonTimes );
 
 	return renderer.object( name, samples, times, attributes );
@@ -162,10 +162,10 @@ IECoreScenePreview::Renderer::ObjectInterfacePtr rendererCamera1( Renderer &rend
 
 IECoreScenePreview::Renderer::ObjectInterfacePtr rendererCamera2( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes, const Renderer::AttributesInterface *attributes )
 {
-	std::vector<const IECoreScene::Camera *> samples;
+	IECoreScenePreview::Renderer::CameraSamples samples;
 	container_utils::extend_container( samples, pythonSamples );
 
-	std::vector<float> times;
+	IECoreScenePreview::Renderer::SampleTimes times;
 	container_utils::extend_container( times, pythonTimes );
 
 	return renderer.camera( name, samples, times, attributes );
@@ -185,10 +185,10 @@ void objectInterfaceTransform1( Renderer::ObjectInterface &objectInterface, cons
 
 void objectInterfaceTransform2( Renderer::ObjectInterface &objectInterface, object pythonSamples, object pythonTimes )
 {
-	std::vector<Imath::M44f> samples;
+	IECoreScenePreview::Renderer::TransformSamples samples;
 	container_utils::extend_container( samples, pythonSamples );
 
-	std::vector<float> times;
+	IECoreScenePreview::Renderer::SampleTimes times;
 	container_utils::extend_container( times, pythonTimes );
 
 	return objectInterface.transform( samples, times );

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -92,7 +92,7 @@ object objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, object python
 	boost::python::container_utils::extend_container( sampleTimes, pythonSampleTimes );
 
 	bool result;
-	std::vector<IECore::ConstObjectPtr> samples;
+	IECoreScenePreview::Renderer::ObjectSamples samples;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
 		result = GafferScene::Private::RendererAlgo::objectSamples( &objectPlug, sampleTimes, samples, hash );

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -86,37 +86,88 @@ std::shared_ptr<RenderManifest> interactiveRenderRenderManifestWrapper( Interact
 	return std::const_pointer_cast<RenderManifest>( r.renderManifest() );
 }
 
+Private::RendererAlgo::SampledObject *sampledObjectConstructor( list samples, list sampleTimes )
+{
+	Private::RendererAlgo::SampledObject result;
+	boost::python::container_utils::extend_container( result.samples, samples );
+	boost::python::container_utils::extend_container( result.sampleTimes, sampleTimes );
+	return new Private::RendererAlgo::SampledObject( result );
+}
+
+
+list sampledObjectSamples( const Private::RendererAlgo::SampledObject &sampledObject )
+{
+	list result;
+	for( const auto &x : sampledObject.samples )
+	{
+		result.append( boost::const_pointer_cast<Object>( x ) );
+	}
+	return result;
+}
+
+list sampledObjectSampleTimes( const Private::RendererAlgo::SampledObject &sampledObject )
+{
+	list result;
+	for( auto x : sampledObject.sampleTimes )
+	{
+		result.append( x );
+	}
+	return result;
+}
+
 object objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, object pythonSampleTimes, IECore::MurmurHash *hash, bool copy )
 {
 	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 	boost::python::container_utils::extend_container( sampleTimes, pythonSampleTimes );
 
-	bool result;
-	IECoreScenePreview::Renderer::ObjectSamples samples;
+	std::optional<GafferScene::Private::RendererAlgo::SampledObject> sampledObject;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
-		result = GafferScene::Private::RendererAlgo::objectSamples( &objectPlug, sampleTimes, samples, hash );
+		sampledObject = GafferScene::Private::RendererAlgo::objectSamples( &objectPlug, sampleTimes, hash );
 	}
 
-	if( !result )
+	if( !sampledObject )
 	{
 		return object();
 	}
 
-	list pythonSamples;
-	for( auto &s : samples )
+	if( copy )
 	{
-		if( copy )
+		for( auto &sample : sampledObject->samples )
 		{
-			pythonSamples.append( s->copy() );
-		}
-		else
-		{
-			pythonSamples.append( boost::const_pointer_cast<IECore::Object>( s ) );
+			sample = sample->copy();
 		}
 	}
 
-	return pythonSamples;
+	return object( *sampledObject );
+}
+
+Private::RendererAlgo::SampledTransform *sampledTransformConstructor( list samples, list sampleTimes )
+{
+	Private::RendererAlgo::SampledTransform result;
+	boost::python::container_utils::extend_container( result.samples, samples );
+	boost::python::container_utils::extend_container( result.sampleTimes, sampleTimes );
+	return new Private::RendererAlgo::SampledTransform( result );
+}
+
+list sampledTransformSamples( const Private::RendererAlgo::SampledTransform &sampledTransform )
+{
+	list result;
+	for( const auto &x : sampledTransform.samples )
+	{
+		result.append( x );
+	}
+	return result;
+}
+
+list sampledTransformSampleTimes( const Private::RendererAlgo::SampledTransform &sampledTransform )
+{
+	list result;
+	for( auto x : sampledTransform.sampleTimes )
+	{
+		result.append( x );
+	}
+	return result;
 }
 
 object transformSamplesWrapper( const Gaffer::M44fPlug &transformPlug, object pythonSampleTimes, IECore::MurmurHash *hash )
@@ -124,25 +175,13 @@ object transformSamplesWrapper( const Gaffer::M44fPlug &transformPlug, object py
 	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 	boost::python::container_utils::extend_container( sampleTimes, pythonSampleTimes );
 
-	bool result;
-	IECoreScenePreview::Renderer::TransformSamples samples;
+	std::optional<GafferScene::Private::RendererAlgo::SampledTransform> sampledTransform;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
-		result = GafferScene::Private::RendererAlgo::transformSamples( &transformPlug, sampleTimes, samples, hash );
+		sampledTransform = GafferScene::Private::RendererAlgo::transformSamples( &transformPlug, sampleTimes, hash );
 	}
 
-	if( !result )
-	{
-		return object();
-	}
-
-	list pythonSamples;
-	for( auto &s : samples )
-	{
-		pythonSamples.append( s );
-	}
-
-	return pythonSamples;
+	return sampledTransform ? object( *sampledTransform ) : object();
 }
 
 void outputCamerasWrapper( const ScenePlug &scene, const GafferScene::Private::RendererAlgo::RenderOptions &renderOptions, const GafferScene::Private::RendererAlgo::RenderSets &renderSets, IECoreScenePreview::Renderer &renderer )
@@ -233,6 +272,19 @@ void GafferSceneModule::bindRender()
 				.def_readwrite( "shutter", &GafferScene::Private::RendererAlgo::RenderOptions::shutter )
 				.def_readwrite( "includedPurposes", &GafferScene::Private::RendererAlgo::RenderOptions::includedPurposes )
 				.def( self == self )
+			;
+
+			class_<GafferScene::Private::RendererAlgo::SampledTransform>( "SampledTransform" )
+				.def( "__init__", make_constructor( sampledTransformConstructor, default_call_policies() ) )
+				.add_property( "samples", &sampledTransformSamples )
+				.add_property( "sampleTimes", &sampledTransformSampleTimes )
+				.def( "concatenate", &GafferScene::Private::RendererAlgo::SampledTransform::concatenate )
+			;
+
+			class_<GafferScene::Private::RendererAlgo::SampledObject>( "SampledObject" )
+				.def( "__init__", make_constructor( sampledObjectConstructor, default_call_policies() ) )
+				.add_property( "samples", &sampledObjectSamples )
+				.add_property( "sampleTimes", &sampledObjectSampleTimes )
 			;
 
 			def( "objectSamples", &objectSamplesWrapper, ( arg( "objectPlug" ), arg( "sampleTimes" ), arg( "hash" ) = object(), arg( "_copy" ) = true ) );

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<RenderManifest> interactiveRenderRenderManifestWrapper( Interact
 
 object objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, object pythonSampleTimes, IECore::MurmurHash *hash, bool copy )
 {
-	std::vector<float> sampleTimes;
+	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 	boost::python::container_utils::extend_container( sampleTimes, pythonSampleTimes );
 
 	bool result;
@@ -121,11 +121,11 @@ object objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, object python
 
 object transformSamplesWrapper( const Gaffer::M44fPlug &transformPlug, object pythonSampleTimes, IECore::MurmurHash *hash )
 {
-	std::vector<float> sampleTimes;
+	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 	boost::python::container_utils::extend_container( sampleTimes, pythonSampleTimes );
 
 	bool result;
-	std::vector<M44f> samples;
+	IECoreScenePreview::Renderer::TransformSamples samples;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
 		result = GafferScene::Private::RendererAlgo::transformSamples( &transformPlug, sampleTimes, samples, hash );

--- a/src/IECoreArnold/CameraAlgo.cpp
+++ b/src/IECoreArnold/CameraAlgo.cpp
@@ -233,10 +233,10 @@ float apertureSize( const IECoreScene::Camera *camera )
 }
 
 template<typename F>
-auto parameterSamples( const std::vector<const IECoreScene::Camera *> &cameraSamples, F &&parameterFunction )
+auto parameterSamples( const IECoreArnold::CameraAlgo::CameraSamples &cameraSamples, F &&parameterFunction )
 {
 	using SampleType = std::invoke_result_t<F, const IECoreScene::Camera *>;
-	std::vector<SampleType> result;
+	IECoreScenePreview::Renderer::Samples<SampleType> result;
 	result.reserve( cameraSamples.size() );
 	for( const auto &camera : cameraSamples )
 	{
@@ -250,7 +250,7 @@ auto parameterSamples( const std::vector<const IECoreScene::Camera *> &cameraSam
 	return result;
 }
 
-void setAnimatedFloat( AtNode *node, AtString name, const std::vector<const IECoreScene::Camera *> &cameraSamples, float (*parameterFunction)( const IECoreScene::Camera * ) )
+void setAnimatedFloat( AtNode *node, AtString name, const IECoreArnold::CameraAlgo::CameraSamples &cameraSamples, float (*parameterFunction)( const IECoreScene::Camera * ) )
 {
 	const auto samples = parameterSamples( cameraSamples, parameterFunction );
 	if( samples.size() > 1 )
@@ -282,7 +282,7 @@ AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, AtUniverse *univ
 	return result;
 }
 
-AtNode *CameraAlgo::convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *CameraAlgo::convert( const CameraSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	AtNode *result = convertCommon( samples[0], universe, nodeName, parentNode, messageContext );
 	if( samples[0]->getProjection()=="perspective" )

--- a/src/IECoreArnold/CameraAlgo.cpp
+++ b/src/IECoreArnold/CameraAlgo.cpp
@@ -58,7 +58,7 @@ using namespace IECoreArnold;
 namespace
 {
 
-NodeAlgo::ConverterDescription<Camera> g_description( CameraAlgo::convert, CameraAlgo::convert );
+NodeAlgo::ConverterDescription<Camera> g_description( CameraAlgo::convert );
 
 const AtString g_perspCameraArnoldString("persp_camera");
 const AtString g_orthoCameraArnoldString("ortho_camera");
@@ -128,8 +128,8 @@ void setShutterCurveParameter( AtNode *camera, const IECore::Data *value, const 
 	AiNodeSetArray( camera, g_shutterCurveArnoldString, array );
 }
 
-// Performs the part of the conversion that is shared by both animated and non-animated cameras.
-AtNode *convertCommon( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+// Converts the parts of the camera that can't be animated in Arnold.
+AtNode *convertStatic( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	// Use projection to decide what sort of camera node to create
 	const std::string projection = camera->getProjection();
@@ -265,26 +265,9 @@ void setAnimatedFloat( AtNode *node, AtString name, const IECoreArnold::CameraAl
 
 } // namespace
 
-AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
-{
-	AtNode *result = convertCommon( camera, universe, nodeName, parentNode, messageContext );
-	if( camera->getProjection()=="perspective" )
-	{
-		AiNodeSetFlt( result, g_fovArnoldString, fieldOfView( camera ) );
-		AiNodeSetFlt( result, g_apertureSizeArnoldString, apertureSize( camera ) );
-		AiNodeSetFlt( result, g_focusDistanceArnoldString, camera->getFocusDistance() );
-	}
-
-	const Imath::Box2f sw = screenWindow( camera );
-	AiNodeSetVec2( result, g_screenWindowMinArnoldString, sw.min.x, sw.min.y );
-	AiNodeSetVec2( result, g_screenWindowMaxArnoldString, sw.max.x, sw.max.y );
-
-	return result;
-}
-
 AtNode *CameraAlgo::convert( const CameraSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *result = convertCommon( samples[0], universe, nodeName, parentNode, messageContext );
+	AtNode *result = convertStatic( samples[0], universe, nodeName, parentNode, messageContext );
 	if( samples[0]->getProjection()=="perspective" )
 	{
 		setAnimatedFloat( result, g_fovArnoldString, samples, fieldOfView );

--- a/src/IECoreArnold/CurvesAlgo.cpp
+++ b/src/IECoreArnold/CurvesAlgo.cpp
@@ -215,39 +215,6 @@ AtNode *convertCommon( const IECoreScene::CurvesPrimitive *curves, AtUniverse *u
 
 }
 
-AtNode *convert( const IECoreScene::CurvesPrimitive *curves, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
-{
-	// Arnold does not support Vertex PrimitiveVariables (see `ShapeAlgo::convertPrimitiveVariable()`),
-	// so we must resample unless Vertex and Varying have equivalent variable sizes.
-	ConstCurvesPrimitivePtr resampledCurves = ::resampleVertexToVarying( curves, messageContext );
-
-	AtNode *result = convertCommon( resampledCurves.get(), universe, nodeName, parentNode, messageContext );
-
-	if( !ShapeAlgo::convertP( resampledCurves.get(), result, g_pointsArnoldString, messageContext ) )
-	{
-		/// \todo Would be nice to refactor `ObjectAlgo::convert()` to return `unique_ptr<AtNode>`
-		/// so we don't do manual deletion like this.
-		AiNodeDestroy( result );
-		return nullptr;
-	}
-
-	ShapeAlgo::convertRadius( resampledCurves.get(), result, messageContext );
-
-	// Convert "N" to orientations
-
-	if( const V3fVectorData *n = resampledCurves.get()->variableData<V3fVectorData>( "N", PrimitiveVariable::Vertex ) )
-	{
-		AiNodeSetStr( result, g_modeArnoldString, g_orientedArnoldString );
-		AiNodeSetArray(
-			result,
-			g_orientationsArnoldString,
-			AiArrayConvert( n->readable().size(), 1, AI_TYPE_VECTOR, (void *)&( n->readable()[0] ) )
-		);
-	}
-
-	return result;
-}
-
 AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	// Arnold does not support Vertex PrimitiveVariables (see `ShapeAlgo::convertPrimitiveVariable()`),
@@ -297,6 +264,6 @@ AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::
 	return result;
 }
 
-NodeAlgo::ConverterDescription<CurvesPrimitive> g_description( ::convert, ::convert );
+NodeAlgo::ConverterDescription<CurvesPrimitive> g_description( ::convert );
 
 } // namespace

--- a/src/IECoreArnold/CurvesAlgo.cpp
+++ b/src/IECoreArnold/CurvesAlgo.cpp
@@ -248,14 +248,14 @@ AtNode *convert( const IECoreScene::CurvesPrimitive *curves, AtUniverse *univers
 	return result;
 }
 
-AtNode *convert( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	// Arnold does not support Vertex PrimitiveVariables (see `ShapeAlgo::convertPrimitiveVariable()`),
 	// so we must resample unless Vertex and Varying have equivalent variable sizes.
-	std::vector<ConstCurvesPrimitivePtr> updatedSamples;
-	std::vector<const Primitive *> primitiveSamples;
+	IECoreScenePreview::Renderer::Samples<ConstCurvesPrimitivePtr> updatedSamples;
+	ShapeAlgo::PrimitiveSamples primitiveSamples;
 	// Also convert "N" to orientations
-	std::vector<const Data *> nSamples;
+	IECoreScenePreview::Renderer::Samples<const Data *> nSamples;
 	updatedSamples.reserve( samples.size() );
 	primitiveSamples.reserve( samples.size() );
 	nSamples.reserve( samples.size() );

--- a/src/IECoreArnold/MeshAlgo.cpp
+++ b/src/IECoreArnold/MeshAlgo.cpp
@@ -404,11 +404,11 @@ AtNode *convert( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, c
 	return result;
 }
 
-AtNode *convert( const std::vector<const IECoreScene::MeshPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode, messageContext );
 
-	std::vector<const IECoreScene::Primitive *> primitiveSamples( samples.begin(), samples.end() );
+	const auto primitiveSamples = IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( samples );
 	if( !ShapeAlgo::convertP( primitiveSamples, result, g_vlistArnoldString, messageContext ) )
 	{
 		AiNodeDestroy( result );
@@ -417,12 +417,12 @@ AtNode *convert( const std::vector<const IECoreScene::MeshPrimitive *> &samples,
 
 	// add normals
 
-	vector<const Data *> nSamples;
+	ParameterAlgo::DataSamples nSamples;
 	nSamples.reserve( samples.size() );
 	PrimitiveVariable::Interpolation nInterpolation = PrimitiveVariable::Invalid;
-	for( vector<const MeshPrimitive *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
+	for( auto sample : samples )
 	{
-		if( const V3fVectorData *n = normal( *it, nInterpolation, messageContext ) )
+		if( const V3fVectorData *n = normal( sample, nInterpolation, messageContext ) )
 		{
 			nSamples.push_back( n );
 		}

--- a/src/IECoreArnold/MeshAlgo.cpp
+++ b/src/IECoreArnold/MeshAlgo.cpp
@@ -226,7 +226,7 @@ void convertCornersAndCreases( const IECoreScene::MeshPrimitive *mesh, AtNode *n
 	AiNodeSetArray( node, g_creaseSharpnessArnoldString, sharpnessesArray );
 }
 
-AtNode *convertCommon( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convertStatic( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 
 	// Make the result mesh and add topology
@@ -374,39 +374,9 @@ void convertNormalIndices( const IECoreScene::MeshPrimitive *mesh, AtNode *node,
 	}
 }
 
-
-AtNode *convert( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
-{
-	AtNode *result = convertCommon( mesh, universe, nodeName, parentNode, messageContext );
-
-	if( !ShapeAlgo::convertP( mesh, result, g_vlistArnoldString, messageContext ) )
-	{
-		/// \todo Would be nice to refactor `ObjectAlgo::convert()` to return `unique_ptr<AtNode>`
-		/// so we don't do manual deletion like this.
-		AiNodeDestroy( result );
-		return nullptr;
-	}
-
-	// add normals
-
-	PrimitiveVariable::Interpolation nInterpolation = PrimitiveVariable::Invalid;
-	if( const V3fVectorData *n = normal( mesh, nInterpolation, messageContext ) )
-	{
-		AiNodeSetArray(
-			result,
-			g_nlistArnoldString,
-			AiArrayConvert( n->readable().size(), 1, AI_TYPE_VECTOR, &n->readable().front() )
-		);
-		convertNormalIndices( mesh, result, nInterpolation );
-		AiNodeSetBool( result, g_smoothingArnoldString, true );
-	}
-
-	return result;
-}
-
 AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode, messageContext );
+	AtNode *result = convertStatic( samples.front(), universe, nodeName, parentNode, messageContext );
 
 	const auto primitiveSamples = IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( samples );
 	if( !ShapeAlgo::convertP( primitiveSamples, result, g_vlistArnoldString, messageContext ) )
@@ -451,6 +421,6 @@ AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::
 	return result;
 }
 
-NodeAlgo::ConverterDescription<MeshPrimitive> g_description( ::convert, ::convert );
+NodeAlgo::ConverterDescription<MeshPrimitive> g_description( ::convert );
 
 } // namespace

--- a/src/IECoreArnold/NodeAlgo.cpp
+++ b/src/IECoreArnold/NodeAlgo.cpp
@@ -98,11 +98,11 @@ AtNode *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, flo
 		return nullptr;
 	}
 
-	const IECore::Object *firstSample = samples.front();
+	const IECore::Object *firstSample = samples.front().get();
 	const IECore::TypeId firstSampleTypeId = firstSample->typeId();
-	for( std::vector<const IECore::Object *>::const_iterator it = samples.begin()+1, eIt = samples.end(); it != eIt; ++it )
+	for( const auto &sample : samples )
 	{
-		if( (*it)->typeId() != firstSampleTypeId )
+		if( sample->typeId() != firstSampleTypeId )
 		{
 			IECore::msg( IECore::Msg::Error, messageContext, "Inconsistent object types." );
 			return nullptr;

--- a/src/IECoreArnold/NodeAlgo.cpp
+++ b/src/IECoreArnold/NodeAlgo.cpp
@@ -47,20 +47,7 @@ namespace
 
 using namespace IECoreArnold;
 
-struct Converters
-{
-
-	Converters( NodeAlgo::Converter converter, NodeAlgo::MotionConverter motionConverter )
-		:	converter( converter ), motionConverter( motionConverter )
-	{
-	}
-
-	NodeAlgo::Converter converter;
-	NodeAlgo::MotionConverter motionConverter;
-
-};
-
-using Registry = boost::unordered_map<IECore::TypeId, Converters>;
+using Registry = boost::unordered_map<IECore::TypeId, NodeAlgo::Converter>;
 
 Registry &registry()
 {
@@ -79,17 +66,6 @@ namespace IECoreArnold
 
 namespace NodeAlgo
 {
-
-AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
-{
-	const Registry &r = registry();
-	Registry::const_iterator it = r.find( object->typeId() );
-	if( it == r.end() )
-	{
-		return nullptr;
-	}
-	return it->second.converter( object, universe, nodeName, parentNode, messageContext );
-}
 
 AtNode *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
@@ -116,19 +92,17 @@ AtNode *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, flo
 		return nullptr;
 	}
 
-	if( it->second.motionConverter )
-	{
-		return it->second.motionConverter( samples, motionStart, motionEnd, universe, nodeName, parentNode, messageContext );
-	}
-	else
-	{
-		return it->second.converter( firstSample, universe, nodeName, parentNode, messageContext );
-	}
+	return it->second( samples, motionStart, motionEnd, universe, nodeName, parentNode, messageContext );
 }
 
-void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter )
+AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	registry().insert( Registry::value_type( fromType, Converters( converter, motionConverter ) ) );
+	return convert( { object }, 0, 1, universe, nodeName, parentNode, messageContext );
+}
+
+void registerConverter( IECore::TypeId fromType, Converter converter )
+{
+	registry().insert( Registry::value_type( fromType, converter ) );
 }
 
 } // namespace NodeAlgo

--- a/src/IECoreArnold/NodeAlgo.cpp
+++ b/src/IECoreArnold/NodeAlgo.cpp
@@ -91,7 +91,7 @@ AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::
 	return it->second.converter( object, universe, nodeName, parentNode, messageContext );
 }
 
-AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	if( samples.empty() )
 	{

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -616,7 +616,7 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 	return AiArrayConvert( size( data ), 1, aiType, address( data ) );
 }
 
-AtArray *dataToArray( const std::vector<const IECore::Data *> &samples, int aiType )
+AtArray *dataToArray( const DataSamples &samples, int aiType )
 {
 	if( aiType == AI_TYPE_NONE )
 	{
@@ -634,7 +634,7 @@ AtArray *dataToArray( const std::vector<const IECore::Data *> &samples, int aiTy
 		AiArrayDestroy
 	);
 
-	for( vector<const IECore::Data *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
+	for( auto it = samples.begin(); it != samples.end(); ++it )
 	{
 		if( (*it)->typeId() != samples.front()->typeId() )
 		{

--- a/src/IECoreArnold/PointsAlgo.cpp
+++ b/src/IECoreArnold/PointsAlgo.cpp
@@ -57,7 +57,7 @@ const AtString g_pointsArnoldString( "points" );
 const AtString g_quadArnoldString( "quad" );
 const AtString g_sphereArnoldString( "sphere" );
 
-AtNode *convertCommon( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convertStatic( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 
 	AtNode *result = AiNode( universe, g_pointsArnoldString, AtString( nodeName.c_str() ), parentNode );
@@ -94,28 +94,9 @@ AtNode *convertCommon( const IECoreScene::PointsPrimitive *points, AtUniverse *u
 
 }
 
-AtNode *convert( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
-{
-	AtNode *result = convertCommon( points, universe, nodeName, parentNode, messageContext );
-
-	if( !ShapeAlgo::convertP( points, result, g_pointsArnoldString, messageContext ) )
-	{
-		/// \todo Would be nice to refactor `ObjectAlgo::convert()` to return `unique_ptr<AtNode>`
-		/// so we don't do manual deletion like this.
-		AiNodeDestroy( result );
-		return nullptr;
-	}
-
-	ShapeAlgo::convertRadius( points, result, messageContext );
-
-	/// \todo Aspect, rotation
-
-	return result;
-}
-
 AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode, messageContext );
+	AtNode *result = convertStatic( samples.front(), universe, nodeName, parentNode, messageContext );
 
 	const auto primitiveSamples = IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( samples );
 	if( !ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString, messageContext ) )
@@ -134,6 +115,6 @@ AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::
 	return result;
 }
 
-NodeAlgo::ConverterDescription<PointsPrimitive> g_description( ::convert, ::convert );
+NodeAlgo::ConverterDescription<PointsPrimitive> g_description( ::convert );
 
 } // namespace

--- a/src/IECoreArnold/PointsAlgo.cpp
+++ b/src/IECoreArnold/PointsAlgo.cpp
@@ -113,11 +113,11 @@ AtNode *convert( const IECoreScene::PointsPrimitive *points, AtUniverse *univers
 	return result;
 }
 
-AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode, messageContext );
 
-	std::vector<const IECoreScene::Primitive *> primitiveSamples( samples.begin(), samples.end() );
+	const auto primitiveSamples = IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( samples );
 	if( !ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString, messageContext ) )
 	{
 		AiNodeDestroy( result );
@@ -125,7 +125,6 @@ AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &sample
 	}
 
 	ShapeAlgo::convertRadius( primitiveSamples, result, messageContext );
-
 
 	AiNodeSetFlt( result, g_motionStartArnoldString, motionStart );
 	AiNodeSetFlt( result, g_motionEndArnoldString, motionEnd );

--- a/src/IECoreArnold/ProceduralAlgo.cpp
+++ b/src/IECoreArnold/ProceduralAlgo.cpp
@@ -67,10 +67,10 @@ namespace IECoreArnold
 namespace ProceduralAlgo
 {
 
-AtNode *convert( const IECoreScene::ExternalProcedural *procedural, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convert( const ProceduralSamples &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *node = AiNode( universe, AtString( procedural->getFileName().c_str() ), AtString( nodeName.c_str() ), parentNode );
-	ParameterAlgo::setParameters( node, procedural->parameters()->readable(), messageContext );
+	AtNode *node = AiNode( universe, AtString( samples.front()->getFileName().c_str() ), AtString( nodeName.c_str() ), parentNode );
+	ParameterAlgo::setParameters( node, samples.front()->parameters()->readable(), messageContext );
 
 	return node;
 }

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -251,7 +251,7 @@ void hashShaderOutputParameter( const IECoreScene::ShaderNetwork *network, const
 // Arnold does not support non-uniform sampling. It just takes a start and end
 // time, and assumes the samples are distributed evenly between them. Throw an
 // exception if given data we can't render.
-void ensureUniformTimeSamples( const std::vector<float> &times )
+void ensureUniformTimeSamples( const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	if( times.size() == 0 )
 	{
@@ -417,11 +417,11 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 
 		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 
 	protected :
 
@@ -2461,7 +2461,7 @@ class InstanceCache : public IECore::RefCounted
 			return Instance( node, m_nodeDeleter, m_universe, nodeName, m_parentNode );
 		}
 
-		Instance get( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &nodeName )
+		Instance get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &nodeName )
 		{
 			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
 
@@ -2475,10 +2475,7 @@ class InstanceCache : public IECore::RefCounted
 			{
 				(*it)->hash( h );
 			}
-			for( std::vector<float>::const_iterator it = times.begin(), eIt = times.end(); it != eIt; ++it )
-			{
-				h.append( *it );
-			}
+			h.append( times.data(), times.size() );
 			arnoldAttributes->hashGeometry( samples.front(), h );
 
 			SharedAtNodePtr node;
@@ -2572,7 +2569,7 @@ class InstanceCache : public IECore::RefCounted
 			return SharedAtNodePtr( node, m_nodeDeleter );
 		}
 
-		SharedAtNodePtr convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const ArnoldAttributes *attributes, const std::string &nodeName, const std::string &messageContext )
+		SharedAtNodePtr convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const ArnoldAttributes *attributes, const std::string &nodeName, const std::string &messageContext )
 		{
 			ensureUniformTimeSamples( times );
 			AtNode *node = nullptr;
@@ -2644,7 +2641,7 @@ class ArnoldObjectBase : public IECoreScenePreview::Renderer::ObjectInterface
 			applyTransform( node, transform );
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			AtNode *node = m_instance.node();
 			if( !node )
@@ -2719,7 +2716,7 @@ class ArnoldObjectBase : public IECoreScenePreview::Renderer::ObjectInterface
 			AiNodeSetMatrix( node, matrixParameterName, reinterpret_cast<const AtMatrix&>( transform.x ) );
 		}
 
-		void applyTransform( AtNode *node, const std::vector<Imath::M44f> &samples, const std::vector<float> &times, const AtString matrixParameterName = g_matrixArnoldString )
+		void applyTransform( AtNode *node, const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const AtString matrixParameterName = g_matrixArnoldString )
 		{
 			const AtParamEntry *parameter = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( node ), matrixParameterName );
 			if( AiParamGetType( parameter ) != AI_TYPE_ARRAY )
@@ -2791,7 +2788,7 @@ class ArnoldLightFilter : public ArnoldObjectBase
 			applyLightFilterTransform();
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			ArnoldObjectBase::transform( samples, times );
 			m_transformMatrices = samples;
@@ -2875,8 +2872,8 @@ class ArnoldLightFilter : public ArnoldObjectBase
 		}
 
 		std::string m_name;
-		vector<Imath::M44f> m_transformMatrices;
-		vector<float> m_transformTimes;
+		IECoreScenePreview::Renderer::TransformSamples m_transformMatrices;
+		IECoreScenePreview::Renderer::SampleTimes m_transformTimes;
 		NodeDeleter m_nodeDeleter;
 		AtUniverse *m_universe;
 		const AtNode *m_parentNode;
@@ -2920,7 +2917,7 @@ class ArnoldLight : public ArnoldObjectBase
 			applyLightTransform();
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			ArnoldObjectBase::transform( samples, times );
 			m_transformMatrices = samples;
@@ -3122,8 +3119,8 @@ class ArnoldLight : public ArnoldObjectBase
 		// we need to store the transform and name ourselves so we have
 		// them later when we need them.
 		std::string m_name;
-		vector<Imath::M44f> m_transformMatrices;
-		vector<float> m_transformTimes;
+		IECoreScenePreview::Renderer::TransformSamples m_transformMatrices;
+		IECoreScenePreview::Renderer::SampleTimes m_transformTimes;
 		NodeDeleter m_nodeDeleter;
 		AtUniverse *m_universe;
 		const AtNode *m_parentNode;
@@ -3289,7 +3286,7 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			return nullptr;
 		}
 
-		ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			IECore::msg( IECore::Msg::Warning, "ArnoldRenderer", "Procedurals can not call camera()" );
 			return nullptr;
@@ -3329,7 +3326,7 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			return result;
 		}
 
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			ArnoldObjectPtr result = static_pointer_cast<ArnoldObject>(
 				ArnoldRendererBase::object( name, samples, times, attributes )
@@ -4729,11 +4726,11 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::st
 	return result;
 }
 
-ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( vector<const IECore::Object *>( samples.begin(), samples.end() ), times, attributes, name );
+	Instance instance = m_instanceCache->get( ObjectSamples( samples.begin(), samples.end() ), times, attributes, name );
 
 	ObjectInterfacePtr result = new ArnoldObject( instance );
 	if( attributes )
@@ -4774,7 +4771,7 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::object( const std::st
 	return result;
 }
 
-ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes )
+ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
@@ -4839,7 +4836,7 @@ class ArnoldRenderer final : public ArnoldRendererBase
 			return ArnoldRendererBase::camera( name, camera, attributes );
 		}
 
-		ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 			m_globals->camera( name, samples[0] );

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -420,7 +420,6 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
-		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 
 	protected :
@@ -2416,53 +2415,13 @@ class InstanceCache : public IECore::RefCounted
 		{
 		}
 
-		// Can be called concurrently with other get() calls.
-		Instance get( const IECore::Object *object, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &nodeName )
-		{
-			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
-
-			if( !arnoldAttributes || !arnoldAttributes->canInstanceGeometry( object ) )
-			{
-				return Instance( convert( object, arnoldAttributes, nodeName, /* messageContext = */ nodeName ) );
-			}
-
-			IECore::MurmurHash h = object->hash();
-			arnoldAttributes->hashGeometry( object, h );
-
-			SharedAtNodePtr node;
-			Cache::const_accessor readAccessor;
-			if( m_cache.find( readAccessor, h ) )
-			{
-				node = readAccessor->second;
-				readAccessor.release();
-			}
-			else
-			{
-				Cache::accessor writeAccessor;
-				if( m_cache.insert( writeAccessor, h ) )
-				{
-					try
-					{
-						writeAccessor->second = convert( object, arnoldAttributes, "instance:" + h.toString(), /* messageContext = */ nodeName );
-					}
-					catch( const IECore::Cancelled & )
-					{
-						// Procedural expansion was cancelled. Erase `nullptr`
-						// result from the cache so that we redo the expansion
-						// if given the same procedural another time.
-						m_cache.erase( writeAccessor );
-						throw;
-					}
-				}
-				node = writeAccessor->second;
-				writeAccessor.release();
-			}
-
-			return Instance( node, m_nodeDeleter, m_universe, nodeName, m_parentNode );
-		}
-
 		Instance get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &nodeName )
 		{
+			if( samples.empty() )
+			{
+				return Instance( SharedAtNodePtr() );
+			}
+
 			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
 
 			if( !arnoldAttributes->canInstanceGeometry( samples.front().get() ) )
@@ -2496,7 +2455,11 @@ class InstanceCache : public IECore::RefCounted
 					}
 					catch( const IECore::Cancelled & )
 					{
+						// Procedural expansion was cancelled. Erase `nullptr`
+						// result from the cache so that we redo the expansion
+						// if given the same procedural another time.
 						m_cache.erase( writeAccessor );
+						throw;
 					}
 				}
 				node = writeAccessor->second;
@@ -2538,36 +2501,6 @@ class InstanceCache : public IECore::RefCounted
 		}
 
 	private :
-
-		SharedAtNodePtr convert( const IECore::Object *object, const ArnoldAttributes *attributes, const std::string &nodeName, const std::string &messageContext )
-		{
-			if( !object )
-			{
-				return SharedAtNodePtr();
-			}
-
-			AtNode *node = nullptr;
-			if( const IECoreScenePreview::Procedural *procedural = IECore::runTimeCast<const IECoreScenePreview::Procedural>( object ) )
-			{
-				node = convertProcedural( procedural, attributes, m_universe, nodeName, m_parentNode );
-			}
-			else
-			{
-				node = NodeAlgo::convert( object, m_universe, nodeName, m_parentNode, messageContext );
-			}
-
-			if( !node )
-			{
-				return SharedAtNodePtr();
-			}
-
-			if( attributes )
-			{
-				attributes->applyGeometry( object, node );
-			}
-
-			return SharedAtNodePtr( node, m_nodeDeleter );
-		}
 
 		SharedAtNodePtr convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const ArnoldAttributes *attributes, const std::string &nodeName, const std::string &messageContext )
 		{
@@ -3313,16 +3246,6 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			auto &nodesCreatedLocal = m_nodesCreated.local();
 			result->instance().nodesCreated( nodesCreatedLocal );
 			result->nodesCreated( nodesCreatedLocal );
-			return result;
-		}
-
-		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
-		{
-			ArnoldObjectPtr result = static_pointer_cast<ArnoldObject>(
-				ArnoldRendererBase::object( name, object, attributes )
-			);
-
-			result->instance().nodesCreated( m_nodesCreated.local() );
 			return result;
 		}
 
@@ -4331,7 +4254,7 @@ class ArnoldGlobals
 					IECoreScene::ConstCameraPtr defaultCortexCamera = new IECoreScene::Camera();
 					m_cameras["ieCoreArnold:defaultCamera"] = defaultCortexCamera;
 					m_defaultCamera = SharedAtNodePtr(
-						NodeAlgo::convert( defaultCortexCamera.get(), m_universeBlock->universe(), "ieCoreArnold:defaultCamera", nullptr, "ieCoreArnold:defaultCamera" ),
+						NodeAlgo::convert( { defaultCortexCamera }, 0.0f, 0.0f, m_universeBlock->universe(), "ieCoreArnold:defaultCamera", nullptr, "ieCoreArnold:defaultCamera" ),
 						nodeDeleter( m_renderType )
 					);
 				}
@@ -4712,11 +4635,12 @@ ArnoldRendererBase::AttributesInterfacePtr ArnoldRendererBase::attributes( const
 	return new ArnoldAttributes( attributes, m_shaderCache.get() );
 }
 
+
 ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes )
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( camera, attributes, name );
+	Instance instance = m_instanceCache->get( { camera }, { 0.0f }, attributes, name );
 
 	ObjectInterfacePtr result = new ArnoldObject( instance );
 	if( attributes )
@@ -4744,7 +4668,7 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::light( const std::str
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( object, attributes, name );
+	Instance instance = m_instanceCache->get( object ? ObjectSamples( { object } ) : ObjectSamples(), object ? SampleTimes( { 0.0f } ) : SampleTimes(),  attributes, name );
 	ObjectInterfacePtr result = new ArnoldLight( name, instance, m_nodeDeleter, m_universe, m_parentNode );
 	result->attributes( attributes );
 	return result;
@@ -4754,20 +4678,10 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::lightFilter( const st
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( object, attributes, name );
+	Instance instance = m_instanceCache->get( object ? ObjectSamples( { object } ) : ObjectSamples(), object ? SampleTimes( { 0.0f } ) : SampleTimes(),  attributes, name );
 	ObjectInterfacePtr result = new ArnoldLightFilter( name, instance, m_nodeDeleter, m_universe, m_parentNode );
 	result->attributes( attributes );
 
-	return result;
-}
-
-ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
-{
-	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
-
-	Instance instance = m_instanceCache->get( object, attributes, name );
-	ObjectInterfacePtr result = new ArnoldObject( instance );
-	result->attributes( attributes );
 	return result;
 }
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2465,18 +2465,18 @@ class InstanceCache : public IECore::RefCounted
 		{
 			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
 
-			if( !arnoldAttributes->canInstanceGeometry( samples.front() ) )
+			if( !arnoldAttributes->canInstanceGeometry( samples.front().get() ) )
 			{
 				return Instance( convert( samples, times, arnoldAttributes, nodeName, /* messageContext = */ nodeName ) );
 			}
 
 			IECore::MurmurHash h;
-			for( std::vector<const IECore::Object *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
+			for( const auto &sample : samples )
 			{
-				(*it)->hash( h );
+				sample->hash( h );
 			}
 			h.append( times.data(), times.size() );
-			arnoldAttributes->hashGeometry( samples.front(), h );
+			arnoldAttributes->hashGeometry( samples.front().get(), h );
 
 			SharedAtNodePtr node;
 			Cache::const_accessor readAccessor;
@@ -2573,7 +2573,7 @@ class InstanceCache : public IECore::RefCounted
 		{
 			ensureUniformTimeSamples( times );
 			AtNode *node = nullptr;
-			if( const IECoreScenePreview::Procedural *procedural = IECore::runTimeCast<const IECoreScenePreview::Procedural>( samples.front() ) )
+			if( const IECoreScenePreview::Procedural *procedural = IECore::runTimeCast<const IECoreScenePreview::Procedural>( samples.front().get() ) )
 			{
 				node = convertProcedural( procedural, attributes, m_universe, nodeName, m_parentNode );
 			}
@@ -2589,7 +2589,7 @@ class InstanceCache : public IECore::RefCounted
 
 			if( attributes )
 			{
-				attributes->applyGeometry( samples.front(), node );
+				attributes->applyGeometry( samples.front().get(), node );
 			}
 
 			return SharedAtNodePtr( node, m_nodeDeleter );

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -416,7 +416,6 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 
 		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
@@ -3213,12 +3212,6 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			return ArnoldRendererBase::attributes( fullAttributes.get() );
 		}
 
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
-		{
-			IECore::msg( IECore::Msg::Warning, "ArnoldRenderer", "Procedurals can not call camera()" );
-			return nullptr;
-		}
-
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			IECore::msg( IECore::Msg::Warning, "ArnoldRenderer", "Procedurals can not call camera()" );
@@ -4635,21 +4628,6 @@ ArnoldRendererBase::AttributesInterfacePtr ArnoldRendererBase::attributes( const
 	return new ArnoldAttributes( attributes, m_shaderCache.get() );
 }
 
-
-ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes )
-{
-	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
-
-	Instance instance = m_instanceCache->get( { camera }, { 0.0f }, attributes, name );
-
-	ObjectInterfacePtr result = new ArnoldObject( instance );
-	if( attributes )
-	{
-		result->attributes( attributes );
-	}
-	return result;
-}
-
 ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
@@ -4740,14 +4718,6 @@ class ArnoldRenderer final : public ArnoldRendererBase
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 			m_globals->output( name, output );
-		}
-
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
-		{
-			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
-
-			m_globals->camera( name, camera );
-			return ArnoldRendererBase::camera( name, camera, attributes );
 		}
 
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2563,16 +2563,6 @@ class ArnoldObjectBase : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 		}
 
-		void transform( const Imath::M44f &transform ) override
-		{
-			AtNode *node = m_instance.node();
-			if( !node )
-			{
-				return;
-			}
-			applyTransform( node, transform );
-		}
-
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			AtNode *node = m_instance.node();
@@ -2643,18 +2633,13 @@ class ArnoldObjectBase : public IECoreScenePreview::Renderer::ObjectInterface
 
 	protected :
 
-		void applyTransform( AtNode *node, const Imath::M44f &transform, const AtString matrixParameterName = g_matrixArnoldString )
-		{
-			AiNodeSetMatrix( node, matrixParameterName, reinterpret_cast<const AtMatrix&>( transform.x ) );
-		}
-
 		void applyTransform( AtNode *node, const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const AtString matrixParameterName = g_matrixArnoldString )
 		{
 			const AtParamEntry *parameter = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( node ), matrixParameterName );
-			if( AiParamGetType( parameter ) != AI_TYPE_ARRAY )
+			if( AiParamGetType( parameter ) != AI_TYPE_ARRAY || samples.size() == 1 )
 			{
-				// Parameter doesn't support motion blur
-				applyTransform( node, samples[0], matrixParameterName );
+				// Parameter doesn't support motion blur, or we only have one sample
+				AiNodeSetMatrix( node, matrixParameterName, reinterpret_cast<const AtMatrix&>( samples[0].x ) );
 				return;
 			}
 
@@ -2709,15 +2694,6 @@ class ArnoldLightFilter : public ArnoldObjectBase
 
 		~ArnoldLightFilter() override
 		{
-		}
-
-		void transform( const Imath::M44f &transform ) override
-		{
-			ArnoldObjectBase::transform( transform );
-			m_transformMatrices.clear();
-			m_transformTimes.clear();
-			m_transformMatrices.push_back( transform );
-			applyLightFilterTransform();
 		}
 
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
@@ -2792,15 +2768,7 @@ class ArnoldLightFilter : public ArnoldObjectBase
 				return;
 			}
 			AtNode *root = m_lightFilterShader->root();
-			if( m_transformTimes.empty() )
-			{
-				assert( m_transformMatrices.size() == 1 );
-				applyTransform( root, m_transformMatrices[0], g_geometryMatrixArnoldString );
-			}
-			else
-			{
-				applyTransform( root, m_transformMatrices, m_transformTimes, g_geometryMatrixArnoldString );
-			}
+			applyTransform( root, m_transformMatrices, m_transformTimes, g_geometryMatrixArnoldString );
 		}
 
 		std::string m_name;
@@ -2838,15 +2806,6 @@ class ArnoldLight : public ArnoldObjectBase
 
 		~ArnoldLight() override
 		{
-		}
-
-		void transform( const Imath::M44f &transform ) override
-		{
-			ArnoldObjectBase::transform( transform );
-			m_transformMatrices.clear();
-			m_transformTimes.clear();
-			m_transformMatrices.push_back( transform );
-			applyLightTransform();
 		}
 
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
@@ -3000,15 +2959,7 @@ class ArnoldLight : public ArnoldObjectBase
 				return;
 			}
 			AtNode *root = m_lightShader->root();
-			if( m_transformTimes.empty() )
-			{
-				assert( m_transformMatrices.size() == 1 );
-				applyTransform( root, m_transformMatrices[0] );
-			}
-			else
-			{
-				applyTransform( root, m_transformMatrices, m_transformTimes );
-			}
+			applyTransform( root, m_transformMatrices, m_transformTimes );
 		}
 
 		void updateLightFilterLinks()

--- a/src/IECoreArnold/ShapeAlgo.cpp
+++ b/src/IECoreArnold/ShapeAlgo.cpp
@@ -161,9 +161,9 @@ bool convertP( const IECoreScene::Primitive *primitive, AtNode *shape, const AtS
 	return false;
 }
 
-bool convertP( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const AtString name, const std::string &messageContext )
+bool convertP( const PrimitiveSamples &samples, AtNode *shape, const AtString name, const std::string &messageContext )
 {
-	vector<const Data *> dataSamples;
+	ParameterAlgo::DataSamples dataSamples;
 	dataSamples.reserve( samples.size() );
 
 	for( auto primitive : samples )
@@ -192,16 +192,16 @@ void convertRadius( const IECoreScene::Primitive *primitive, AtNode *shape, cons
 	);
 }
 
-void convertRadius( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const std::string &messageContext )
+void convertRadius( const PrimitiveSamples &samples, AtNode *shape, const std::string &messageContext )
 {
 	vector<ConstFloatVectorDataPtr> radiusSamples; // for ownership
-	vector<const Data *> dataSamples; // for passing to dataToArray()
+	ParameterAlgo::DataSamples dataSamples; // for passing to dataToArray()
 	radiusSamples.reserve( samples.size() );
 	dataSamples.reserve( samples.size() );
 
-	for( vector<const Primitive *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
+	for( auto primitive : samples )
 	{
-		ConstFloatVectorDataPtr r = radius( *it );
+		ConstFloatVectorDataPtr r = radius( primitive );
 		radiusSamples.push_back( r );
 		dataSamples.push_back( r.get() );
 	}

--- a/src/IECoreArnold/SphereAlgo.cpp
+++ b/src/IECoreArnold/SphereAlgo.cpp
@@ -80,18 +80,18 @@ AtNode *convert( const IECoreScene::SpherePrimitive *sphere, AtUniverse *univers
 	return result;
 }
 
-AtNode *convert( const std::vector<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
+AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	AtNode *result = AiNode( universe, g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
 	ShapeAlgo::convertPrimitiveVariables( samples.front(), result, nullptr, messageContext );
 
 	AtArray *radiusSamples = AiArrayAllocate( 1, samples.size(), AI_TYPE_FLOAT );
 
-	for( vector<const IECoreScene::SpherePrimitive *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
+	for( size_t i = 0; i < samples.size(); ++i )
 	{
-		warnIfUnsupported( *it );
-		float radius = (*it)->radius();
-		AiArraySetKey( radiusSamples, /* key = */ it - samples.begin(), &radius );
+		warnIfUnsupported( samples[i] );
+		float radius = samples[i]->radius();
+		AiArraySetKey( radiusSamples, /* key = */ i, &radius );
 	}
 
 	AiNodeSetArray( result, g_radiusArnoldString, radiusSamples );

--- a/src/IECoreArnold/SphereAlgo.cpp
+++ b/src/IECoreArnold/SphereAlgo.cpp
@@ -68,18 +68,6 @@ void warnIfUnsupported( const IECoreScene::SpherePrimitive *sphere )
 	}
 }
 
-AtNode *convert( const IECoreScene::SpherePrimitive *sphere, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
-{
-	warnIfUnsupported( sphere );
-
-	AtNode *result = AiNode( universe, g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
-	ShapeAlgo::convertPrimitiveVariables( sphere, result, nullptr, messageContext );
-
-	AiNodeSetFlt( result, g_radiusArnoldString, sphere->radius() );
-
-	return result;
-}
-
 AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	AtNode *result = AiNode( universe, g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
@@ -101,6 +89,6 @@ AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::
 	return result;
 }
 
-NodeAlgo::ConverterDescription<SpherePrimitive> g_description( convert, convert );
+NodeAlgo::ConverterDescription<SpherePrimitive> g_description( convert );
 
 } // namespace

--- a/src/IECoreArnold/VDBAlgo.cpp
+++ b/src/IECoreArnold/VDBAlgo.cpp
@@ -121,11 +121,11 @@ CompoundDataPtr createParameters(const IECoreVDB::VDBObject* vdbObject)
 	return parameters;
 }
 
-AtNode *convert( const IECoreVDB::VDBObject *vdbObject, AtUniverse *universe, const std::string &name, const AtNode* parent, const std::string &messageContext )
+AtNode *convert( const IECoreScenePreview::Renderer::Samples<const IECoreVDB::VDBObject *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &name, const AtNode* parent, const std::string &messageContext )
 {
 	AtNode *node = AiNode( universe, g_volume, AtString( name.c_str() ), parent );
 
-	CompoundDataPtr parameters = createParameters( vdbObject );
+	CompoundDataPtr parameters = createParameters( samples.front() );
 	ParameterAlgo::setParameters( node, parameters->readable(), messageContext );
 
 	return node;

--- a/src/IECoreArnoldModule/IECoreArnoldModule.cpp
+++ b/src/IECoreArnoldModule/IECoreArnoldModule.cpp
@@ -131,7 +131,7 @@ object convertWrapper( const IECore::Object *object, boost::python::object unive
 
 object convertWrapper2( object pythonSamples, float motionStart, float motionEnd, boost::python::object universe, const std::string &nodeName )
 {
-	std::vector<const IECore::Object *> samples;
+	IECoreScenePreview::Renderer::ObjectSamples samples;
 	container_utils::extend_container( samples, pythonSamples );
 
 	return atNodeToPythonObject( NodeAlgo::convert( samples, motionStart, motionEnd, pythonObjectToAtUniverse( universe ), nodeName, nullptr ) );

--- a/src/IECoreDelight/CameraAlgo.cpp
+++ b/src/IECoreDelight/CameraAlgo.cpp
@@ -50,8 +50,10 @@ using namespace IECoreDelight;
 namespace
 {
 
-bool convert( const IECoreScene::Camera *camera, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Camera *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
+	const IECoreScene::Camera *camera = samples[0];
+
 	const string &projection = camera->getProjection();
 	const string nodeType = projection + "camera";
 

--- a/src/IECoreDelight/CurvesAlgo.cpp
+++ b/src/IECoreDelight/CurvesAlgo.cpp
@@ -112,7 +112,7 @@ bool convertStatic( const IECoreScene::CurvesPrimitive *object, NSIContext_t con
 	return true;
 }
 
-bool convertAnimated( const vector<const IECoreScene::CurvesPrimitive *> &objects, const vector<float> &times, NSIContext_t context, const char *handle )
+bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &objects, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "cubiccurves", 0, nullptr );
 
@@ -121,7 +121,7 @@ bool convertAnimated( const vector<const IECoreScene::CurvesPrimitive *> &object
 
 	vector<ParameterList> animatedParameters;
 	NodeAlgo::primitiveVariableParameterLists(
-		vector<const Primitive *>( objects.begin(), objects.end() ),
+		IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( objects ),
 		parameters, animatedParameters
 	);
 

--- a/src/IECoreDelight/CurvesAlgo.cpp
+++ b/src/IECoreDelight/CurvesAlgo.cpp
@@ -98,21 +98,7 @@ void staticParameters( const IECoreScene::CurvesPrimitive *object, ParameterList
 
 }
 
-bool convertStatic( const IECoreScene::CurvesPrimitive *object, NSIContext_t context, const char *handle )
-{
-	NSICreate( context, handle, "cubiccurves", 0, nullptr );
-
-	ParameterList parameters;
-	staticParameters( object, parameters );
-
-	NodeAlgo::primitiveVariableParameterList( object, parameters );
-
-	NSISetAttribute( context, handle, parameters.size(), parameters.data() );
-
-	return true;
-}
-
-bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &objects, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &objects, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "cubiccurves", 0, nullptr );
 
@@ -138,6 +124,6 @@ bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreSc
 	return true;
 }
 
-NodeAlgo::ConverterDescription<CurvesPrimitive> g_description( convertStatic, convertAnimated );
+NodeAlgo::ConverterDescription<CurvesPrimitive> g_description( convert );
 
 } // namespace

--- a/src/IECoreDelight/CurvesAlgo.cpp
+++ b/src/IECoreDelight/CurvesAlgo.cpp
@@ -105,7 +105,7 @@ bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Cur
 	ParameterList parameters;
 	staticParameters( objects.front(), parameters );
 
-	vector<ParameterList> animatedParameters;
+	IECoreScenePreview::Renderer::Samples<ParameterList> animatedParameters;
 	NodeAlgo::primitiveVariableParameterLists(
 		IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( objects ),
 		parameters, animatedParameters

--- a/src/IECoreDelight/DiskAlgo.cpp
+++ b/src/IECoreDelight/DiskAlgo.cpp
@@ -48,13 +48,13 @@ using namespace IECoreDelight;
 namespace
 {
 
-bool convert( const IECoreScene::DiskPrimitive *object, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const DiskPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "particles", 0, nullptr );
 
 	ParameterList parameters;
 
-	const V3f p( 0, 0, object->getZ() );
+	const V3f p( 0, 0, samples[0]->getZ() );
 	parameters.add( {
 		"P",
 		&p,
@@ -79,7 +79,7 @@ bool convert( const IECoreScene::DiskPrimitive *object, NSIContext_t context, co
 		NSIParamPerVertex
 	} );
 
-	const float width = object->getRadius() * 2;
+	const float width = samples[0]->getRadius() * 2;
 	parameters.add( {
 		"width",
 		&width,

--- a/src/IECoreDelight/GeometryAlgo.cpp
+++ b/src/IECoreDelight/GeometryAlgo.cpp
@@ -50,8 +50,10 @@ using namespace IECoreDelight;
 namespace
 {
 
-bool convert( const IECoreScenePreview::Geometry *geometry, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScenePreview::Geometry *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
+	const IECoreScenePreview::Geometry *geometry = samples[0];
+
 	if( geometry->getType() != "dl:environment" )
 	{
 		return false;

--- a/src/IECoreDelight/MeshAlgo.cpp
+++ b/src/IECoreDelight/MeshAlgo.cpp
@@ -120,22 +120,7 @@ void convertCornersAndCreases( const IECoreScene::MeshPrimitive *mesh, NSIContex
 	}
 }
 
-bool convertStatic( const IECoreScene::MeshPrimitive *mesh, NSIContext_t context, const char *handle )
-{
-	NSICreate( context, handle, "mesh", 0, nullptr );
-
-	ParameterList parameters;
-	staticParameters( mesh, parameters );
-	NodeAlgo::primitiveVariableParameterList( mesh, parameters, mesh->vertexIds() );
-
-	NSISetAttribute( context, handle, parameters.size(), parameters.data() );
-
-	convertCornersAndCreases( mesh, context, handle );
-
-	return true;
-}
-
-bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &meshes, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &meshes, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "mesh", 0, nullptr );
 
@@ -164,6 +149,6 @@ bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreSc
 	return true;
 }
 
-NodeAlgo::ConverterDescription<MeshPrimitive> g_description( convertStatic, convertAnimated );
+NodeAlgo::ConverterDescription<MeshPrimitive> g_description( convert );
 
 } // namespace

--- a/src/IECoreDelight/MeshAlgo.cpp
+++ b/src/IECoreDelight/MeshAlgo.cpp
@@ -135,7 +135,7 @@ bool convertStatic( const IECoreScene::MeshPrimitive *mesh, NSIContext_t context
 	return true;
 }
 
-bool convertAnimated( const vector<const IECoreScene::MeshPrimitive *> &meshes, const vector<float> &times, NSIContext_t context, const char *handle )
+bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &meshes, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "mesh", 0, nullptr );
 
@@ -144,7 +144,7 @@ bool convertAnimated( const vector<const IECoreScene::MeshPrimitive *> &meshes, 
 
 	vector<ParameterList> animatedParameters;
 	NodeAlgo::primitiveVariableParameterLists(
-		vector<const Primitive *>( meshes.begin(), meshes.end() ),
+		IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( meshes ),
 		parameters, animatedParameters,
 		meshes.front()->vertexIds()
 	);

--- a/src/IECoreDelight/MeshAlgo.cpp
+++ b/src/IECoreDelight/MeshAlgo.cpp
@@ -127,7 +127,7 @@ bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Mes
 	ParameterList parameters;
 	staticParameters( meshes.front(), parameters );
 
-	vector<ParameterList> animatedParameters;
+	IECoreScenePreview::Renderer::Samples<ParameterList> animatedParameters;
 	NodeAlgo::primitiveVariableParameterLists(
 		IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( meshes ),
 		parameters, animatedParameters,

--- a/src/IECoreDelight/NodeAlgo.cpp
+++ b/src/IECoreDelight/NodeAlgo.cpp
@@ -68,15 +68,7 @@ namespace
 
 using namespace IECoreDelight;
 
-struct Converters
-{
-
-	NodeAlgo::Converter converter;
-	NodeAlgo::MotionConverter motionConverter;
-
-};
-
-using Registry = std::unordered_map<IECore::TypeId, Converters>;
+using Registry = std::unordered_map<IECore::TypeId, NodeAlgo::Converter>;
 
 Registry &registry()
 {
@@ -166,17 +158,6 @@ namespace IECoreDelight
 namespace NodeAlgo
 {
 
-bool convert( const IECore::Object *object, NSIContext_t context, const char *handle )
-{
-	Registry &r = registry();
-	auto it = r.find( object->typeId() );
-	if( it == r.end() )
-	{
-		return false;
-	}
-	return it->second.converter( object, context, handle );
-}
-
 bool convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
 	Registry &r = registry();
@@ -185,27 +166,12 @@ bool convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const 
 	{
 		return false;
 	}
-	if( it->second.motionConverter )
-	{
-		return it->second.motionConverter( samples, sampleTimes, context, handle );
-	}
-	else
-	{
-		return it->second.converter( samples.front().get(), context, handle );
-	}
+	return it->second( samples, sampleTimes, context, handle );
 }
 
-void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter )
+void registerConverter( IECore::TypeId fromType, Converter converter )
 {
-	registry()[fromType] = { converter, motionConverter };
-}
-
-void primitiveVariableParameterList( const IECoreScene::Primitive *primitive, ParameterList &parameters, const IECore::IntVectorData *vertexIndices )
-{
-	for( const auto &variable : primitive->variables )
-	{
-		addPrimitiveVariableParameters( variable.first.c_str(), variable.second, vertexIndices, parameters, &parameters );
-	}
+	registry()[fromType] = converter;
 }
 
 void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices )

--- a/src/IECoreDelight/NodeAlgo.cpp
+++ b/src/IECoreDelight/NodeAlgo.cpp
@@ -191,7 +191,7 @@ bool convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const 
 	}
 	else
 	{
-		return it->second.converter( samples.front(), context, handle );
+		return it->second.converter( samples.front().get(), context, handle );
 	}
 }
 

--- a/src/IECoreDelight/NodeAlgo.cpp
+++ b/src/IECoreDelight/NodeAlgo.cpp
@@ -174,7 +174,7 @@ void registerConverter( IECore::TypeId fromType, Converter converter )
 	registry()[fromType] = converter;
 }
 
-void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices )
+void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, IECoreScenePreview::Renderer::Samples<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices )
 {
 	for( const auto &variable : primitives.front()->variables )
 	{

--- a/src/IECoreDelight/NodeAlgo.cpp
+++ b/src/IECoreDelight/NodeAlgo.cpp
@@ -177,7 +177,7 @@ bool convert( const IECore::Object *object, NSIContext_t context, const char *ha
 	return it->second.converter( object, context, handle );
 }
 
-bool convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
 	Registry &r = registry();
 	auto it = r.find( samples.front()->typeId() );

--- a/src/IECoreDelight/NodeAlgo.cpp
+++ b/src/IECoreDelight/NodeAlgo.cpp
@@ -208,7 +208,7 @@ void primitiveVariableParameterList( const IECoreScene::Primitive *primitive, Pa
 	}
 }
 
-void primitiveVariableParameterLists( const std::vector<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices )
+void primitiveVariableParameterLists( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *> &primitives, ParameterList &staticParameters, std::vector<ParameterList> &animatedParameters, const IECore::IntVectorData *vertexIndices )
 {
 	for( const auto &variable : primitives.front()->variables )
 	{

--- a/src/IECoreDelight/PointsAlgo.cpp
+++ b/src/IECoreDelight/PointsAlgo.cpp
@@ -79,7 +79,7 @@ bool convertStatic( const IECoreScene::PointsPrimitive *object, NSIContext_t con
 	return true;
 }
 
-bool convertAnimated( const vector<const IECoreScene::PointsPrimitive *> &objects, const vector<float> &times, NSIContext_t context, const char *handle )
+bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &objects, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "particles", 0, nullptr );
 
@@ -88,7 +88,7 @@ bool convertAnimated( const vector<const IECoreScene::PointsPrimitive *> &object
 
 	vector<ParameterList> animatedParameters;
 	NodeAlgo::primitiveVariableParameterLists(
-		vector<const Primitive *>( objects.begin(), objects.end() ),
+		IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( objects ),
 		parameters, animatedParameters
 	);
 

--- a/src/IECoreDelight/PointsAlgo.cpp
+++ b/src/IECoreDelight/PointsAlgo.cpp
@@ -72,7 +72,7 @@ bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::Poi
 	ParameterList parameters;
 	staticParameters( objects.front(), parameters );
 
-	vector<ParameterList> animatedParameters;
+	IECoreScenePreview::Renderer::Samples<ParameterList> animatedParameters;
 	NodeAlgo::primitiveVariableParameterLists(
 		IECoreScenePreview::Renderer::staticSamplesCast<const Primitive *>( objects ),
 		parameters, animatedParameters

--- a/src/IECoreDelight/PointsAlgo.cpp
+++ b/src/IECoreDelight/PointsAlgo.cpp
@@ -65,21 +65,7 @@ void staticParameters( const IECoreScene::PointsPrimitive *object, ParameterList
 	}
 }
 
-bool convertStatic( const IECoreScene::PointsPrimitive *object, NSIContext_t context, const char *handle )
-{
-	NSICreate( context, handle, "particles", 0, nullptr );
-
-	ParameterList parameters;
-	staticParameters( object, parameters );
-
-	NodeAlgo::primitiveVariableParameterList( object, parameters );
-
-	NSISetAttribute( context, handle, parameters.size(), parameters.data() );
-
-	return true;
-}
-
-bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &objects, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &objects, const IECoreScenePreview::Renderer::SampleTimes &times, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "particles", 0, nullptr );
 
@@ -105,6 +91,6 @@ bool convertAnimated( const IECoreScenePreview::Renderer::Samples<const IECoreSc
 	return true;
 }
 
-NodeAlgo::ConverterDescription<PointsPrimitive> g_description( convertStatic, convertAnimated );
+NodeAlgo::ConverterDescription<PointsPrimitive> g_description( convert );
 
 } // namespace

--- a/src/IECoreDelight/ProceduralAlgo.cpp
+++ b/src/IECoreDelight/ProceduralAlgo.cpp
@@ -57,8 +57,10 @@ using namespace IECoreDelight;
 namespace
 {
 
-bool convert( const IECoreScene::ExternalProcedural *object, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::ExternalProcedural *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
+	const IECoreScene::ExternalProcedural *object = samples[0];
+
 	NSICreate( context, handle, "procedural", 0, nullptr );
 
 	ParameterList procParameters;

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -943,29 +943,6 @@ class InstanceCache : public IECore::RefCounted
 		}
 
 		// Can be called concurrently with other get() calls.
-		DelightHandleSharedPtr get( const IECore::Object *object )
-		{
-			const IECore::MurmurHash hash = object->Object::hash();
-
-			Cache::accessor a;
-			m_cache.insert( a, hash );
-			if( !a->second )
-			{
-				const std::string &name = "instance:" + hash.toString();
-				if( NodeAlgo::convert( object, m_context, name.c_str() ) )
-				{
-					a->second = make_shared<DelightHandle>( m_context, name, m_ownership );
-				}
-				else
-				{
-					a->second = nullptr;
-				}
-			}
-
-			return a->second;
-		}
-
-		// Can be called concurrently with other get() calls.
 		DelightHandleSharedPtr get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 		{
 			IECore::MurmurHash hash;
@@ -1571,7 +1548,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
 			const string objectHandle = "camera:" + name;
-			if( !NodeAlgo::convert( camera, m_context, objectHandle.c_str() ) )
+			if( !NodeAlgo::convert( { camera }, { 0.0 }, m_context, objectHandle.c_str() ) )
 			{
 				return nullptr;
 			}
@@ -1611,7 +1588,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			DelightHandleSharedPtr instance;
 			if( object )
 			{
-				instance = m_instanceCache->get( object );
+				instance = m_instanceCache->get( { object }, { 0.0 } );
 			}
 
 			ObjectInterfacePtr result = new DelightLight( m_context, name, instance, ownership() );
@@ -1623,26 +1600,6 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
 			return nullptr;
-		}
-
-		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
-		{
-			if( !object )
-			{
-				return nullptr;
-			}
-
-			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
-
-			DelightHandleSharedPtr instance = m_instanceCache->get( object );
-			if( !instance )
-			{
-				return nullptr;
-			}
-
-			ObjectInterfacePtr result = new DelightObject( m_context, name, instance, ownership() );
-			result->attributes( attributes );
-			return result;
 		}
 
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
@@ -1804,7 +1761,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 				camera = defaultCamera;
 
 				cameraHandle = "ieCoreDelight:defaultCamera";
-				NodeAlgo::convert( defaultCamera.get(), m_context, cameraHandle.c_str() );
+				NodeAlgo::convert( { defaultCamera.get() }, { 0.0 }, m_context, cameraHandle.c_str() );
 
 				m_defaultCamera = DelightHandle( m_context, cameraHandle, ownership() );
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1038,36 +1038,22 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 			);
 		}
 
-		void transform( const Imath::M44f &transform ) override
-		{
-			if( transform == M44f() && !m_haveTransform )
-			{
-				return;
-			}
-
-			M44d m( transform );
-			NSIParam_t param = {
-				"transformationmatrix",
-				m.getValue(),
-				NSITypeDoubleMatrix,
-				0, 1, // array length, count
-				0 // flags
-			};
-			NSISetAttribute( m_transformHandle.context(), m_transformHandle.name(), 1, &param );
-
-			m_haveTransform = true;
-		}
-
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			if( m_haveTransform )
 			{
 				NSIDeleteAttribute( m_transformHandle.context(), m_transformHandle.name(), "transformationmatrix" );
+				m_haveTransform = false;
 			}
 
-			for( size_t i = 0, e = samples.size(); i < e; ++i )
+			if( std::all_of( samples.begin(), samples.end(), [] ( const M44f &m ) { return m == M44f(); } ) )
 			{
-				M44d m( samples[i] );
+				return;
+			}
+
+			if( samples.size() == 1 )
+			{
+				M44d m( samples[0] );
 				NSIParam_t param = {
 					"transformationmatrix",
 					m.getValue(),
@@ -1075,7 +1061,22 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 					0, 1, // array length, count
 					0 // flags
 				};
-				NSISetAttributeAtTime( m_transformHandle.context(), m_transformHandle.name(), times[i], 1, &param );
+				NSISetAttribute( m_transformHandle.context(), m_transformHandle.name(), 1, &param );
+			}
+			else
+			{
+				for( size_t i = 0, e = samples.size(); i < e; ++i )
+				{
+					M44d m( samples[i] );
+					NSIParam_t param = {
+						"transformationmatrix",
+						m.getValue(),
+						NSITypeDoubleMatrix,
+						0, 1, // array length, count
+						0 // flags
+					};
+					NSISetAttributeAtTime( m_transformHandle.context(), m_transformHandle.name(), times[i], 1, &param );
+				}
 			}
 
 			m_haveTransform = true;

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1543,12 +1543,12 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			return m_attributesCache->get( attributes );
 		}
 
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
 			const string objectHandle = "camera:" + name;
-			if( !NodeAlgo::convert( { camera }, { 0.0 }, m_context, objectHandle.c_str() ) )
+			if( !NodeAlgo::convert( ObjectSamples( samples.begin(), samples.end() ), times, m_context, objectHandle.c_str() ) )
 			{
 				return nullptr;
 			}
@@ -1556,7 +1556,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			// Store the camera for later use in updateCamera().
 			{
 				tbb::spin_mutex::scoped_lock lock( m_camerasMutex );
-				m_cameras[objectHandle] = camera;
+				m_cameras[objectHandle] = samples[0];
 			}
 
 			DelightHandleSharedPtr cameraHandle(

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -969,9 +969,9 @@ class InstanceCache : public IECore::RefCounted
 		DelightHandleSharedPtr get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 		{
 			IECore::MurmurHash hash;
-			for( std::vector<const IECore::Object *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
+			for( const auto &sample : samples )
 			{
-				(*it)->hash( hash );
+				sample->hash( hash );
 			}
 			hash.append( times.data(), times.size() );
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -966,17 +966,14 @@ class InstanceCache : public IECore::RefCounted
 		}
 
 		// Can be called concurrently with other get() calls.
-		DelightHandleSharedPtr get( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times )
+		DelightHandleSharedPtr get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 		{
 			IECore::MurmurHash hash;
 			for( std::vector<const IECore::Object *>::const_iterator it = samples.begin(), eIt = samples.end(); it != eIt; ++it )
 			{
 				(*it)->hash( hash );
 			}
-			for( std::vector<float>::const_iterator it = times.begin(), eIt = times.end(); it != eIt; ++it )
-			{
-				hash.append( *it );
-			}
+			hash.append( times.data(), times.size() );
 
 			Cache::accessor a;
 			m_cache.insert( a, hash );
@@ -1084,7 +1081,7 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 			m_haveTransform = true;
 		}
 
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override
 		{
 			if( m_haveTransform )
 			{
@@ -1648,7 +1645,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 

--- a/src/IECoreDelight/SphereAlgo.cpp
+++ b/src/IECoreDelight/SphereAlgo.cpp
@@ -48,7 +48,7 @@ using namespace IECoreDelight;
 namespace
 {
 
-bool convert( const IECoreScene::SpherePrimitive *object, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::SpherePrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
 	NSICreate( context, handle, "particles", 0, nullptr );
 
@@ -64,7 +64,7 @@ bool convert( const IECoreScene::SpherePrimitive *object, NSIContext_t context, 
 		NSIParamPerVertex
 	} );
 
-	const float width = object->radius() * 2;
+	const float width = samples[0]->radius() * 2;
 	parameters.add( {
 		"width",
 		&width,

--- a/src/IECoreDelight/VDBAlgo.cpp
+++ b/src/IECoreDelight/VDBAlgo.cpp
@@ -57,8 +57,10 @@ static std::vector<std::pair<std::string, std::vector<std::string>>> g_gridCandi
 namespace
 {
 
-bool convert( const IECoreVDB::VDBObject *object, NSIContext_t context, const char *handle )
+bool convert( const IECoreScenePreview::Renderer::Samples<const IECoreVDB::VDBObject *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, NSIContext_t context, const char *handle )
 {
+	const IECoreVDB::VDBObject *object = samples[0];
+
 	ParameterList parameters;
 
 	if( !object->unmodifiedFromFile() )

--- a/src/IECoreRenderMan/Camera.cpp
+++ b/src/IECoreRenderMan/Camera.cpp
@@ -212,7 +212,7 @@ void Camera::transform( const Imath::M44f &transform )
 	transformInternal( { transform }, { 0.0f } );
 }
 
-void Camera::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+void Camera::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	transformInternal( samples, times );
 }
@@ -234,7 +234,7 @@ void Camera::assignInstanceID( uint32_t id )
 {
 }
 
-void Camera::transformInternal( std::vector<Imath::M44f> samples, const std::vector<float> &times )
+void Camera::transformInternal( IECoreScenePreview::Renderer::TransformSamples samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	for( auto &m : samples )
 	{

--- a/src/IECoreRenderMan/Camera.cpp
+++ b/src/IECoreRenderMan/Camera.cpp
@@ -207,14 +207,27 @@ Camera::~Camera()
 	}
 }
 
-void Camera::transform( const Imath::M44f &transform )
-{
-	transformInternal( { transform }, { 0.0f } );
-}
-
 void Camera::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
-	transformInternal( samples, times );
+	IECoreScenePreview::Renderer::TransformSamples processedSamples = samples;
+	for( auto &m : processedSamples )
+	{
+		m = M44f().scale( V3f( 1, 1, -1 ) ) * m;
+	}
+
+	AnimatedTransform transform( processedSamples, times );
+
+	const auto result = m_session->riley->ModifyCamera(
+		m_cameraId,
+		nullptr,
+		&transform,
+		nullptr
+	);
+
+	if( result != riley::CameraResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Camera::transform", "Unexpected edit failure" );
+	}
 }
 
 bool Camera::attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
@@ -232,26 +245,4 @@ void Camera::assignID( uint32_t id )
 
 void Camera::assignInstanceID( uint32_t id )
 {
-}
-
-void Camera::transformInternal( IECoreScenePreview::Renderer::TransformSamples samples, const IECoreScenePreview::Renderer::SampleTimes &times )
-{
-	for( auto &m : samples )
-	{
-		m = M44f().scale( V3f( 1, 1, -1 ) ) * m;
-	}
-
-	AnimatedTransform transform( samples, times );
-
-	const auto result = m_session->riley->ModifyCamera(
-		m_cameraId,
-		nullptr,
-		&transform,
-		nullptr
-	);
-
-	if( result != riley::CameraResult::k_Success )
-	{
-		IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Camera::transform", "Unexpected edit failure" );
-	}
 }

--- a/src/IECoreRenderMan/Camera.h
+++ b/src/IECoreRenderMan/Camera.h
@@ -51,7 +51,6 @@ class Camera :  public IECoreScenePreview::Renderer::ObjectInterface
 		Camera( const std::string &name, const IECoreScene::Camera *camera, Session *session );
 		~Camera() override;
 
-		void transform( const Imath::M44f &transform ) override;
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
@@ -59,8 +58,6 @@ class Camera :  public IECoreScenePreview::Renderer::ObjectInterface
 		void assignInstanceID( uint32_t id ) override;
 
 	private :
-
-		void transformInternal( IECoreScenePreview::Renderer::TransformSamples samples, const IECoreScenePreview::Renderer::SampleTimes &times );
 
 		Session *m_session;
 		riley::CameraId m_cameraId;

--- a/src/IECoreRenderMan/Camera.h
+++ b/src/IECoreRenderMan/Camera.h
@@ -52,7 +52,7 @@ class Camera :  public IECoreScenePreview::Renderer::ObjectInterface
 		~Camera() override;
 
 		void transform( const Imath::M44f &transform ) override;
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;
@@ -60,7 +60,7 @@ class Camera :  public IECoreScenePreview::Renderer::ObjectInterface
 
 	private :
 
-		void transformInternal( std::vector<Imath::M44f> samples, const std::vector<float> &times );
+		void transformInternal( IECoreScenePreview::Renderer::TransformSamples samples, const IECoreScenePreview::Renderer::SampleTimes &times );
 
 		Session *m_session;
 		riley::CameraId m_cameraId;

--- a/src/IECoreRenderMan/CurvesAlgo.cpp
+++ b/src/IECoreRenderMan/CurvesAlgo.cpp
@@ -96,7 +96,7 @@ RtUString convertStaticCurves( const IECoreScene::CurvesPrimitive *curves, RtPri
 	return Loader::strings().k_Ri_Curves;
 }
 
-RtUString convertAnimatedCurves( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertAnimatedCurves( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	if( CurvesAlgo::isPinned( samples[0] ) )
 	{

--- a/src/IECoreRenderMan/CurvesAlgo.cpp
+++ b/src/IECoreRenderMan/CurvesAlgo.cpp
@@ -86,17 +86,14 @@ RtUString convertCurves( const IECoreScenePreview::Renderer::Samples<const IECor
 {
 	if( CurvesAlgo::isPinned( samples[0] ) )
 	{
-		boost::container::small_vector<CurvesPrimitivePtr, 2> processedCurves;
-		boost::container::small_vector<const CurvesPrimitive *, 2> processedSamples;
-		processedCurves.reserve( samples.size() );
+		IECoreScenePreview::Renderer::Samples<CurvesPrimitivePtr> processedSamples;
 		processedSamples.reserve( samples.size() );
 		for( auto sample : samples )
 		{
-			processedCurves.push_back( sample->copy() );
-			CurvesAlgo::convertPinnedToNonPeriodic( processedCurves.back().get() );
-			processedSamples.push_back( processedCurves.back().get() );
+			processedSamples.push_back( sample->copy() );
+			CurvesAlgo::convertPinnedToNonPeriodic( processedSamples.back().get() );
 		}
-		return convertCurves( processedSamples, sampleTimes, primVars, messageContext );
+		return convertCurves( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::CurvesPrimitive *>( processedSamples ), sampleTimes, primVars, messageContext );
 	}
 
 	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );

--- a/src/IECoreRenderMan/CurvesAlgo.cpp
+++ b/src/IECoreRenderMan/CurvesAlgo.cpp
@@ -82,21 +82,7 @@ void convertCurvesTopology( const IECoreScene::CurvesPrimitive *curves, RtPrimVa
 	primVars.SetIntegerDetail( Loader::strings().k_Ri_nvertices, curves->verticesPerCurve()->readable().data(), RtDetailType::k_uniform );
 }
 
-RtUString convertStaticCurves( const IECoreScene::CurvesPrimitive *curves, RtPrimVarList &primVars, const std::string &messageContext )
-{
-	if( CurvesAlgo::isPinned( curves ) )
-	{
-		CurvesPrimitivePtr processedCurves = curves->copy();
-		CurvesAlgo::convertPinnedToNonPeriodic( processedCurves.get() );
-		return convertStaticCurves( processedCurves.get(), primVars, messageContext );
-	}
-
-	GeometryAlgo::convertPrimitive( curves, primVars, messageContext );
-	convertCurvesTopology( curves, primVars, messageContext );
-	return Loader::strings().k_Ri_Curves;
-}
-
-RtUString convertAnimatedCurves( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertCurves( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	if( CurvesAlgo::isPinned( samples[0] ) )
 	{
@@ -110,7 +96,7 @@ RtUString convertAnimatedCurves( const IECoreScenePreview::Renderer::Samples<con
 			CurvesAlgo::convertPinnedToNonPeriodic( processedCurves.back().get() );
 			processedSamples.push_back( processedCurves.back().get() );
 		}
-		return convertAnimatedCurves( processedSamples, sampleTimes, primVars, messageContext );
+		return convertCurves( processedSamples, sampleTimes, primVars, messageContext );
 	}
 
 	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );
@@ -118,6 +104,6 @@ RtUString convertAnimatedCurves( const IECoreScenePreview::Renderer::Samples<con
 	return Loader::strings().k_Ri_Curves;
 }
 
-GeometryAlgo::ConverterDescription<CurvesPrimitive> g_curvesConverterDescription( convertStaticCurves, convertAnimatedCurves );
+GeometryAlgo::ConverterDescription<CurvesPrimitive> g_curvesConverterDescription( convertCurves );
 
 } // namespace

--- a/src/IECoreRenderMan/CurvesAlgo.cpp
+++ b/src/IECoreRenderMan/CurvesAlgo.cpp
@@ -96,12 +96,12 @@ RtUString convertStaticCurves( const IECoreScene::CurvesPrimitive *curves, RtPri
 	return Loader::strings().k_Ri_Curves;
 }
 
-RtUString convertAnimatedCurves( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertAnimatedCurves( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	if( CurvesAlgo::isPinned( samples[0] ) )
 	{
-		std::vector<CurvesPrimitivePtr> processedCurves;
-		std::vector<const CurvesPrimitive *> processedSamples;
+		boost::container::small_vector<CurvesPrimitivePtr, 2> processedCurves;
+		boost::container::small_vector<const CurvesPrimitive *, 2> processedSamples;
 		processedCurves.reserve( samples.size() );
 		processedSamples.reserve( samples.size() );
 		for( auto sample : samples )
@@ -113,7 +113,7 @@ RtUString convertAnimatedCurves( const std::vector<const IECoreScene::CurvesPrim
 		return convertAnimatedCurves( processedSamples, sampleTimes, primVars, messageContext );
 	}
 
-	GeometryAlgo::convertPrimitive( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
+	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );
 	convertCurvesTopology( samples[0], primVars, messageContext );
 	return Loader::strings().k_Ri_Curves;
 }

--- a/src/IECoreRenderMan/GeometryAlgo.cpp
+++ b/src/IECoreRenderMan/GeometryAlgo.cpp
@@ -57,15 +57,7 @@ namespace
 
 using namespace IECoreRenderMan;
 
-struct Converters
-{
-
-	GeometryAlgo::Converter converter;
-	GeometryAlgo::MotionConverter motionConverter;
-
-};
-
-using Registry = std::unordered_map<IECore::TypeId, Converters>;
+using Registry = std::unordered_map<IECore::TypeId, GeometryAlgo::Converter>;
 
 Registry &registry()
 {
@@ -324,16 +316,6 @@ void convertDetail( const IECoreScene::Primitive *primitive, RtPrimVarList &prim
 
 const std::string g_p( "P" );
 
-void convertP( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarList, const std::string &messageContext )
-{
-	auto it = primitive->variables.find( g_p );
-	if( it != primitive->variables.end() )
-	{
-		const PrimitiveVariableConverter converter( messageContext );
-		dispatch( it->second.data.get(), converter, Loader::strings().k_P, it->second, primVarList );
-	}
-}
-
 void convertP( const GeometryAlgo::PrimitiveSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
 {
 	const auto firstSampleIt = samples[0]->variables.find( g_p );
@@ -395,17 +377,6 @@ void convertPrimitiveVariables( const IECoreScene::Primitive *primitive, RtPrimV
 // Implementation of external API
 //////////////////////////////////////////////////////////////////////////
 
-RtUString IECoreRenderMan::GeometryAlgo::convert( const IECore::Object *object, RtPrimVarList &primVars, const std::string &messageContext )
-{
-	Registry &r = registry();
-	auto it = r.find( object->typeId() );
-	if( it == r.end() )
-	{
-		return RtUString();
-	}
-	return it->second.converter( object, primVars, messageContext );
-}
-
 RtUString IECoreRenderMan::GeometryAlgo::convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	Registry &r = registry();
@@ -414,26 +385,12 @@ RtUString IECoreRenderMan::GeometryAlgo::convert( const IECoreScenePreview::Rend
 	{
 		return RtUString();
 	}
-	if( it->second.motionConverter )
-	{
-		return it->second.motionConverter( samples, sampleTimes, primVars, messageContext );
-	}
-	else
-	{
-		return it->second.converter( samples.front().get(), primVars, messageContext );
-	}
+	return it->second( samples, sampleTimes, primVars, messageContext );
 }
 
-void IECoreRenderMan::GeometryAlgo::registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter )
+void IECoreRenderMan::GeometryAlgo::registerConverter( IECore::TypeId fromType, Converter converter )
 {
-	registry()[fromType] = { converter, motionConverter };
-}
-
-void IECoreRenderMan::GeometryAlgo::convertPrimitive( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarList, const std::string &messageContext )
-{
-	convertDetail( primitive, primVarList );
-	convertP( primitive, primVarList, messageContext );
-	convertPrimitiveVariables( primitive, primVarList, messageContext );
+	registry()[fromType] = converter;
 }
 
 void IECoreRenderMan::GeometryAlgo::convertPrimitive( const PrimitiveSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )

--- a/src/IECoreRenderMan/GeometryAlgo.cpp
+++ b/src/IECoreRenderMan/GeometryAlgo.cpp
@@ -334,7 +334,7 @@ void convertP( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarLi
 	}
 }
 
-void convertP( const std::vector<const IECoreScene::Primitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
+void convertP( const GeometryAlgo::PrimitiveSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
 {
 	const auto firstSampleIt = samples[0]->variables.find( g_p );
 	if( firstSampleIt == samples[0]->variables.end() )
@@ -436,7 +436,7 @@ void IECoreRenderMan::GeometryAlgo::convertPrimitive( const IECoreScene::Primiti
 	convertPrimitiveVariables( primitive, primVarList, messageContext );
 }
 
-void IECoreRenderMan::GeometryAlgo::convertPrimitive( const std::vector<const IECoreScene::Primitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
+void IECoreRenderMan::GeometryAlgo::convertPrimitive( const PrimitiveSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
 {
 	convertDetail( samples[0], primVarList );
 	// "P" is the only primitive variable that RenderMan allows to be animated

--- a/src/IECoreRenderMan/GeometryAlgo.cpp
+++ b/src/IECoreRenderMan/GeometryAlgo.cpp
@@ -334,7 +334,7 @@ void convertP( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarLi
 	}
 }
 
-void convertP( const std::vector<const IECoreScene::Primitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
+void convertP( const std::vector<const IECoreScene::Primitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
 {
 	const auto firstSampleIt = samples[0]->variables.find( g_p );
 	if( firstSampleIt == samples[0]->variables.end() )
@@ -406,7 +406,7 @@ RtUString IECoreRenderMan::GeometryAlgo::convert( const IECore::Object *object, 
 	return it->second.converter( object, primVars, messageContext );
 }
 
-RtUString IECoreRenderMan::GeometryAlgo::convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString IECoreRenderMan::GeometryAlgo::convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	Registry &r = registry();
 	auto it = r.find( samples.front()->typeId() );
@@ -436,7 +436,7 @@ void IECoreRenderMan::GeometryAlgo::convertPrimitive( const IECoreScene::Primiti
 	convertPrimitiveVariables( primitive, primVarList, messageContext );
 }
 
-void IECoreRenderMan::GeometryAlgo::convertPrimitive( const std::vector<const IECoreScene::Primitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext = "GeometryAlgo::convertPrimitive" )
+void IECoreRenderMan::GeometryAlgo::convertPrimitive( const std::vector<const IECoreScene::Primitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
 {
 	convertDetail( samples[0], primVarList );
 	// "P" is the only primitive variable that RenderMan allows to be animated

--- a/src/IECoreRenderMan/GeometryAlgo.cpp
+++ b/src/IECoreRenderMan/GeometryAlgo.cpp
@@ -420,7 +420,7 @@ RtUString IECoreRenderMan::GeometryAlgo::convert( const IECoreScenePreview::Rend
 	}
 	else
 	{
-		return it->second.converter( samples.front(), primVars, messageContext );
+		return it->second.converter( samples.front().get(), primVars, messageContext );
 	}
 }
 

--- a/src/IECoreRenderMan/GeometryAlgo.h
+++ b/src/IECoreRenderMan/GeometryAlgo.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
 #include "IECoreScene/Primitive.h"
 
 #include "IECore/Object.h"
@@ -56,11 +58,11 @@ RtUString convert( const IECore::Object *object, RtPrimVarList &primVars, const 
 
 /// As above, but converting a moving object. If no motion converter
 /// is available, the first sample is converted instead.
-RtUString convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext = "GeometryAlgo::convert" );
+RtUString convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext = "GeometryAlgo::convert" );
 
 /// Signature of a function which can convert an IECore::Object into a geometry prototype.
 using Converter = RtUString (*)( const IECore::Object *object, RtParamList &primVars, const std::string &messageContext );
-using MotionConverter = RtUString (*)( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
+using MotionConverter = RtUString (*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
 
 /// Registers a converter for a specific type. Use the ConverterDescription
 /// utility class in preference to this, since it provides additional type
@@ -77,7 +79,7 @@ class ConverterDescription
 
 		/// Type-specific conversion functions.
 		using Converter = RtUString (*)( const T *object, RtPrimVarList &primVars, const std::string &messageContext );
-		using MotionConverter = RtUString (*)( const std::vector<const T *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
+		using MotionConverter = RtUString (*)( const std::vector<const T *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{
@@ -95,6 +97,6 @@ class ConverterDescription
 
 /// Primitive converters should call this function before doing their own type-specific conversion.
 void convertPrimitive( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarList, const std::string &messageContext );
-void convertPrimitive( const std::vector<const IECoreScene::Primitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext );
+void convertPrimitive( const std::vector<const IECoreScene::Primitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext );
 
 } // namespace IECoreRenderMan::GeometryAlgo

--- a/src/IECoreRenderMan/GeometryAlgo.h
+++ b/src/IECoreRenderMan/GeometryAlgo.h
@@ -61,8 +61,8 @@ RtUString convert( const IECore::Object *object, RtPrimVarList &primVars, const 
 RtUString convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext = "GeometryAlgo::convert" );
 
 /// Signature of a function which can convert an IECore::Object into a geometry prototype.
-using Converter = RtUString (*)( const IECore::Object *object, RtParamList &primVars, const std::string &messageContext );
-using MotionConverter = RtUString (*)( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
+using Converter = std::function<RtUString ( const IECore::Object *object, RtPrimVarList &primVars, const std::string &messageContext )>;
+using MotionConverter = std::function<RtUString ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )>;
 
 /// Registers a converter for a specific type. Use the ConverterDescription
 /// utility class in preference to this, since it provides additional type
@@ -78,15 +78,28 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using Converter = RtUString (*)( const T *object, RtPrimVarList &primVars, const std::string &messageContext );
-		using MotionConverter = RtUString (*)( const std::vector<const T *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
+		using TypedConverter = RtUString (*)( const T *object, RtPrimVarList &primVars, const std::string &messageContext );
+		using TypedObjectSamples = IECoreScenePreview::Renderer::Samples<const T *>;
+		using TypedMotionConverter = RtUString (*)( const TypedObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
 
-		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
 		{
+			MotionConverter motionConverterWrapper;
+			if( motionConverter )
+			{
+				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+				{
+					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), sampleTimes, primVars, messageContext );
+				};
+			}
+
 			registerConverter(
 				T::staticTypeId(),
-				reinterpret_cast<GeometryAlgo::Converter>( converter ),
-				reinterpret_cast<GeometryAlgo::MotionConverter>( motionConverter )
+				[converter] ( const IECore::Object *sample, RtPrimVarList &primVars, const std::string &messageContext )
+				{
+					return converter( static_cast<const T *>( sample ), primVars, messageContext );
+				},
+				motionConverterWrapper
 			);
 		}
 
@@ -95,8 +108,10 @@ class ConverterDescription
 /// Primitive conversion helpers
 /// ============================
 
+using PrimitiveSamples = IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *>;
+
 /// Primitive converters should call this function before doing their own type-specific conversion.
 void convertPrimitive( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarList, const std::string &messageContext );
-void convertPrimitive( const std::vector<const IECoreScene::Primitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext );
+void convertPrimitive( const PrimitiveSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext );
 
 } // namespace IECoreRenderMan::GeometryAlgo

--- a/src/IECoreRenderMan/GeometryAlgo.h
+++ b/src/IECoreRenderMan/GeometryAlgo.h
@@ -51,23 +51,18 @@ namespace IECoreRenderMan::GeometryAlgo
 /// Geometry conversion
 /// ===================
 
-/// Converts the specified `IECore::Object` into arguments for
+/// Converts the specified `IECore::Object` samples into arguments for
 /// `Riley::CreateGeometryPrototype()`. Fills `primVars` and returns the
 /// geometry `type`. Returns an empty string if no converter is available.
-RtUString convert( const IECore::Object *object, RtPrimVarList &primVars, const std::string &messageContext = "GeometryAlgo::convert" );
-
-/// As above, but converting a moving object. If no motion converter
-/// is available, the first sample is converted instead.
 RtUString convert( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext = "GeometryAlgo::convert" );
 
-/// Signature of a function which can convert an IECore::Object into a geometry prototype.
-using Converter = std::function<RtUString ( const IECore::Object *object, RtPrimVarList &primVars, const std::string &messageContext )>;
-using MotionConverter = std::function<RtUString ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )>;
+/// Signature of a function which implements `convert()` for a particular type.
+using Converter = std::function<RtUString ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )>;
 
 /// Registers a converter for a specific type. Use the ConverterDescription
 /// utility class in preference to this, since it provides additional type
 /// safety.
-void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter = nullptr );
+void registerConverter( IECore::TypeId fromType, Converter converter );
 
 /// Class which registers a converter for type T automatically
 /// when instantiated.
@@ -78,28 +73,17 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using TypedConverter = RtUString (*)( const T *object, RtPrimVarList &primVars, const std::string &messageContext );
 		using TypedObjectSamples = IECoreScenePreview::Renderer::Samples<const T *>;
-		using TypedMotionConverter = RtUString (*)( const TypedObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
+		using TypedConverter = RtUString (*)( const TypedObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
 
-		ConverterDescription( TypedConverter converter, TypedMotionConverter motionConverter = nullptr )
+		ConverterDescription( TypedConverter converter )
 		{
-			MotionConverter motionConverterWrapper;
-			if( motionConverter )
-			{
-				motionConverterWrapper = [motionConverter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
-				{
-					return motionConverter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), sampleTimes, primVars, messageContext );
-				};
-			}
-
 			registerConverter(
 				T::staticTypeId(),
-				[converter] ( const IECore::Object *sample, RtPrimVarList &primVars, const std::string &messageContext )
+				[converter] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 				{
-					return converter( static_cast<const T *>( sample ), primVars, messageContext );
-				},
-				motionConverterWrapper
+					return converter( IECoreScenePreview::Renderer::staticSamplesCast<const T *>( samples ), sampleTimes, primVars, messageContext );
+				}
 			);
 		}
 
@@ -111,7 +95,6 @@ class ConverterDescription
 using PrimitiveSamples = IECoreScenePreview::Renderer::Samples<const IECoreScene::Primitive *>;
 
 /// Primitive converters should call this function before doing their own type-specific conversion.
-void convertPrimitive( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarList, const std::string &messageContext );
 void convertPrimitive( const PrimitiveSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext );
 
 } // namespace IECoreRenderMan::GeometryAlgo

--- a/src/IECoreRenderMan/GeometryPrototypeCache.cpp
+++ b/src/IECoreRenderMan/GeometryPrototypeCache.cpp
@@ -75,7 +75,7 @@ GeometryPrototypePtr GeometryPrototypeCache::get( const IECoreScenePreview::Rend
 		if( samples.size() == 1 )
 		{
 			/// \todo Remove static conversions from GeometryAlgo?
-			type = GeometryAlgo::convert( samples[0], primVars, messageContext );
+			type = GeometryAlgo::convert( samples[0].get(), primVars, messageContext );
 		}
 		else
 		{

--- a/src/IECoreRenderMan/GeometryPrototypeCache.cpp
+++ b/src/IECoreRenderMan/GeometryPrototypeCache.cpp
@@ -60,9 +60,9 @@ GeometryPrototypePtr GeometryPrototypeCache::get( const IECore::Object *object, 
 	return get( { object }, { 0.0f }, attributes, messageContext );
 }
 
-GeometryPrototypePtr GeometryPrototypeCache::get( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, const Attributes *attributes, const std::string &messageContext )
+GeometryPrototypePtr GeometryPrototypeCache::get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, const Attributes *attributes, const std::string &messageContext )
 {
-	auto converter = [&] ( const vector<const IECore::Object *> &samples, const vector<float> &sampleTimes, const Attributes *attributes, Session *session, GeometryPrototypePtr &result ) {
+	auto converter = [&] ( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, const Attributes *attributes, Session *session, GeometryPrototypePtr &result ) {
 
 		riley::DisplacementId displacement;
 		if( auto d = attributes->displacement() )

--- a/src/IECoreRenderMan/GeometryPrototypeCache.cpp
+++ b/src/IECoreRenderMan/GeometryPrototypeCache.cpp
@@ -71,16 +71,7 @@ GeometryPrototypePtr GeometryPrototypeCache::get( const IECoreScenePreview::Rend
 		}
 
 		RtPrimVarList primVars;
-		RtUString type;
-		if( samples.size() == 1 )
-		{
-			/// \todo Remove static conversions from GeometryAlgo?
-			type = GeometryAlgo::convert( samples[0].get(), primVars, messageContext );
-		}
-		else
-		{
-			type = GeometryAlgo::convert( samples, sampleTimes, primVars, messageContext );
-		}
+		const RtUString type = GeometryAlgo::convert( samples, sampleTimes, primVars, messageContext );
 
 		if( !type.Empty() )
 		{

--- a/src/IECoreRenderMan/GeometryPrototypeCache.h
+++ b/src/IECoreRenderMan/GeometryPrototypeCache.h
@@ -61,7 +61,7 @@ class GeometryPrototypeCache
 
 		// Can be called concurrently with other calls to `get()`.
 		GeometryPrototypePtr get( const IECore::Object *object, const Attributes *attributes, const std::string &messageContext );
-		GeometryPrototypePtr get( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, const Attributes *attributes, const std::string &messageContext );
+		GeometryPrototypePtr get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, const Attributes *attributes, const std::string &messageContext );
 
 		// Must not be called concurrently with anything.
 		void clearUnused();

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -180,14 +180,14 @@ void Light::transform( const Imath::M44f &transform )
 	}
 }
 
-void Light::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+void Light::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	if( m_lightInstance == riley::LightInstanceId::InvalidId() )
 	{
 		return;
 	}
 
-	vector<Imath::M44f> correctedSamples = samples;
+	IECoreScenePreview::Renderer::TransformSamples correctedSamples = samples;
 	for( auto &m : correctedSamples )
 	{
 		m = m_preTransform * m;

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -155,31 +155,6 @@ Light::~Light()
 	}
 }
 
-void Light::transform( const Imath::M44f &transform )
-{
-	if( m_lightInstance == riley::LightInstanceId::InvalidId() )
-	{
-		return;
-	}
-
-	const M44f correctedTransform = m_preTransform * transform;
-	StaticTransform staticTransform( correctedTransform );
-
-	const riley::LightInstanceResult result = m_session->modifyLightInstance(
-		m_lightInstance,
-		/* material = */ nullptr,
-		/* light shader = */ nullptr,
-		/* coordinateSystems = */ nullptr,
-		&staticTransform,
-		/* attributes = */ nullptr
-	);
-
-	if( result != riley::LightInstanceResult::k_Success )
-	{
-		IECore::msg( IECore::Msg::Warning, "RenderManLight::transform", "Unexpected edit failure" );
-	}
-}
-
 void Light::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	if( m_lightInstance == riley::LightInstanceId::InvalidId() )

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -61,7 +61,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		// =========================
 
 		void transform( const Imath::M44f &transform ) override;
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -60,7 +60,6 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		// ObjectInterface overrides
 		// =========================
 
-		void transform( const Imath::M44f &transform ) override;
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;

--- a/src/IECoreRenderMan/LightFilter.cpp
+++ b/src/IECoreRenderMan/LightFilter.cpp
@@ -87,7 +87,7 @@ void LightFilter::transform( const Imath::M44f &transform )
 	}
 }
 
-void LightFilter::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+void LightFilter::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	AnimatedTransform animatedTransform( samples, times );
 

--- a/src/IECoreRenderMan/LightFilter.cpp
+++ b/src/IECoreRenderMan/LightFilter.cpp
@@ -73,20 +73,6 @@ LightFilter::~LightFilter()
 	}
 }
 
-void LightFilter::transform( const Imath::M44f &transform )
-{
-	StaticTransform staticTransform( transform );
-
-	const riley::CoordinateSystemResult result = m_session->riley->ModifyCoordinateSystem(
-		m_coordinateSystem, &staticTransform, /* attributes = */ nullptr
-	);
-
-	if( result != riley::CoordinateSystemResult::k_Success )
-	{
-		IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::LightFilter::transform", "Unexpected edit failure" );
-	}
-}
-
 void LightFilter::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	AnimatedTransform animatedTransform( samples, times );

--- a/src/IECoreRenderMan/LightFilter.h
+++ b/src/IECoreRenderMan/LightFilter.h
@@ -58,7 +58,6 @@ class LightFilter : public IECoreScenePreview::Renderer::ObjectInterface
 		// ObjectInterface overrides
 		// =========================
 
-		void transform( const Imath::M44f &transform ) override;
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;

--- a/src/IECoreRenderMan/LightFilter.h
+++ b/src/IECoreRenderMan/LightFilter.h
@@ -59,7 +59,7 @@ class LightFilter : public IECoreScenePreview::Renderer::ObjectInterface
 		// =========================
 
 		void transform( const Imath::M44f &transform ) override;
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;

--- a/src/IECoreRenderMan/MeshAlgo.cpp
+++ b/src/IECoreRenderMan/MeshAlgo.cpp
@@ -204,7 +204,7 @@ RtUString convertStaticMesh( const IECoreScene::MeshPrimitive *mesh, RtPrimVarLi
 	return convertMeshTopology( mesh, primVars, messageContext );
 }
 
-RtUString convertAnimatedMesh( const std::vector<const IECoreScene::MeshPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertAnimatedMesh( const std::vector<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	GeometryAlgo::convertPrimitive( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
 	return convertMeshTopology( samples[0], primVars, messageContext );;

--- a/src/IECoreRenderMan/MeshAlgo.cpp
+++ b/src/IECoreRenderMan/MeshAlgo.cpp
@@ -204,9 +204,9 @@ RtUString convertStaticMesh( const IECoreScene::MeshPrimitive *mesh, RtPrimVarLi
 	return convertMeshTopology( mesh, primVars, messageContext );
 }
 
-RtUString convertAnimatedMesh( const std::vector<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertAnimatedMesh( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
-	GeometryAlgo::convertPrimitive( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
+	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );
 	return convertMeshTopology( samples[0], primVars, messageContext );;
 }
 

--- a/src/IECoreRenderMan/MeshAlgo.cpp
+++ b/src/IECoreRenderMan/MeshAlgo.cpp
@@ -198,18 +198,12 @@ RtUString convertMeshTopology( const IECoreScene::MeshPrimitive *mesh, RtPrimVar
 	return geometryType;
 }
 
-RtUString convertStaticMesh( const IECoreScene::MeshPrimitive *mesh, RtPrimVarList &primVars, const std::string &messageContext )
-{
-	GeometryAlgo::convertPrimitive( mesh, primVars, messageContext );
-	return convertMeshTopology( mesh, primVars, messageContext );
-}
-
-RtUString convertAnimatedMesh( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertMesh( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );
-	return convertMeshTopology( samples[0], primVars, messageContext );;
+	return convertMeshTopology( samples[0], primVars, messageContext );
 }
 
-GeometryAlgo::ConverterDescription<MeshPrimitive> g_meshConverterDescription( convertStaticMesh, convertAnimatedMesh );
+GeometryAlgo::ConverterDescription<MeshPrimitive> g_meshConverterDescription( convertMesh );
 
 } // namespace

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -138,7 +138,7 @@ void Object::transform( const Imath::M44f &transform )
 	}
 }
 
-void Object::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+void Object::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	AnimatedTransform animatedTransform( samples, times );
 	const riley::GeometryInstanceResult result = m_session->riley->ModifyGeometryInstance(

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -120,24 +120,6 @@ Object::~Object()
 	}
 }
 
-void Object::transform( const Imath::M44f &transform )
-{
-	StaticTransform staticTransform( transform );
-	const riley::GeometryInstanceResult result = m_session->riley->ModifyGeometryInstance(
-		/* group = */ riley::GeometryPrototypeId::InvalidId(),
-		m_geometryInstance,
-		/* material = */ nullptr,
-		/* coordsys = */ nullptr,
-		&staticTransform,
-		/* attributes = */ nullptr
-	);
-
-	if( result != riley::GeometryInstanceResult::k_Success )
-	{
-		IECore::msg( IECore::Msg::Warning, "RenderManObject::transform", "Unexpected edit failure" );
-	}
-}
-
 void Object::transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times )
 {
 	AnimatedTransform animatedTransform( samples, times );

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -55,11 +55,10 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 		~Object() override;
 
 		/// \todo RenderMan volumes seem to reject attempts to transform them
-		/// after creation, althought we get lucky and the first one works
+		/// after creation, although we get lucky and the first one works
 		/// despite returning a failure code. Perhaps we need to add transform
 		/// arguments to `Renderer::object()` and to be able to return a `bool`
 		/// here to request that the object is sent again instead?
-		void transform( const Imath::M44f &transform ) override;
 		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -60,7 +60,7 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 		/// arguments to `Renderer::object()` and to be able to return a `bool`
 		/// here to request that the object is sent again instead?
 		void transform( const Imath::M44f &transform ) override;
-		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;

--- a/src/IECoreRenderMan/PointsAlgo.cpp
+++ b/src/IECoreRenderMan/PointsAlgo.cpp
@@ -45,18 +45,12 @@ using namespace IECoreRenderMan;
 namespace
 {
 
-RtUString convertStaticPoints( const IECoreScene::PointsPrimitive *points, RtPrimVarList &primVars, const std::string &messageContext )
-{
-	GeometryAlgo::convertPrimitive( points, primVars, messageContext );
-	return Loader::strings().k_Ri_Points;
-}
-
-RtUString convertAnimatedPoints( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertPoints( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );
 	return Loader::strings().k_Ri_Points;
 }
 
-GeometryAlgo::ConverterDescription<PointsPrimitive> g_pointsConverterDescription( convertStaticPoints, convertAnimatedPoints );
+GeometryAlgo::ConverterDescription<PointsPrimitive> g_pointsConverterDescription( convertPoints );
 
 } // namespace

--- a/src/IECoreRenderMan/PointsAlgo.cpp
+++ b/src/IECoreRenderMan/PointsAlgo.cpp
@@ -51,7 +51,7 @@ RtUString convertStaticPoints( const IECoreScene::PointsPrimitive *points, RtPri
 	return Loader::strings().k_Ri_Points;
 }
 
-RtUString convertAnimatedPoints( const std::vector<const IECoreScene::PointsPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertAnimatedPoints( const std::vector<const IECoreScene::PointsPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	GeometryAlgo::convertPrimitive( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
 	return Loader::strings().k_Ri_Points;

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -167,26 +167,6 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			return new LightFilter( name, typedAttributes, m_session, m_lightLinker.get() );
 		}
 
-		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
-		{
-			if( !object )
-			{
-				return nullptr;
-			}
-
-			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
-			acquireSession();
-
-			auto typedAttributes = static_cast<const Attributes *>( attributes );
-			ConstGeometryPrototypePtr geometryPrototype = m_geometryPrototypeCache->get( object, typedAttributes, /* messageContext = */ name );
-			if( !geometryPrototype )
-			{
-				return nullptr;
-			}
-
-			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_lightLinker.get(), m_session );
-		}
-
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -187,7 +187,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_lightLinker.get(), m_session );
 		}
 
-		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
 			acquireSession();

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -129,10 +129,10 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			return new Attributes( attributes, m_materialCache.get() );
 		}
 
-		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
-			IECoreRenderMan::CameraPtr result = new IECoreRenderMan::Camera( name, camera, acquireSession() );
+			IECoreRenderMan::CameraPtr result = new IECoreRenderMan::Camera( name, samples.front().get(), acquireSession() );
 			result->attributes( attributes );
 			return result;
 		}

--- a/src/IECoreRenderMan/SphereAlgo.cpp
+++ b/src/IECoreRenderMan/SphereAlgo.cpp
@@ -49,18 +49,20 @@ namespace
 
 const RtUString g_xpuVariant( "xpu" );
 
-RtUString convertStaticSphere( const IECoreScene::SpherePrimitive *sphere, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertSphere( const IECoreScenePreview::Renderer::Samples<const SpherePrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
+	const SpherePrimitive *sphere = samples[0];
+
 	const Session *session = Session::instance();
 	assert( session );
 	if( session->rileyVariant == g_xpuVariant )
 	{
 		// XPU doesn't support sphere primitives, so convert to a mesh.
 		MeshPrimitivePtr mesh = MeshPrimitive::createSphere( sphere->radius(), sphere->zMin(), sphere->zMax(), sphere->thetaMax() );
-		return GeometryAlgo::convert( mesh.get(), primVars, messageContext );
+		return GeometryAlgo::convert( { mesh.get() }, {}, primVars, messageContext );
 	}
 
-	GeometryAlgo::convertPrimitive( sphere, primVars, messageContext );
+	GeometryAlgo::convertPrimitive( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), sampleTimes, primVars, messageContext );
 
 	const float radius = sphere->radius();
 	const float zMin = sphere->zMin();
@@ -75,6 +77,6 @@ RtUString convertStaticSphere( const IECoreScene::SpherePrimitive *sphere, RtPri
 	return Loader::strings().k_Ri_Sphere;
 }
 
-GeometryAlgo::ConverterDescription<SpherePrimitive> g_sphereConverterDescription( convertStaticSphere );
+GeometryAlgo::ConverterDescription<SpherePrimitive> g_sphereConverterDescription( convertSphere );
 
 } // namespace

--- a/src/IECoreRenderMan/Transform.h
+++ b/src/IECoreRenderMan/Transform.h
@@ -69,7 +69,7 @@ struct AnimatedTransform : riley::Transform
 
 	/// Caution : `transformSamples` and `sampleTimes` are referenced
 	/// directly, and must live until the AnimatedTransform is passed to Riley.
-	AnimatedTransform( const std::vector<Imath::M44f> &transformSamples, const std::vector<float> &sampleTimes )
+	AnimatedTransform( const IECoreScenePreview::Renderer::TransformSamples &transformSamples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes )
 	{
 		samples = transformSamples.size();
 		matrix = reinterpret_cast<const RtMatrix4x4 *>( transformSamples.data() );

--- a/src/IECoreRenderMan/VolumeAlgo.cpp
+++ b/src/IECoreRenderMan/VolumeAlgo.cpp
@@ -52,8 +52,10 @@ namespace
 
 const RtUString g_implOpenVDB( "blobbydso:impl_openvdb" );
 
-RtUString convertVDBObject( const IECoreVDB::VDBObject *vdbObject, RtPrimVarList &primVars, const std::string &messageContext )
+RtUString convertVDBObject( const IECoreScenePreview::Renderer::Samples<const IECoreVDB::VDBObject *> &samples, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
+	const IECoreVDB::VDBObject *vdbObject = samples[0];
+
 	string fileName = vdbObject->fileName();
 	if( fileName.empty() || !vdbObject->unmodifiedFromFile() )
 	{


### PR DESCRIPTION
Duplicate of #6892. I made that PR from my own fork, meaning CI didn't have the licenses needed to run the renderer tests. Opening this from the GafferHQ repo so we get full testing.