### PR TITLE
BasicInspector : Implement `source()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,11 @@ Fixes
 - Cycles, OSLObject, OSLImage, Expression : Fixed crashes when using OSL on macOS.
 - Dispatcher : Removed `dispatcher:scriptFileName` from labels for isolated tasks.
 - NodeMenu : Fixed slow operation when many OSLCode shaders have been generated.
+- SceneInspector : Added missing "source type" cell background colours for the following properties :
+  - Bound
+  - Object Type, Primitive Topology and Primitive Variables
+  - Camera and ExternalProcedural parameters
+  - Globals
 
 1.6.16.0 (relative to 1.6.15.0)
 ========

--- a/include/GafferSceneUI/Private/BasicInspector.h
+++ b/include/GafferSceneUI/Private/BasicInspector.h
@@ -72,6 +72,7 @@ class GAFFERSCENEUI_API BasicInspector : public Inspector
 
 		GafferScene::SceneAlgo::History::ConstPtr history() const override;
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
+		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -305,7 +305,9 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 		const T typedValue( const T &defaultValue, bool useFallbacks = true ) const;
 
 		/// The plug that was used to author the current value, or null if
-		/// it cannot be determined.
+		/// it cannot be determined. This may be an input plug that the user
+		/// could edit, or where not possible, an output plug where the value
+		/// was first visible.
 		///
 		/// > Note : Does not consider fallback values. When a fallback is in
 		/// > effect because the main value is null, `source()` will either

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -286,14 +286,19 @@ class _HistoryWindow( GafferUI.Window ) :
 		) :
 			editPlug = selectedPath.property( "history:source" )
 			if editPlug is not None :
-				## \todo It would be nice to implement direct toggling for boolean values here.
-				self.__popup = GafferUI.PlugPopup(
-					[ editPlug ], warning = selectedPath.property( "history:editWarning" )
-				)
-				if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
-					self.__popup.plugValueWidget().setNameVisible( False )
-
-				self.__popup.popup( parent = self )
+				if editPlug.direction() == Gaffer.Plug.Direction.In :
+					## \todo It would be nice to implement direct toggling for boolean values here.
+					self.__popup = GafferUI.PlugPopup(
+						[ editPlug ], warning = selectedPath.property( "history:editWarning" )
+					)
+					if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
+						self.__popup.plugValueWidget().setNameVisible( False )
+					self.__popup.popup( parent = self )
+				else :
+					GafferUI.PopupWindow.showWarning(
+						"{} is not editable".format( editPlug.relativeName( editPlug.ancestor( Gaffer.ScriptNode ) ) ),
+						parent = pathListing
+					)
 
 	def __dragBegin( self, pathListing, event ) :
 

--- a/python/GafferSceneUITest/BasicInspectorTest.py
+++ b/python/GafferSceneUITest/BasicInspectorTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import functools
 import unittest
 
 import IECore
@@ -89,18 +90,20 @@ class BasicInspectorTest( GafferUITest.TestCase ) :
 
 	def testInspectObject( self ) :
 
-		sphere = GafferScene.Sphere()
-		inspection = self.__inspect( sphere["out"]["object"], lambda objectPlug : objectPlug.getValue(), path = "/sphere" )
+		script = Gaffer.ScriptNode()
 
-		self.assertEqual( inspection.value(), sphere["out"].object( "/sphere" ) )
-		self.assertIsNone( inspection.source() )
+		script["sphere"] = GafferScene.Sphere()
+		inspection = self.__inspect( script["sphere"]["out"]["object"], lambda objectPlug : objectPlug.getValue(), path = "/sphere" )
+
+		self.assertEqual( inspection.value(), script["sphere"]["out"].object( "/sphere" ) )
+		self.assertEqual( inspection.source(), script["sphere"]["out"]["object"] )
 		self.assertEqual( inspection.sourceType(), inspection.SourceType.Other )
 		self.assertEqual( inspection.fallbackDescription(), "" )
 		self.assertFalse( inspection.editable() )
-		self.assertEqual( inspection.nonEditableReason(), "No editable source found in history." )
+		self.assertEqual( inspection.nonEditableReason(), "sphere.out.object is not editable." )
 		self.assertRaises( RuntimeError, inspection.acquireEdit )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "No editable source found in history." )
+		self.assertEqual( inspection.nonDisableableReason(), "sphere.out.object is not editable." )
 		self.assertRaises( RuntimeError, inspection.disableEdit )
 		self.assertFalse( inspection.canEdit( inspection.value() ) )
 		self.assertRaises( RuntimeError, inspection.edit, inspection.value() )
@@ -113,19 +116,21 @@ class BasicInspectorTest( GafferUITest.TestCase ) :
 
 	def testInspectGlobals( self ) :
 
-		options = GafferScene.CustomOptions()
-		options["options"].addChild( Gaffer.NameValuePlug( "test", 10 ) )
-		inspection = self.__inspect( options["out"]["globals"], lambda globalsPlug : globalsPlug.getValue() )
+		script = Gaffer.ScriptNode()
 
-		self.assertEqual( inspection.value(), options["out"].globals() )
-		self.assertIsNone( inspection.source() )
+		script["options"] = GafferScene.CustomOptions()
+		script["options"]["options"].addChild( Gaffer.NameValuePlug( "test", 10 ) )
+		inspection = self.__inspect( script["options"]["out"]["globals"], lambda globalsPlug : globalsPlug.getValue() )
+
+		self.assertEqual( inspection.value(), script["options"]["out"].globals() )
+		self.assertEqual( inspection.source(), script["options"]["out"]["globals"] )
 		self.assertEqual( inspection.sourceType(), inspection.SourceType.Other )
 		self.assertEqual( inspection.fallbackDescription(), "" )
 		self.assertFalse( inspection.editable() )
-		self.assertEqual( inspection.nonEditableReason(), "No editable source found in history." )
+		self.assertEqual( inspection.nonEditableReason(), "options.out.globals is not editable." )
 		self.assertRaises( RuntimeError, inspection.acquireEdit )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "No editable source found in history." )
+		self.assertEqual( inspection.nonDisableableReason(), "options.out.globals is not editable." )
 		self.assertRaises( RuntimeError, inspection.disableEdit )
 		self.assertFalse( inspection.canEdit( inspection.value() ) )
 		self.assertRaises( RuntimeError, inspection.edit, inspection.value() )
@@ -163,6 +168,84 @@ class BasicInspectorTest( GafferUITest.TestCase ) :
 			[ c.property( "history:node" ) for c in children ],
 			[ cube, primitiveVariables, meshTangents, group ]
 		)
+
+	def testSourceAndSourceType( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["cube"] = GafferScene.Cube()
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		script["primitiveVariables1"] = GafferScene.PrimitiveVariables()
+		script["primitiveVariables1"]["in"].setInput( script["cube"]["out"] )
+		script["primitiveVariables1"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["primitiveVariables1"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "beforeEditScope", 10 ) )
+
+		script["editScope"] = Gaffer.EditScope()
+		script["editScope"].setup( script["primitiveVariables1"]["out"] )
+		script["editScope"]["in"].setInput( script["primitiveVariables1"]["out"] )
+
+		script["editScope"]["primitiveVariables"] = GafferScene.PrimitiveVariables()
+		script["editScope"]["primitiveVariables"]["in"].setInput( script["editScope"]["in"] )
+		script["editScope"]["primitiveVariables"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["editScope"]["primitiveVariables"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "insideEditScope", 10 ) )
+
+		script["editScope"]["out"].setInput( script["editScope"]["primitiveVariables"]["out"] )
+
+		script["primitiveVariables2"] = GafferScene.PrimitiveVariables()
+		script["primitiveVariables2"]["in"].setInput( script["editScope"]["out"] )
+		script["primitiveVariables2"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["primitiveVariables2"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "afterEditScope", 10 ) )
+
+		def primitiveVariableData( objectPlug, primitiveVariable ) :
+
+			o = objectPlug.getValue()
+			if primitiveVariable in o :
+				return o[primitiveVariable].data
+
+			return None
+
+		def assertExpectedSource( scene, primitiveVariable, source, sourceType = None, editScope = None ) :
+
+			inspection = self.__inspect(
+				scene["object"], functools.partial( primitiveVariableData, primitiveVariable = primitiveVariable ),
+				path = "/cube", editScope = editScope
+			)
+
+			if source is None :
+				self.assertIsNone( inspection )
+				return
+
+			self.assertIsNotNone( inspection )
+			self.assertEqual( inspection.source(), source )
+			self.assertEqual( inspection.sourceType(), sourceType )
+			self.assertFalse( inspection.editable() )
+			with self.assertRaisesRegex( RuntimeError, "Not editable.*" ) :
+				inspection.acquireEdit()
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+		assertExpectedSource( script["primitiveVariables2"]["out"], "afterEditScope", script["primitiveVariables2"]["out"]["object"], SourceType.Other )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "afterEditScope", script["primitiveVariables2"]["out"]["object"], SourceType.Downstream, editScope = script["editScope"] )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["out"]["object"], SourceType.Other )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["out"]["object"], SourceType.EditScope, editScope = script["editScope"] )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "beforeEditScope", script["primitiveVariables1"]["out"]["object"], SourceType.Other )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "beforeEditScope", script["primitiveVariables1"]["out"]["object"], SourceType.Upstream, editScope = script["editScope"] )
+
+		assertExpectedSource( script["editScope"]["out"], "afterEditScope", None )
+		assertExpectedSource( script["editScope"]["out"], "afterEditScope", None, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["out"]["object"], SourceType.Other )
+		assertExpectedSource( script["editScope"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["out"]["object"], SourceType.EditScope, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["out"], "beforeEditScope", script["primitiveVariables1"]["out"]["object"], SourceType.Other )
+		assertExpectedSource( script["editScope"]["out"], "beforeEditScope", script["primitiveVariables1"]["out"]["object"], SourceType.Upstream, editScope = script["editScope"] )
+
+		assertExpectedSource( script["editScope"]["in"], "afterEditScope", None )
+		assertExpectedSource( script["editScope"]["in"], "afterEditScope", None, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["in"], "insideEditScope", None )
+		assertExpectedSource( script["editScope"]["in"], "insideEditScope", None, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["in"], "beforeEditScope", script["primitiveVariables1"]["out"]["object"], SourceType.Other )
+		assertExpectedSource( script["editScope"]["in"], "beforeEditScope", script["primitiveVariables1"]["out"]["object"], SourceType.Upstream, editScope = script["editScope"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/BasicInspector.cpp
+++ b/src/GafferSceneUI/BasicInspector.cpp
@@ -154,3 +154,21 @@ IECore::ConstObjectPtr BasicInspector::value( const GafferScene::SceneAlgo::Hist
 	Context::Scope scope( history->context.get() );
 	return m_valueFunction( history->scene->getChild<ValuePlug>( m_plug->getName() ) );
 }
+
+Gaffer::ValuePlugPtr BasicInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const
+{
+	if( history->scene->direction() == Plug::Out )
+	{
+		ConstObjectPtr v = value( history );
+		ConstObjectPtr previousValue;
+		if( history->predecessors.size() )
+		{
+			previousValue = value( history->predecessors.front().get() );
+		}
+		if( (bool)v != bool(previousValue) || (v && !v->isEqualTo( previousValue.get() )) )
+		{
+			return history->scene->getChild<ValuePlug>( m_plug->getName() );
+		}
+	}
+	return nullptr;
+}


### PR DESCRIPTION
We don't have enough knowledge to determine a source in the sense of an input plug that the user could edit. But we can at least still do it in the sense of "the value last changed here". That is sufficient to get SourceType highlighting working reasonably well in the SceneInspector.

This makes me wonder a couple of things :

- Should `Result::source()` actually always be returning the output plug where the value was first visible? It seems like this might reduce confusion between it and the plug returned by `acquireEdit()`.
- Should the test for changing values be moved to the Inspector base class?
