### PR TITLE
GafferScene : Add MeshLight base class

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -57,6 +57,7 @@ API
   - Improved automatic parenting via the `with parent` syntax. Children are now guaranteed to be fully constructed before they are parented.
   - Turned `toolTip`, `parenting` and `displayTransform` keyword-only constructor arguments.
 - Light : Simplified implementation of derived classes, which are now merely responsible for passing a Shader node to the base class constructor.
+- MeshLight : Added based class to simplify the implementation of renderer-specific mesh light nodes.
 - PathColumn : `headerData()` is now passed the root Path.
 
 Breaking Changes

--- a/include/GafferRenderMan/RenderManMeshLight.h
+++ b/include/GafferRenderMan/RenderManMeshLight.h
@@ -39,12 +39,12 @@
 #include "GafferRenderMan/Export.h"
 #include "GafferRenderMan/TypeIds.h"
 
-#include "GafferScene/FilteredSceneProcessor.h"
+#include "GafferScene/MeshLight.h"
 
 namespace GafferRenderMan
 {
 
-class GAFFERRENDERMAN_API RenderManMeshLight : public GafferScene::FilteredSceneProcessor
+class GAFFERRENDERMAN_API RenderManMeshLight : public GafferScene::MeshLight
 {
 
 	public :
@@ -52,11 +52,7 @@ class GAFFERRENDERMAN_API RenderManMeshLight : public GafferScene::FilteredScene
 		explicit RenderManMeshLight( const std::string &name=defaultName<RenderManMeshLight>() );
 		~RenderManMeshLight() override;
 
-		GAFFER_NODE_DECLARE_TYPE( GafferRenderMan::RenderManMeshLight, RenderManMeshLightTypeId, FilteredSceneProcessor );
-
-	private :
-
-		static size_t g_firstPlugIndex;
+		GAFFER_NODE_DECLARE_TYPE( GafferRenderMan::RenderManMeshLight, RenderManMeshLightTypeId, MeshLight );
 
 };
 

--- a/include/GafferScene/MeshLight.h
+++ b/include/GafferScene/MeshLight.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,26 +36,38 @@
 
 #pragma once
 
-#include "GafferArnold/Export.h"
-#include "GafferArnold/TypeIds.h"
+#include "GafferScene/Export.h"
+#include "GafferScene/FilteredSceneProcessor.h"
+#include "GafferScene/TypeIds.h"
 
-#include "GafferScene/MeshLight.h"
-
-namespace GafferArnold
+namespace GafferScene
 {
 
-class GAFFERARNOLD_API ArnoldMeshLight : public GafferScene::MeshLight
+IE_CORE_FORWARDDECLARE( CustomAttributes );
+IE_CORE_FORWARDDECLARE( Shader );
+
+class GAFFERSCENE_API MeshLight : public GafferScene::FilteredSceneProcessor
 {
 
 	public :
 
-		explicit ArnoldMeshLight( const std::string &name=defaultName<ArnoldMeshLight>() );
-		~ArnoldMeshLight() override;
+		~MeshLight() override;
 
-		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldMeshLight, ArnoldMeshLightTypeId, GafferScene::MeshLight );
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::MeshLight, MeshLightTypeId, FilteredSceneProcessor );
+
+	protected :
+
+		MeshLight( const std::string &name, const ShaderPtr &shader );
+
+		// Derived classes may use this to add attributes to the created light.
+		CustomAttributes *customAttributes();
+
+	private :
+
+		static size_t g_firstChildIndex;
 
 };
 
-IE_CORE_DECLAREPTR( ArnoldMeshLight )
+IE_CORE_DECLAREPTR( MeshLight )
 
-} // namespace GafferArnold
+} // namespace GafferScene

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -197,6 +197,7 @@ enum TypeId
 	ClosurePlugTypeId = 120152,
 	ReflectionConstraintTypeId = 120153,
 	CurvesInterpolationTypeId = 120154,
+	MeshLightTypeId = 120155,
 
 	LastTypeId = 120999
 };

--- a/python/GafferArnoldUI/ArnoldMeshLightUI.py
+++ b/python/GafferArnoldUI/ArnoldMeshLightUI.py
@@ -34,14 +34,8 @@
 #
 ##########################################################################
 
-import functools
-
 import Gaffer
 import GafferArnold
-
-def __shaderMetadata( plug, name ) :
-
-	return Gaffer.Metadata.value( plug.node()["__shader"].descendant( plug.relativeName( plug.node() ) ), name )
 
 Gaffer.Metadata.registerNode(
 
@@ -65,23 +59,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nameValuePlugPlugValueWidget:ignoreNamePlug" : True,
-
-		},
-
-		"parameters" : {
-
-			"description" :
-			"""
-			The parameters of the Arnold mesh_light shader that
-			is applied to the meshes.
-			""",
-
-			## \todo Extend the Metadata API so we can register a provider for "*",
-			# which can automatically transfer all internal metadata.
-			"noduleLayout:section" : functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
-			"nodule:type" : functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"noduleLayout:spacing" : functools.partial( __shaderMetadata, name = "noduleLayout:spacing" ),
-			"plugValueWidget:type" : functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
+			"layout:index" : 0,
 
 		},
 
@@ -93,28 +71,7 @@ Gaffer.Metadata.registerNode(
 			shader.
 			""",
 
-			"nodule:type" : functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"noduleLayout:section" : functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
-			"nodule:color" : functools.partial( __shaderMetadata, name = "nodule:color" ),
-			"plugValueWidget:type" : functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
-			"presetNames" : functools.partial( __shaderMetadata, name = "presetNames" ),
-			"presetValues" : functools.partial( __shaderMetadata, name = "presetValues" ),
-
 		},
-
-		"defaultLight" : {
-
-			"description" :
-			"""
-			Whether this light illuminates all geometry by default. When
-			toggled, the light will be added to the \"defaultLights\" set, which
-			can be referenced in set expressions and manipulated by downstream
-			nodes.
-			""",
-
-			"layout:section" : "Light Linking",
-
-		}
 
 	}
 

--- a/python/GafferArnoldUI/ArnoldMeshLightUI.py
+++ b/python/GafferArnoldUI/ArnoldMeshLightUI.py
@@ -63,16 +63,6 @@ Gaffer.Metadata.registerNode(
 
 		},
 
-		"parameters.*" : {
-
-			"description" :
-			"""
-			Refer to Arnold's documentation for the mesh_light
-			shader.
-			""",
-
-		},
-
 	}
 
 )

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -260,8 +260,7 @@ def __translateNodeMetadata( nodeEntry ) :
 			nodeEntry, paramName, "desc",
 			defaultValue = __aiMetadataGetStr( nodeEntry, paramName, "help" )
 		)
-		if description is not None :
-			__metadata[paramPath]["description"] = description
+		__metadata[paramPath]["description"] = description or "Refer to Arnold's documentation for further details."
 
 		# Presets
 

--- a/python/GafferRenderManTest/RenderManMeshLightTest.py
+++ b/python/GafferRenderManTest/RenderManMeshLightTest.py
@@ -81,5 +81,29 @@ class RenderManMeshLightTest( GafferSceneTest.SceneTestCase ) :
 		# One for the node. None for plugs, since they are not dynamic.
 		self.assertEqual( serialisation.count( "addChild" ), 1 )
 
+	def testVisibilityAttributes( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		light = GafferRenderMan.RenderManMeshLight()
+		light["in"].setInput( sphere["out"] )
+		light["filter"].setInput( sphereFilter["out"] )
+
+		attributes = light["out"].attributes( "/sphere" )
+		self.assertEqual( attributes["ri:visibility:indirect"], IECore.BoolData( False ) )
+		self.assertEqual( attributes["ri:visibility:transmission"], IECore.BoolData( False ) )
+		self.assertNotIn( "ri:visibility:camera", attributes )
+
+		light["cameraVisibility"]["enabled"].setValue( True )
+		attributes = light["out"].attributes( "/sphere" )
+		self.assertEqual( attributes["ri:visibility:camera"], IECore.BoolData( True ) )
+
+		light["cameraVisibility"]["value"].setValue( False )
+		attributes = light["out"].attributes( "/sphere" )
+		self.assertEqual( attributes["ri:visibility:camera"], IECore.BoolData( False ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManUI/RenderManMeshLightUI.py
+++ b/python/GafferRenderManUI/RenderManMeshLightUI.py
@@ -34,14 +34,8 @@
 #
 ##########################################################################
 
-import functools
-
 import Gaffer
 import GafferRenderMan
-
-def __shaderMetadata( plug, name ) :
-
-	return Gaffer.Metadata.value( plug.node()["__shader"].descendant( plug.relativeName( plug.node() ) ), name )
 
 Gaffer.Metadata.registerNode(
 
@@ -65,6 +59,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nameValuePlugPlugValueWidget:ignoreNamePlug" : True,
+			"layout:index" : 0,
 
 		},
 
@@ -76,48 +71,9 @@ Gaffer.Metadata.registerNode(
 
 		"parameters" : {
 
-			"description" :
-			"""
-			The parameters of the PxrMeshLight shader that is applied to the
-			meshes.
-			""",
-
-			## \todo Extend the Metadata API so we can register a provider for "*",
-			# which can automatically transfer all internal metadata.
-			"noduleLayout:section" : functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
-			"nodule:type" : functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"noduleLayout:spacing" : functools.partial( __shaderMetadata, name = "noduleLayout:spacing" ),
-			"plugValueWidget:type" : functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
-			"layout:section:Basic:collapsed" : False
+			"layout:section:Basic:collapsed" : False,
 
 		},
-
-		"parameters.*" : {
-
-			"description" : functools.partial( __shaderMetadata, name = "description" ),
-			"nodule:type" : functools.partial( __shaderMetadata, name = "nodule:type" ),
-			"noduleLayout:section" : functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
-			"nodule:color" : functools.partial( __shaderMetadata, name = "nodule:color" ),
-			"layout:section" : functools.partial( __shaderMetadata, name = "layout:section" ),
-			"plugValueWidget:type" : functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
-			"presetNames" : functools.partial( __shaderMetadata, name = "presetNames" ),
-			"presetValues" : functools.partial( __shaderMetadata, name = "presetValues" ),
-
-		},
-
-		"defaultLight" : {
-
-			"description" :
-			"""
-			Whether this light illuminates all geometry by default. When
-			toggled, the light will be added to the `defaultLights` set, which
-			can be referenced in set expressions and manipulated by downstream
-			nodes.
-			""",
-
-			"layout:section" : "Light Linking",
-
-		}
 
 	}
 

--- a/python/GafferSceneUI/MeshLightUI.py
+++ b/python/GafferSceneUI/MeshLightUI.py
@@ -1,0 +1,101 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import Gaffer
+import GafferScene
+
+def __shaderMetadata( plug, name ) :
+
+	return Gaffer.Metadata.value( plug.node()["__shader"].descendant( plug.relativeName( plug.node() ) ), name )
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.MeshLight,
+
+	plugs = {
+
+		"parameters" : {
+
+			"description" :
+			"""
+			The parameters of the light shader applied to the mesh.
+			""",
+
+			## \todo Extend the Metadata API so we can register a provider for "*",
+			# which can automatically transfer all internal metadata. Currently we
+			# can't forward metadata for which we don't know the names upfront, including
+			# `layout:activator:{name}`, so we still rely on some manual registrations such
+			# as those ArnoldShaderUI.py makes for ArnoldMeshLight.
+			"noduleLayout:section" : functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
+			"nodule:type" : functools.partial( __shaderMetadata, name = "nodule:type" ),
+			"noduleLayout:spacing" : functools.partial( __shaderMetadata, name = "noduleLayout:spacing" ),
+			"plugValueWidget:type" : functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
+
+		},
+
+		"parameters.*" : {
+
+			"label" : functools.partial( __shaderMetadata, name = "label" ),
+			"description" : functools.partial( __shaderMetadata, name = "description" ),
+			"nodule:type" : functools.partial( __shaderMetadata, name = "nodule:type" ),
+			"noduleLayout:section" : functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
+			"nodule:color" : functools.partial( __shaderMetadata, name = "nodule:color" ),
+			"plugValueWidget:type" : functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
+			"presetNames" : functools.partial( __shaderMetadata, name = "presetNames" ),
+			"presetValues" : functools.partial( __shaderMetadata, name = "presetValues" ),
+			"layout:section" : functools.partial( __shaderMetadata, name = "layout:section" ),
+
+		},
+
+		"defaultLight" : {
+
+			"description" :
+			"""
+			Whether this light illuminates all geometry by default. When
+			toggled, the light will be added to the \"defaultLights\" set, which
+			can be referenced in set expressions and manipulated by downstream
+			nodes.
+			""",
+
+			"layout:section" : "Light Linking",
+
+		}
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -214,6 +214,7 @@ from . import ImageSelectionToolUI
 from . import CameraQueryUI
 from . import ReflectionConstraintUI
 from . import CurvesInterpolationUI
+from . import MeshLightUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferArnold/ArnoldMeshLight.cpp
+++ b/src/GafferArnold/ArnoldMeshLight.cpp
@@ -36,120 +36,66 @@
 
 #include "GafferArnold/ArnoldMeshLight.h"
 
-#include "GafferArnold/ArnoldAttributes.h"
 #include "GafferArnold/ArnoldShader.h"
 
-#include "GafferScene/Set.h"
-#include "GafferScene/ShaderAssignment.h"
+#include "GafferScene/CustomAttributes.h"
 
-#include "Gaffer/StringPlug.h"
-#include "Gaffer/Switch.h"
-
-#include "boost/algorithm/string/predicate.hpp"
-
+using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 using namespace GafferArnold;
 
+namespace
+{
+
+const ConstCompoundObjectPtr g_hiddenVisibilityAttributes = [] {
+
+	const std::vector<std::string> names = {
+		"ai:visibility:shadow",
+		"ai:visibility:diffuse_reflect", "ai:visibility:specular_reflect",
+		"ai:visibility:diffuse_transmit", "ai:visibility:specular_transmit",
+		"ai:visibility:volume", "ai:visibility:subsurface"
+	};
+
+	const CompoundObjectPtr result = new CompoundObject;
+	for( const auto &name : names )
+	{
+		result->members()[name] = new BoolData( false );
+	}
+	return result;
+
+} ();
+
+} // namespace
+
 GAFFER_NODE_DEFINE_TYPE( ArnoldMeshLight );
 
 ArnoldMeshLight::ArnoldMeshLight( const std::string &name )
-	:	GafferScene::FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
+	:	GafferScene::MeshLight(
+			name,
+			[] { ArnoldShaderPtr shader = new ArnoldShader; shader->loadShader( "mesh_light" ); return shader; } ()
+		)
 {
 
-	// ArnoldAttributesNode. This hides the objects from the majority
-	// of ray types, since we don't want to add the poor sampling of the
-	// object on top of the nice sampling of the light. The only visibility
-	// option we don't turn off is camera visibility - instead we promote
-	// so the user can decide whether or not the mesh should be visible in
-	// the render.
+	// Hide the object from the majority of ray types, since we don't want to
+	// add the poor sampling of the object on top of the nice sampling of the
+	// light.
 
-	ArnoldAttributesPtr attributes = new ArnoldAttributes( "__attributes" );
-	attributes->inPlug()->setInput( inPlug() );
-	attributes->filterPlug()->setInput( filterPlug() );
-	for( NameValuePlug::Iterator it( attributes->attributesPlug() ); !it.done(); ++it )
-	{
-		if(
-			boost::starts_with( (*it)->getName().string(), "ai:visibility:" ) &&
-			(*it)->getName() != "ai:visibility:shadow_group" &&
-			(*it)->getName() != "ai:visibility:camera"
-		)
-		{
-			(*it)->enabledPlug()->setValue( true );
-			(*it)->valuePlug<BoolPlug>()->setValue( false );
-		}
-	}
+	customAttributes()->extraAttributesPlug()->setValue( g_hiddenVisibilityAttributes );
 
-	addChild( attributes );
+	// The only visibility option we don't turn off is camera visibility
+	// - instead we promote so the user can decide whether or not the mesh
+	// should be visible in the render.
+	/// \todo We could promote as OptionalValuePlug to avoid exposing the
+	/// `name` plug unnecessarily.
 
-	Plug *internalCameraVisibilityPlug = attributes->attributesPlug()->getChild<Plug>( "ai:visibility:camera" );
+	NameValuePlugPtr internalCameraVisibilityPlug = new NameValuePlug(
+		"ai:visibility:camera", new BoolPlug( "value", Plug::In, true ), false, "cameraVisibility"
+	);
+	customAttributes()->attributesPlug()->addChild( internalCameraVisibilityPlug );
 	PlugPtr cameraVisibilityPlug = internalCameraVisibilityPlug->createCounterpart( "cameraVisibility", Plug::In );
 	addChild( cameraVisibilityPlug );
 	internalCameraVisibilityPlug->setInput( cameraVisibilityPlug );
-
-	// Shader node. This loads the Arnold mesh_light shader.
-
-	ArnoldShaderPtr shader = new ArnoldShader( "__shader" );
-	shader->loadShader( "mesh_light" );
-	addChild( shader );
-
-	PlugPtr parametersPlug = shader->parametersPlug()->createCounterpart( "parameters", Plug::In );
-	addChild( parametersPlug );
-	for( Plug::Iterator srcIt( parametersPlug.get() ), dstIt( shader->parametersPlug() ); !srcIt.done(); ++srcIt, ++dstIt )
-	{
-		(*dstIt)->setInput( *srcIt );
-		// We don't need the parameters to be dynamic, because we create the
-		// plugs in our constructor when calling `loadShader()`.
-		(*srcIt)->setFlags( Plug::Dynamic, false );
-	}
-
-	// ShaderAssignment node. This assigns the mesh_light shader
-	// to the objects chosen by the filter.
-
-	ShaderAssignmentPtr shaderAssignment = new ShaderAssignment( "__shaderAssignment" );
-	shaderAssignment->inPlug()->setInput( attributes->outPlug() );
-	shaderAssignment->filterPlug()->setInput( filterPlug() );
-	shaderAssignment->shaderPlug()->setInput( shader->outPlug() );
-	addChild( shaderAssignment );
-
-	// Set node. This adds the objects into the __lights set,
-	// so they will be output correctly to the renderer.
-
-	SetPtr set = new Set( "__set" );
-	set->inPlug()->setInput( shaderAssignment->outPlug() );
-	set->filterPlug()->setInput( filterPlug() );
-	set->namePlug()->setValue( "__lights" );
-	set->modePlug()->setValue( Set::Add );
-	addChild( set );
-
-	// Default lights Set node.
-
-	BoolPlugPtr defaultLightPlug = new BoolPlug( "defaultLight", Plug::In, true );
-	addChild( defaultLightPlug );
-
-	SetPtr defaultLightsSet = new Set( "__defaultLightsSet" );
-	defaultLightsSet->inPlug()->setInput( set->outPlug() );
-	defaultLightsSet->filterPlug()->setInput( filterPlug() );
-	defaultLightsSet->enabledPlug()->setInput( defaultLightPlug.get() );
-	defaultLightsSet->namePlug()->setValue( "defaultLights" );
-	defaultLightsSet->modePlug()->setValue( Set::Add );
-	addChild( defaultLightsSet );
-
-	// Switch for enabling/disabling
-
-	SwitchPtr enabledSwitch = new Switch( "__switch" );
-	enabledSwitch->setup( inPlug() );
-	enabledSwitch->inPlugs()->getChild<ScenePlug>( 0 )->setInput( inPlug() );
-	enabledSwitch->inPlugs()->getChild<ScenePlug>( 1 )->setInput( defaultLightsSet->outPlug() );
-	enabledSwitch->indexPlug()->setValue( 1 );
-	enabledSwitch->enabledPlug()->setInput( enabledPlug() );
-	addChild( enabledSwitch );
-
-	outPlug()->setInput( enabledSwitch->outPlug() );
-	// We don't need to serialise the connection because we make
-	// it upon construction.
-	/// \todo Can we just do this in the SceneProcessor base class?
-	outPlug()->setFlags( Plug::Serialisable, false );
 }
 
 ArnoldMeshLight::~ArnoldMeshLight()

--- a/src/GafferRenderMan/RenderManMeshLight.cpp
+++ b/src/GafferRenderMan/RenderManMeshLight.cpp
@@ -36,117 +36,57 @@
 
 #include "GafferRenderMan/RenderManMeshLight.h"
 
-#include "GafferRenderMan/RenderManAttributes.h"
 #include "GafferRenderMan/RenderManShader.h"
 
-#include "GafferScene/Set.h"
-#include "GafferScene/ShaderAssignment.h"
+#include "GafferScene/CustomAttributes.h"
 
-#include "Gaffer/StringPlug.h"
-#include "Gaffer/Switch.h"
-
+using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 using namespace GafferRenderMan;
 
+namespace
+{
+
+const ConstCompoundObjectPtr g_hiddenVisibilityAttributes = [] {
+
+	const CompoundObjectPtr result = new CompoundObject;
+	result->members()["ri:visibility:indirect"] = new BoolData( false );
+	result->members()["ri:visibility:transmission"] = new BoolData( false );
+	return result;
+
+} ();
+
+} // namespace
+
 GAFFER_NODE_DEFINE_TYPE( RenderManMeshLight );
 
 RenderManMeshLight::RenderManMeshLight( const std::string &name )
-	:	GafferScene::FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
+	:	GafferScene::MeshLight(
+			name,
+			[] { RenderManShaderPtr shader = new RenderManShader; shader->loadShader( "PxrMeshLight" ); return shader; } ()
+		)
 {
 
-	// RenderManAttributes node. We use this to hide the objects to everything
-	// except camera rays, since that seems a reasonable default behaviour for
-	// a mesh light. The user can turn this back on with a RenderManAttributes
-	// node, in which case the surface shader is used for ray hits.
+	// Hide the objects to everything except camera rays, since that seems a
+	// reasonable default behaviour for a mesh light. The user can turn this
+	// back on with a RenderManAttributes node, in which case the surface shader
+	// is used for ray hits.
 
-	RenderManAttributesPtr attributes = new RenderManAttributes( "__attributes" );
-	attributes->inPlug()->setInput( inPlug() );
-	attributes->filterPlug()->setInput( filterPlug() );
-	for( const auto &attributeName : { "ri:visibility:indirect", "ri:visibility:transmission" } )
-	{
-		auto plug = attributes->attributesPlug()->getChild<NameValuePlug>( attributeName );
-		plug->enabledPlug()->setValue( true );
-		if( auto p = plug->valuePlug<BoolPlug>() )
-		{
-			p->setValue( false );
-		}
-		else
-		{
-			plug->valuePlug<IntPlug>()->setValue( 0 );
-		}
-	}
+	customAttributes()->extraAttributesPlug()->setValue( g_hiddenVisibilityAttributes );
 
-	addChild( attributes );
-
-	// Promote the camera visibility plug, since that is more likely to be used
+	// Promote a camera visibility plug, since that is more likely to be used
 	// than the others.
+	/// \todo We could promote as OptionalValuePlug to avoid exposing the
+	/// `name` plug unnecessarily.
 
-	Plug *internalCameraVisibilityPlug = attributes->attributesPlug()->getChild<Plug>( "ri:visibility:camera" );
+	NameValuePlugPtr internalCameraVisibilityPlug = new NameValuePlug(
+		"ri:visibility:camera", new BoolPlug( "value", Plug::In, true ), false, "cameraVisibility"
+	);
+	customAttributes()->attributesPlug()->addChild( internalCameraVisibilityPlug );
 	PlugPtr cameraVisibilityPlug = internalCameraVisibilityPlug->createCounterpart( "cameraVisibility", Plug::In );
 	addChild( cameraVisibilityPlug );
 	internalCameraVisibilityPlug->setInput( cameraVisibilityPlug );
-
-	// Shader node. This loads the PxrMeshLight shader.
-
-	RenderManShaderPtr shader = new RenderManShader( "__shader" );
-	shader->loadShader( "PxrMeshLight" );
-	addChild( shader );
-
-	PlugPtr parametersPlug = shader->parametersPlug()->createCounterpart( "parameters", Plug::In );
-	addChild( parametersPlug );
-	for( Plug::Iterator srcIt( parametersPlug.get() ), dstIt( shader->parametersPlug() ); !srcIt.done(); ++srcIt, ++dstIt )
-	{
-		(*dstIt)->setInput( *srcIt );
-	}
-
-	// ShaderAssignment node. This assigns the PxrMeshLight shader
-	// to the objects chosen by the filter.
-
-	ShaderAssignmentPtr shaderAssignment = new ShaderAssignment( "__shaderAssignment" );
-	shaderAssignment->inPlug()->setInput( attributes->outPlug() );
-	shaderAssignment->filterPlug()->setInput( filterPlug() );
-	shaderAssignment->shaderPlug()->setInput( shader->outPlug() );
-	addChild( shaderAssignment );
-
-	// Set node. This adds the objects into the __lights set,
-	// so they will be output correctly to the renderer.
-
-	SetPtr set = new Set( "__set" );
-	set->inPlug()->setInput( shaderAssignment->outPlug() );
-	set->filterPlug()->setInput( filterPlug() );
-	set->namePlug()->setValue( "__lights" );
-	set->modePlug()->setValue( Set::Add );
-	addChild( set );
-
-	// Default lights Set node.
-
-	BoolPlugPtr defaultLightPlug = new BoolPlug( "defaultLight", Plug::In, true );
-	addChild( defaultLightPlug );
-
-	SetPtr defaultLightsSet = new Set( "__defaultLightsSet" );
-	defaultLightsSet->inPlug()->setInput( set->outPlug() );
-	defaultLightsSet->filterPlug()->setInput( filterPlug() );
-	defaultLightsSet->enabledPlug()->setInput( defaultLightPlug.get() );
-	defaultLightsSet->namePlug()->setValue( "defaultLights" );
-	defaultLightsSet->modePlug()->setValue( Set::Add );
-	addChild( defaultLightsSet );
-
-	// Switch for enabling/disabling
-
-	SwitchPtr enabledSwitch = new Switch( "__switch" );
-	enabledSwitch->setup( inPlug() );
-	enabledSwitch->inPlugs()->getChild<ScenePlug>( 0 )->setInput( inPlug() );
-	enabledSwitch->inPlugs()->getChild<ScenePlug>( 1 )->setInput( defaultLightsSet->outPlug() );
-	enabledSwitch->indexPlug()->setValue( 1 );
-	enabledSwitch->enabledPlug()->setInput( enabledPlug() );
-	addChild( enabledSwitch );
-
-	outPlug()->setInput( enabledSwitch->outPlug() );
-	// We don't need to serialise the connection because we make
-	// it upon construction.
-	/// \todo Can we just do this in the SceneProcessor base class?
-	outPlug()->setFlags( Plug::Serialisable, false );
 }
 
 RenderManMeshLight::~RenderManMeshLight()

--- a/src/GafferScene/MeshLight.cpp
+++ b/src/GafferScene/MeshLight.cpp
@@ -1,0 +1,137 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/MeshLight.h"
+
+#include "GafferScene/CustomAttributes.h"
+#include "GafferScene/Set.h"
+#include "GafferScene/Shader.h"
+#include "GafferScene/ShaderAssignment.h"
+
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/Switch.h"
+
+#include "boost/algorithm/string/predicate.hpp"
+
+using namespace Gaffer;
+using namespace GafferScene;
+
+GAFFER_NODE_DEFINE_TYPE( MeshLight );
+
+size_t MeshLight::g_firstChildIndex = 0;
+
+MeshLight::MeshLight( const std::string &name, const ShaderPtr &shader )
+	:	GafferScene::FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
+{
+	storeIndexOfNextChild( g_firstChildIndex );
+
+	// CustomAttributes node to allow derived classes to easily add renderer-specific
+	// attributes, typically for controlling visibility.
+
+	CustomAttributesPtr attributes = new CustomAttributes( "__attributes" );
+	attributes->inPlug()->setInput( inPlug() );
+	attributes->filterPlug()->setInput( filterPlug() );
+	addChild( attributes );
+
+	// Shader node. This is provided by the derived class and loads
+	// the renderer-specific shader.
+
+	setChild( "__shader", shader );
+
+	PlugPtr parametersPlug = shader->parametersPlug()->createCounterpart( "parameters", Plug::In );
+	addChild( parametersPlug );
+	for( Plug::Iterator srcIt( parametersPlug.get() ), dstIt( shader->parametersPlug() ); !srcIt.done(); ++srcIt, ++dstIt )
+	{
+		(*dstIt)->setInput( *srcIt );
+	}
+
+	// ShaderAssignment node. This assigns the shader
+	// to the objects chosen by the filter.
+
+	ShaderAssignmentPtr shaderAssignment = new ShaderAssignment( "__shaderAssignment" );
+	shaderAssignment->inPlug()->setInput( attributes->outPlug() );
+	shaderAssignment->filterPlug()->setInput( filterPlug() );
+	shaderAssignment->shaderPlug()->setInput( shader->outPlug() );
+	addChild( shaderAssignment );
+
+	// Set node. This adds the objects into the __lights set,
+	// so they will be output correctly to the renderer.
+
+	SetPtr set = new Set( "__set" );
+	set->inPlug()->setInput( shaderAssignment->outPlug() );
+	set->filterPlug()->setInput( filterPlug() );
+	set->namePlug()->setValue( "__lights" );
+	set->modePlug()->setValue( Set::Add );
+	addChild( set );
+
+	// Default lights Set node.
+
+	BoolPlugPtr defaultLightPlug = new BoolPlug( "defaultLight", Plug::In, true );
+	addChild( defaultLightPlug );
+
+	SetPtr defaultLightsSet = new Set( "__defaultLightsSet" );
+	defaultLightsSet->inPlug()->setInput( set->outPlug() );
+	defaultLightsSet->filterPlug()->setInput( filterPlug() );
+	defaultLightsSet->enabledPlug()->setInput( defaultLightPlug.get() );
+	defaultLightsSet->namePlug()->setValue( "defaultLights" );
+	defaultLightsSet->modePlug()->setValue( Set::Add );
+	addChild( defaultLightsSet );
+
+	// Switch for enabling/disabling
+
+	SwitchPtr enabledSwitch = new Switch( "__switch" );
+	enabledSwitch->setup( inPlug() );
+	enabledSwitch->inPlugs()->getChild<ScenePlug>( 0 )->setInput( inPlug() );
+	enabledSwitch->inPlugs()->getChild<ScenePlug>( 1 )->setInput( defaultLightsSet->outPlug() );
+	enabledSwitch->indexPlug()->setValue( 1 );
+	enabledSwitch->enabledPlug()->setInput( enabledPlug() );
+	addChild( enabledSwitch );
+
+	outPlug()->setInput( enabledSwitch->outPlug() );
+	// We don't need to serialise the connection because we make
+	// it upon construction.
+	/// \todo Can we just do this in the SceneProcessor base class?
+	outPlug()->setFlags( Plug::Serialisable, false );
+}
+
+MeshLight::~MeshLight()
+{
+}
+
+CustomAttributes *MeshLight::customAttributes()
+{
+	return getChild<CustomAttributes>( g_firstChildIndex );
+}

--- a/src/GafferSceneModule/PrimitivesBinding.cpp
+++ b/src/GafferSceneModule/PrimitivesBinding.cpp
@@ -49,6 +49,7 @@
 #include "GafferScene/ImageScatter.h"
 #include "GafferScene/ImageToPoints.h"
 #include "GafferScene/Light.h"
+#include "GafferScene/MeshLight.h"
 #include "GafferScene/ObjectToScene.h"
 #include "GafferScene/Plane.h"
 #include "GafferScene/ShaderPlug.h"
@@ -163,6 +164,8 @@ void GafferSceneModule::bindPrimitives()
 	;
 
 	GafferBindings::Serialisation::registerSerialiser( LightFilter::staticTypeId(), new LightFilterSerialiser() );
+
+	GafferBindings::DependencyNodeClass<MeshLight>( nullptr, no_init );
 
 	{
 		scope s = GafferBindings::DependencyNodeClass<Sphere>();


### PR DESCRIPTION
This lets us remove a bunch of duplication between ArnoldMeshLight and RenderManMeshLight, and paves the way for making a similarly minimal USDMeshLight in future.

CyclesMeshLight remains as before, because it doesn't actually create lights.
