### PR TITLE
Deforming mesh lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Improvements
 and BSpline curves to their endpoints automatically, without manual management of duplicate endpoints or "phantom vertices".
 - SceneReader, SceneWriter : Added support for pinned UsdGeomBasisCurves.
 - OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.
+- ArnoldMeshLight : Added support for deformation motion blur (#6869).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -25,7 +25,7 @@ Improvements
 and BSpline curves to their endpoints automatically, without manual management of duplicate endpoints or "phantom vertices".
 - SceneReader, SceneWriter : Added support for pinned UsdGeomBasisCurves.
 - OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.
-- ArnoldMeshLight : Added support for deformation motion blur (#6869).
+- ArnoldMeshLight, RenderManMeshLight : Added support for deformation motion blur (#6869). In the case of RenderMan, this only affects the camera-visible mesh, since RenderMan doesn't yet support deformation for the light itself.
 
 Fixes
 -----

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -166,7 +166,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 		void output( const IECore::InternedString &name, const IECoreScene::Output *output ) override;
 		AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -167,7 +167,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 		AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;

--- a/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
@@ -60,7 +60,7 @@ class GAFFERSCENE_API CompoundRenderer final : public IECoreScenePreview::Render
 		void output( const IECore::InternedString &name, const IECoreScene::Output *output ) override;
 		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;

--- a/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
@@ -61,7 +61,7 @@ class GAFFERSCENE_API CompoundRenderer final : public IECoreScenePreview::Render
 		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -287,12 +287,13 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes = nullptr );
 
 		/// Adds a named light with the initially supplied set of attributes, which are expected
-		/// to provide at least a light shader. Object may be non-null to specify arbitrary geometry
-		/// for a geometric area light, or null to indicate that the light shader specifies its own
+		/// to provide at least a light shader. Object samples may be non-empty to specify arbitrary geometry
+		/// for a geometric area light, or empty to indicate that the light shader specifies its own
 		/// geometry internally (or is non-geometric in nature).
 		/// May return a nullptr if the light definition is not supported by the renderer.
-		/// \todo Should object be typed as Primitive?
-		virtual ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) = 0;
+		virtual ObjectInterfacePtr light( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) = 0;
+		/// Convenience wrapper for the above when there is only a single sample.
+		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes );
 
 		/// Adds a named light filter with the initially supplied set of attributes, which are expected
 		/// to provide at least a light filter shader.

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -298,7 +298,8 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		/// Adds a named light filter with the initially supplied set of attributes, which are expected
 		/// to provide at least a light filter shader.
 		/// May return a nullptr if the light filter definition is not supported by the renderer.
-		virtual ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) = 0;
+		virtual ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) = 0;
+		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes );
 
 		/// Adds a named object to the render with the initally supplied set of attributes.
 		/// The attributes may subsequently be edited in interactive mode using

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -335,6 +335,56 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		links = renderer.capturedObject( "/group/spheres/instances/sphere/0" ).capturedLinks( "lights" )
 		self.assertEqual( len( links ), numLights )
 
+	def testDeformingLight( self ) :
+
+		# Make a deforming mesh light by hand.
+
+		frame = GafferTest.FrameNode()
+
+		sphere = GafferScene.Sphere()
+		sphere["radius"].setInput( frame["output"] )
+		sphere["type"].setValue( sphere.Type.Primitive )
+
+		lightSet = GafferScene.Set()
+		lightSet["in"].setInput( sphere["out"] )
+		lightSet["name"].setValue( '__lights' )
+		lightSet["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
+
+		# Turn on deformation blur.
+
+		options = GafferScene.StandardOptions()
+		options["in"].setInput( lightSet["out"] )
+		options["options"]["render:deformationBlur"]["enabled"].setValue( True )
+		options["options"]["render:deformationBlur"]["value"].setValue( True )
+
+		# Render, and check we get the samples we want.
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( options["out"], Gaffer.Context(), renderer )
+		controller.update()
+
+		self.assertEqual( [ s.radius() for s in renderer.capturedObject( "/sphere" ).capturedSamples() ], [ 0.75, 1.25 ] )
+		self.assertEqual( renderer.capturedObject( "/sphere" ).capturedSampleTimes(), [ 0.75, 1.25 ] )
+
+	def testDeletingObject( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		deleteObject = GafferScene.DeleteObject()
+		deleteObject["in"].setInput( sphere["out"] )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( deleteObject["out"], Gaffer.Context(), renderer )
+		controller.update()
+		self.assertIsNotNone( renderer.capturedObject( "/sphere" ) )
+
+		deleteObject["filter"].setInput( sphereFilter["out"] )
+		controller.update()
+		self.assertIsNone( renderer.capturedObject( "/sphere" ) )
+
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testCapsuleDeformPerformance( self ) :
 

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -585,6 +585,15 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( sampledObject.sampleTimes, [ 1.0 ] )
 			self.assertNotEqual( h, IECore.MurmurHash() )
 
+	def testObjectSamplesWithoutObject( self ) :
+
+		group = GafferScene.Group()
+		with Gaffer.Context() as context :
+			context.set( "scene:path", GafferScene.ScenePlug.stringToPath( "/sphere" ) )
+			sampledObject = GafferScene.Private.RendererAlgo.objectSamples( group["out"]["object"], [ 0.75, 1.25 ] )
+		self.assertEqual( len( sampledObject.samples ), 0 )
+		self.assertEqual( len( sampledObject.sampleTimes ), 0 )
+
 	def testTransformSamplesCancellation( self ) :
 
 		sphere = GafferScene.Sphere()

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2560,7 +2560,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 			acquireSession();

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2550,7 +2550,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 			acquireSession();

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -958,11 +958,11 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-			OpenGLLightPtr result = new OpenGLLight( name, object, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
+			OpenGLLightPtr result = new OpenGLLight( name, samples.size() ? samples[0].get() : nullptr, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
 			m_editQueue.push( [this, result]() { m_objects.push_back( result ); } );
 			return result;
 		}

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -967,11 +967,11 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-			OpenGLLightFilterPtr result = new OpenGLLightFilter( name, object, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
+			OpenGLLightFilterPtr result = new OpenGLLightFilter( name, samples.size() ? samples[0].get() : nullptr, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
 			m_editQueue.push( [this, result]() { m_objects.push_back( result ); } );
 			return result;
 		}

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -125,9 +125,9 @@ Renderer::ObjectInterfacePtr CapturingRenderer::light( const std::string &name, 
 	return this->object( name, samples, times, attributes );
 }
 
-Renderer::ObjectInterfacePtr CapturingRenderer::lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CapturingRenderer::lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
-	return this->object( name, { object }, { 0.0 }, attributes );
+	return this->object( name, samples, times, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -120,9 +120,9 @@ Renderer::ObjectInterfacePtr CapturingRenderer::camera( const std::string &name,
 	return this->object( name, ObjectSamples( samples.begin(), samples.end() ), times, attributes );
 }
 
-Renderer::ObjectInterfacePtr CapturingRenderer::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CapturingRenderer::light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
-	return this->object( name, { object }, { 0.0 }, attributes );
+	return this->object( name, samples, times, attributes );
 }
 
 Renderer::ObjectInterfacePtr CapturingRenderer::lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -363,13 +363,13 @@ Renderer::ObjectInterfacePtr CompoundRenderer::light( const std::string &name, c
 	return result;
 }
 
-Renderer::ObjectInterfacePtr CompoundRenderer::lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CompoundRenderer::lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	auto compoundAttributes = static_cast<const CompoundAttributesInterface *>( attributes );
 	CompoundObjectInterfacePtr result = new CompoundObjectInterface;
 	for( size_t i = 0; i < m_renderers.size(); ++i )
 	{
-		result->objects[i] = m_renderers[i]->lightFilter( name, object, compoundAttributes->attributes[i].get() );
+		result->objects[i] = m_renderers[i]->lightFilter( name, samples, times, compoundAttributes->attributes[i].get() );
 	}
 	return result;
 }

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -352,13 +352,13 @@ Renderer::ObjectInterfacePtr CompoundRenderer::camera( const std::string &name, 
 	return result;
 }
 
-Renderer::ObjectInterfacePtr CompoundRenderer::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+Renderer::ObjectInterfacePtr CompoundRenderer::light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	auto compoundAttributes = static_cast<const CompoundAttributesInterface *>( attributes );
 	CompoundObjectInterfacePtr result = new CompoundObjectInterface;
 	for( size_t i = 0; i < m_renderers.size(); ++i )
 	{
-		result->objects[i] = m_renderers[i]->light( name, object, compoundAttributes->attributes[i].get() );
+		result->objects[i] = m_renderers[i]->light( name, samples, times, compoundAttributes->attributes[i].get() );
 	}
 	return result;
 }

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -94,6 +94,18 @@ Renderer::ObjectInterfacePtr Renderer::light( const std::string &name, const IEC
 	}
 }
 
+Renderer::ObjectInterfacePtr Renderer::lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+{
+	if( object )
+	{
+		return this->lightFilter( name, { object }, { 0.0f }, attributes );
+	}
+	else
+	{
+		return this->lightFilter( name, {}, {}, attributes );
+	}
+}
+
 Renderer::ObjectInterfacePtr Renderer::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
 	return this->object( name, { object }, { 0.0f }, attributes );

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -82,6 +82,18 @@ Renderer::ObjectInterfacePtr Renderer::camera( const std::string &name, const IE
 	return this->camera( name, { camera }, { 0.0f }, attributes );
 }
 
+Renderer::ObjectInterfacePtr Renderer::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+{
+	if( object )
+	{
+		return this->light( name, { object }, { 0.0f }, attributes );
+	}
+	else
+	{
+		return this->light( name, {}, {}, attributes );
+	}
+}
+
 Renderer::ObjectInterfacePtr Renderer::object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
 {
 	return this->object( name, { object }, { 0.0f }, attributes );

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -816,77 +816,11 @@ class RenderController::SceneGraph
 				return hadObjectInterface;
 			}
 
-			// Types that don't support motion blur
-			if( type == LightType || type == LightFilterType )
-			{
-				const IECore::MurmurHash objectHash = objectPlug->hash();
-				if( objectHash == m_objectHash )
-				{
-					return false;
-				}
-
-				IECore::ConstObjectPtr object = objectPlug->getValue( &objectHash );
-				m_objectHash = objectHash;
-
-				const IECore::NullObject *nullObject = runTimeCast<const IECore::NullObject>( object.get() );
-				if( renderer->name() != g_openGLRendererName )
-				{
-					m_objectInterface = nullptr;
-				}
-
-				std::string name;
-				ScenePlug::pathToString( Context::current()->get<vector<InternedString> >( ScenePlug::scenePathContextName ), name );
-				if( type == LightType )
-				{
-					auto light = renderer->light( name, nullObject ? nullptr : object.get(), attributesInterface( renderer ) );
-					if( light && lightLinks )
-					{
-						lightLinks->addLight( name, light );
-						m_objectInterface.assign(
-							light,
-							[name, lightLinks]() {
-								lightLinks->removeLight( name );
-							}
-						);
-					}
-					else
-					{
-						m_objectInterface = light;
-					}
-				}
-				else
-				{
-					auto lightFilter = renderer->lightFilter( name, nullObject ? nullptr : object.get(), attributesInterface( renderer ) );
-					if( lightFilter && lightLinks )
-					{
-						lightLinks->addLightFilter( lightFilter, m_fullAttributes.get() );
-						m_objectInterface.assign(
-							lightFilter,
-							[lightFilter, lightLinks]() {
-								lightLinks->removeLightFilter( lightFilter );
-							}
-						);
-					}
-					else
-					{
-						m_objectInterface = lightFilter;
-					}
-				}
-
-				return true;
-			}
-
 			auto sampledObject = Private::RendererAlgo::objectSamples( objectPlug, m_deformationTimes, &m_objectHash );
 			if( !sampledObject )
 			{
 				// No update required.
 				return false;
-			}
-
-			if( sampledObject->samples.empty() )
-			{
-				m_objectInterface = nullptr;
-				return hadObjectInterface;
 			}
 
 			if( renderer->name() != g_openGLRendererName )
@@ -911,8 +845,58 @@ class RenderController::SceneGraph
 				m_objectInterface = nullptr;
 			}
 
+			// First consider types that don't require object samples.
+
 			std::string name;
 			ScenePlug::pathToString( Context::current()->get<vector<InternedString> >( ScenePlug::scenePathContextName ), name );
+			if( type == LightType )
+			{
+				auto light = renderer->light( name, sampledObject->samples, sampledObject->sampleTimes, attributesInterface( renderer ) );
+				if( light && lightLinks )
+				{
+					lightLinks->addLight( name, light );
+					m_objectInterface.assign(
+						light,
+						[name, lightLinks]() {
+							lightLinks->removeLight( name );
+						}
+					);
+				}
+				else
+				{
+					m_objectInterface = light;
+				}
+				return true;
+			}
+			else if( type == LightFilterType )
+			{
+				auto lightFilter = renderer->lightFilter( name, sampledObject->samples, sampledObject->sampleTimes, attributesInterface( renderer ) );
+				if( lightFilter && lightLinks )
+				{
+					lightLinks->addLightFilter( lightFilter, m_fullAttributes.get() );
+					m_objectInterface.assign(
+						lightFilter,
+						[lightFilter, lightLinks]() {
+							lightLinks->removeLightFilter( lightFilter );
+						}
+					);
+				}
+				else
+				{
+					m_objectInterface = lightFilter;
+				}
+				return true;
+			}
+
+			// Remaining types require object samples, so early out if we don't
+			// have any.
+
+			if( sampledObject->samples.empty() )
+			{
+				m_objectInterface = nullptr;
+				return hadObjectInterface;
+			}
+
 			if( type == CameraType )
 			{
 				IECoreScenePreview::Renderer::CameraSamples cameraSamples; cameraSamples.reserve( sampledObject->samples.size() );
@@ -948,14 +932,10 @@ class RenderController::SceneGraph
 						attributesInterface( renderer )
 					);
 				}
+				return true;
 			}
 			else
 			{
-				if( !sampledObject->samples.size() )
-				{
-					return true;
-				}
-
 				bool isCapsule = false;
 				if( sampledObject->samples.size() == 1 )
 				{
@@ -973,9 +953,8 @@ class RenderController::SceneGraph
 					ObjectInterfaceHandle::RemovalCallback(),
 					isCapsule
 				);
+				return true;
 			}
-
-			return true;
 		}
 
 		void clearObject()

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -883,12 +883,7 @@ class RenderController::SceneGraph
 				return false;
 			}
 
-			if(
-				std::all_of(
-					sampledObject->samples.begin(), sampledObject->samples.end(),
-					[] ( const ConstObjectPtr &sample ) { return runTimeCast<const IECore::NullObject>( sample.get() ); }
-				)
-			)
+			if( sampledObject->samples.empty() )
 			{
 				m_objectInterface = nullptr;
 				return hadObjectInterface;

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1548,13 +1548,13 @@ struct LightOutput : public LocationOutput
 		const size_t lightMatch = m_lightSet.match( path );
 		if( ( lightMatch & IECore::PathMatcher::ExactMatch ) && purposeIncluded() )
 		{
-			IECore::ConstObjectPtr object = scene->objectPlug()->getValue();
+			IECoreScenePreview::Renderer::SampleTimes sampleTimes;
+			deformationMotionTimes( sampleTimes );
+			auto sampledObject = GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), sampleTimes );
 
 			const std::string name = this->name( path );
 			IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface = renderer()->light(
-				name,
-				!runTimeCast<const NullObject>( object.get() ) ? object.get() : nullptr,
-				attributesInterface().get()
+				name, sampledObject->samples, sampledObject->sampleTimes, attributesInterface().get()
 			);
 
 			if( objectInterface )

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -138,7 +138,6 @@ const char *rendererName( Renderer &renderer )
 	return renderer.name().c_str();
 }
 
-
 IECoreScenePreview::Renderer::ObjectInterfacePtr rendererLight1( Renderer &renderer, const std::string &name, const IECore::Object *object, const Renderer::AttributesInterface *attributes )
 {
 	return renderer.light( name, object, attributes );
@@ -153,6 +152,22 @@ IECoreScenePreview::Renderer::ObjectInterfacePtr rendererLight2( Renderer &rende
 	container_utils::extend_container( times, pythonTimes );
 
 	return renderer.light( name, samples, times, attributes );
+}
+
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererLightFilter1( Renderer &renderer, const std::string &name, const IECore::Object *object, const Renderer::AttributesInterface *attributes )
+{
+	return renderer.lightFilter( name, object, attributes );
+}
+
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererLightFilter2( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes, const Renderer::AttributesInterface *attributes )
+{
+	IECoreScenePreview::Renderer::ObjectSamples samples;
+	container_utils::extend_container( samples, pythonSamples );
+
+	IECoreScenePreview::Renderer::SampleTimes times;
+	container_utils::extend_container( times, pythonTimes );
+
+	return renderer.lightFilter( name, samples, times, attributes );
 }
 
 IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject1( Renderer &renderer, const std::string &name, const IECore::Object *object, const Renderer::AttributesInterface *attributes )
@@ -468,7 +483,8 @@ void GafferSceneModule::bindIECoreScenePreview()
 		.def( "camera", &rendererCamera1, ( arg( "name" ), arg( "camera" ), arg( "attributes" ) = object() ) )
 		.def( "light", &rendererLight2, ( arg( "name" ), arg( "samples" ), arg( "times" ), arg( "attributes" ) = object() ) )
 		.def( "light", &rendererLight1, ( arg( "name" ), arg( "object" ), arg( "attributes" ) = object() ) )
-		.def( "lightFilter", &Renderer::lightFilter )
+		.def( "lightFilter", &rendererLightFilter2, ( arg( "name" ), arg( "samples" ), arg( "times" ), arg( "attributes" ) = object() ) )
+		.def( "lightFilter", &rendererLightFilter1, ( arg( "name" ), arg( "object" ), arg( "attributes" ) = object() ) )
 
 		.def( "object", &rendererObject1 )
 		.def( "object", &rendererObject2 )

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -138,6 +138,23 @@ const char *rendererName( Renderer &renderer )
 	return renderer.name().c_str();
 }
 
+
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererLight1( Renderer &renderer, const std::string &name, const IECore::Object *object, const Renderer::AttributesInterface *attributes )
+{
+	return renderer.light( name, object, attributes );
+}
+
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererLight2( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes, const Renderer::AttributesInterface *attributes )
+{
+	IECoreScenePreview::Renderer::ObjectSamples samples;
+	container_utils::extend_container( samples, pythonSamples );
+
+	IECoreScenePreview::Renderer::SampleTimes times;
+	container_utils::extend_container( times, pythonTimes );
+
+	return renderer.light( name, samples, times, attributes );
+}
+
 IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject1( Renderer &renderer, const std::string &name, const IECore::Object *object, const Renderer::AttributesInterface *attributes )
 {
 	return renderer.object( name, object, attributes );
@@ -449,7 +466,8 @@ void GafferSceneModule::bindIECoreScenePreview()
 
 		.def( "camera", &rendererCamera2, ( arg( "name" ), arg( "samples" ), arg( "times" ), arg( "attributes" ) = object() ) )
 		.def( "camera", &rendererCamera1, ( arg( "name" ), arg( "camera" ), arg( "attributes" ) = object() ) )
-		.def( "light", &Renderer::light )
+		.def( "light", &rendererLight2, ( arg( "name" ), arg( "samples" ), arg( "times" ), arg( "attributes" ) = object() ) )
+		.def( "light", &rendererLight1, ( arg( "name" ), arg( "object" ), arg( "attributes" ) = object() ) )
 		.def( "lightFilter", &Renderer::lightFilter )
 
 		.def( "object", &rendererObject1 )

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -417,7 +417,7 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override;
 
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 
@@ -3169,10 +3169,10 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			return nullptr;
 		}
 
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			ArnoldLightPtr result = static_pointer_cast<ArnoldLight>(
-				ArnoldRendererBase::light( name, object, attributes )
+				ArnoldRendererBase::light( name, samples, times, attributes )
 			);
 
 			auto &nodesCreatedLocal = m_nodesCreated.local();
@@ -4593,11 +4593,11 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::st
 	return result;
 }
 
-ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( object ? ObjectSamples( { object } ) : ObjectSamples(), object ? SampleTimes( { 0.0f } ) : SampleTimes(),  attributes, name );
+	Instance instance = m_instanceCache->get( samples, times, attributes, name );
 	ObjectInterfacePtr result = new ArnoldLight( name, instance, m_nodeDeleter, m_universe, m_parentNode );
 	result->attributes( attributes );
 	return result;

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -418,7 +418,7 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 
 		ObjectInterfacePtr camera( const std::string &name, const CameraSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override;
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 
 	protected :
@@ -3181,10 +3181,10 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			return result;
 		}
 
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			ArnoldLightFilterPtr result = static_pointer_cast<ArnoldLightFilter>(
-				ArnoldRendererBase::lightFilter( name, object, attributes )
+				ArnoldRendererBase::lightFilter( name, objectSamples, times, attributes )
 			);
 
 			auto &nodesCreatedLocal = m_nodesCreated.local();
@@ -4603,11 +4603,11 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::light( const std::str
 	return result;
 }
 
-ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes )
+ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes )
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( object ? ObjectSamples( { object } ) : ObjectSamples(), object ? SampleTimes( { 0.0f } ) : SampleTimes(),  attributes, name );
+	Instance instance = m_instanceCache->get( samples, times,  attributes, name );
 	ObjectInterfacePtr result = new ArnoldLightFilter( name, instance, m_nodeDeleter, m_universe, m_parentNode );
 	result->attributes( attributes );
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1582,14 +1582,14 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
 			DelightHandleSharedPtr instance;
-			if( object )
+			if( objectSamples.size() )
 			{
-				instance = m_instanceCache->get( { object }, { 0.0 } );
+				instance = m_instanceCache->get( objectSamples, times );
 			}
 
 			ObjectInterfacePtr result = new DelightLight( m_context, name, instance, ownership() );

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1598,7 +1598,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			return nullptr;
 		}

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -145,15 +145,20 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			auto typedAttributes = static_cast<const Attributes *>( attributes );
 
 			ConstGeometryPrototypePtr geometryPrototype;
-			if( auto mesh = runTimeCast<const MeshPrimitive>( object ) )
+			if( objectSamples.size() )
 			{
-				// RenderMan refuses to share mesh prototypes between GeometryInstances and
-				// LightInstances, so we insert some blind data to give the mesh geometry
-				// a different hash, causing the GeometryPrototypeCache to create a prototype
-				// that won't be used by `Renderer::object()`.
-				MeshPrimitivePtr meshCopy = mesh->copy();
-				meshCopy->blindData()->writable().insert( g_forMeshLightBlindData );
-				geometryPrototype = m_geometryPrototypeCache->get( meshCopy.get(), typedAttributes, /* messageContext = */ name );
+				if( auto mesh = runTimeCast<const MeshPrimitive>( objectSamples[0].get() ) )
+				{
+					// RenderMan refuses to share mesh prototypes between GeometryInstances and
+					// LightInstances, so we insert some blind data to give the mesh geometry
+					// a different hash, causing the GeometryPrototypeCache to create a prototype
+					// that won't be used by `Renderer::object()`.
+					ObjectSamples uniquefiedObjectSamples = objectSamples;
+					MeshPrimitivePtr meshCopy = mesh->copy();
+					meshCopy->blindData()->writable().insert( g_forMeshLightBlindData );
+					uniquefiedObjectSamples[0] = meshCopy;
+					geometryPrototype = m_geometryPrototypeCache->get( uniquefiedObjectSamples, times, typedAttributes, /* messageContext = */ name );
+				}
 			}
 
 			return new IECoreRenderMan::Light( geometryPrototype, typedAttributes, m_materialCache.get(), m_lightLinker.get(), m_session );

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -159,7 +159,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			return new IECoreRenderMan::Light( geometryPrototype, typedAttributes, m_materialCache.get(), m_lightLinker.get(), m_session );
 		}
 
-		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
 			acquireSession();

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -137,7 +137,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
-		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override
 		{
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
 			acquireSession();


### PR DESCRIPTION
Building on top of #6894, this updates the Renderer API to allow mesh lights to be rendered with deformation motion blur.