### PR TITLE
Path bread crumbs widget

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,7 +27,9 @@ and BSpline curves to their endpoints automatically, without manual management o
 - OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.
 - ArnoldMeshLight, RenderManMeshLight : Added support for deformation motion blur (#6869). In the case of RenderMan, this only affects the camera-visible mesh, since RenderMan doesn't yet support deformation for the light itself.
 - TweakPlug : Added `SetExpressionInclude` and `SetExpressionExclude` modes for tweaking set expressions.
-- Graph Editor : Added location bar for navigation through Boxes and References. Text and button interactions can be used to navigate the node hierarchy.
+- Graph Editor :
+  - Added location bar for navigation through Boxes and References. Text and button interactions can be used to navigate the node hierarchy.
+  - Added forward and back buttons to step through the history.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ and BSpline curves to their endpoints automatically, without manual management o
 - OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.
 - ArnoldMeshLight, RenderManMeshLight : Added support for deformation motion blur (#6869). In the case of RenderMan, this only affects the camera-visible mesh, since RenderMan doesn't yet support deformation for the light itself.
 - TweakPlug : Added `SetExpressionInclude` and `SetExpressionExclude` modes for tweaking set expressions.
+- Graph Editor : Added location bar for navigation through Boxes and References. Text and button interactions can be used to navigate the node hierarchy.
 
 Fixes
 -----
@@ -62,6 +63,8 @@ API
 - MeshLight : Added based class to simplify the implementation of renderer-specific mesh light nodes.
 - PathColumn : `headerData()` is now passed the root Path.
 - SetExpressionAlgo : Added new namespace with functions for evaluating and editing set expressions.
+- GraphComponentPath : Added `setFromComponent()`
+- BreadCrumbsWidget : Added widget for interacting with paths using a combination of button widgets and text entry.
 
 Breaking Changes
 ----------------

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -95,6 +95,8 @@ Leave `Box` node (subgraph)          | {kbd}`↑`
 Search for nodes                     | {kbd}`Ctrl` + {kbd}`F`
 Frame to numeric bookmark            | {kbd}`1` … {kbd}`9`
 Frame to focus node                  | <kbd>&#96;</kbd>
+Go back in history                   | {kbd}`[`
+Go forward in history                | {kbd}`]`
 
 ### Node creation ###
 

--- a/python/Gaffer/GraphComponentPath.py
+++ b/python/Gaffer/GraphComponentPath.py
@@ -95,6 +95,10 @@ class GraphComponentPath( Gaffer.Path ) :
 		## \todo Perhaps BackgroundTask cancellation shouldn't only be plug-centric?
 		return script["fileName"]
 
+	def setFromComponent( self, component ) :
+
+		self.setFromString( component.relativeName( self.__rootComponent ).replace( ".", "/" ) if not component.isSame( self.__rootComponent ) else "/" )
+
 	def _children( self, canceller ) :
 
 		try :

--- a/python/GafferUI/BreadCrumbsWidget.py
+++ b/python/GafferUI/BreadCrumbsWidget.py
@@ -1,0 +1,360 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import functools
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+from Qt import QtWidgets
+
+class BreadCrumbsWidget( GafferUI.Widget ) :
+
+	def __init__( self, path, **kw ) :
+
+		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, borderWidth = 1, spacing = 4 )
+
+		GafferUI.Widget.__init__( self, self.__row, **kw )
+
+		with self.__row :
+			self.__pathButtonContainer = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+			self.__textWidget = GafferUI.TextWidget( toolTip =
+				"## Actions\n\n"
+				"- Right-click for contents menu.\n"
+				"- <kbd>Down</kbd> to show children.\n"
+				"- <kbd>Up</kbd> to go to parent.\n"
+				"- <kbd>Tab</kbd> for auto-complete.\n"
+				"- <kbd>Home</kbd> to return to root."
+			)
+
+			self.__textWidget.keyPressSignal().connect( Gaffer.WeakMethod( self.__textKeyPress ) )
+			self.__textWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__textEditingFinished ) )
+			self.__textWidget.activatedSignal().connect( Gaffer.WeakMethod( self.__textActivated ) )
+			self.__textWidget.contextMenuSignal().connect( Gaffer.WeakMethod( self.__textContextMenu ) )
+			self.__textWidget.textChangedSignal().connect( Gaffer.WeakMethod( self.__textChanged ) )
+
+		self.__popupMenu = None
+
+		self.__pathContextMenuSignal = Gaffer.Signal3()
+
+		self.setPath( path )
+
+	def setPath( self, path ) :
+
+		self.__path = path
+		self.__pathChangedConnection = self.__path.pathChangedSignal().connect( Gaffer.WeakMethod( self.__pathChanged ), scoped = True )
+		self.__updateWidgets()
+
+	def getPath( self ) :
+
+		return self.__path
+
+	# Signal emitted to generate a context menu for a path bread crumb item. This
+	# allows multiple clients to collaborate in the construction of a menu, with
+	# each providing different items. The supplied `menuDefinition` will be
+	# prepopulated with items for setting the path and copying the path to the clipboard.
+	#
+	# Slots must have the following signature, with the `menuDefinition` being
+	# edited directly in place :
+	#
+	# `slot( path, breadCrumbsWidget, menuDefinition )`
+	def pathContextMenuSignal( self ) :
+
+		return self.__pathContextMenuSignal
+
+	def __updateWidgets( self ) :
+
+		del self.__pathButtonContainer[:]
+
+		path = self.__path.copy()
+		path.setFromString( path.root() )
+
+		for w in self.__pathWidgets( path.copy() ) :
+			self.__pathButtonContainer.append( w )
+
+		for i in range( 0, len( self.__path ) ) :
+			path.append( self.__path[i] )
+			if path.isValid() :
+				for w in self.__pathWidgets( path.copy() ) :
+					self.__pathButtonContainer.append( w )
+			else :
+				break
+
+		self.__textWidget.setText( path[-1] if ( len( path ) > 0 and not path.isValid() ) else "" )
+
+	def __pathWidgets( self, path ) :
+
+		pathButton = GafferUI.Button(
+			path[-1] if len( path ) > 0 else "",
+			image = "home.png" if len( path ) == 0 else None,
+			hasFrame = False,
+			toolTip = "Click to navigate here." + ( "<br>Right-click to choose a sibling." if len( path ) > 0 else "" )
+		)
+		pathButton._qtWidget().setProperty( "hasIcon", len( path ) == 0 )
+		pathButton.buttonPressSignal().connect( functools.partial( Gaffer.WeakMethod( self.__pathButtonPress ), path ) )
+
+		return ( pathButton, GafferUI.Label( "/" ) )
+
+	def __copyPathToClipboard( self, pathString ) :
+
+		self.ancestor( GafferUI.ScriptWindow ).scriptNode().applicationRoot().setClipboardContents( IECore.StringData( pathString ) )
+
+	def __pathButtonPress( self, path, button, event ) :
+
+		if event.buttons == GafferUI.ButtonEvent.Buttons.Right :
+			menuDefinition = IECore.MenuDefinition()
+
+			if len( path ) > 0 :
+				parentPath = path.copy()
+				del parentPath[-1]
+
+				menuDefinition.update( self.__pathMenuDefinition( parentPath ) )
+
+				menuDefinition.append(
+					"/copyDivider",
+					{
+						"divider" : True
+					}
+				)
+				menuDefinition.append(
+					"Copy Path",
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__copyPathToClipboard ), pathString = str( path ) ),
+					}
+				)
+
+			self.pathContextMenuSignal()( path, self, menuDefinition )
+
+			self.__popupListing( menuDefinition, button )
+
+			return True
+
+		elif event.button == event.Buttons.Left :
+			self.__path[:] = path[:]
+			return True
+
+		return False
+
+	def __textChanged( self, textWidget ) :
+
+		popupRequested = False
+		if self.__popupMenu is not None and self.__popupMenu.visible() :
+			# Dispose of current menu safely. We can be called from the keypress
+			# forwarding code of the menu, so we can't destroy it immediately.
+			GafferUI.WidgetAlgo.keepUntilIdle( self.__popupMenu )
+			self.__popupMenu = None
+			popupRequested = True
+
+		text = textWidget.getText()
+		newPath = self.__validatedPath( self.__path, text )
+
+		if newPath is not None and ( ( len( text ) > 0 and text[-1] == "/" ) or len( newPath ) == 0 ) :
+			self.__path[:] = newPath[:]
+			return
+
+		if popupRequested :
+			self.__popupListing( self.__pathMenuDefinition( self.__path, text ), self.__textWidget )
+
+	def __textEditingFinished( self, textWidget ) :
+
+		# This signal is also emitted when the menu pops up. If that's the case,
+		# don't clear the text. Also leave the text intact if we still have focus,
+		# i.e. the enter key was pressed. `__textActivated()` takes care of the contents
+		# in that case.`
+		if ( self.__popupMenu is None or not self.__popupMenu.visible() ) and not self.__textWidget._qtWidget().hasFocus() :
+			self.__textWidget.setText( "" )
+
+		return True
+
+	def __textActivated( self, textWidget ) :
+
+		if self.__popupMenu is not None and self.__popupMenu.visible() :
+			self.__popupMenu = None
+
+		text = textWidget.getText()
+		newPath = self.__validatedPath( self.__path, text )
+
+		if newPath is not None :
+			self.__path[:] = newPath[:]
+
+		return True
+
+	def __validatedPath( self, path, suffix ) :
+
+		newPath = path.copy()
+
+		if suffix == "" :
+			return None
+
+		suffix = suffix.replace( ".", "/" )
+		newPath.setFromString( str( path ) + "/" + suffix )
+
+		passesFilter = True
+		if path.getFilter() is not None :
+			passesFilter = path.getFilter().filter( [newPath] ) == [newPath]
+
+		return newPath if ( newPath.isValid() and passesFilter ) else None
+
+	def __textKeyPress( self, widget, event ) :
+
+		if not self.__textWidget.getEditable() :
+			# \todo This is copied from the `PathWidget`, is it possible to arrive here?
+			# Does it belong on `self` instead?
+			return False
+
+		if event.key == "Backspace" and self.__textWidget.getText() == "" and len( self.__path ) > 0 :
+			t = self.__path[-1]
+			del self.__path[-1]
+			self.__textWidget.setText( t )
+			return True
+
+		elif event.key=="Tab" :
+			self.__tabComplete()
+			return True
+
+		elif event.key == "Down" :
+			self.__popupListing( self.__pathMenuDefinition( self.__path ), self.__textWidget )
+			return True
+
+		elif event.key == "Up" :
+			if self.__textWidget.getText() != "" :
+				self.__textWidget.setText( "" )
+			elif len( self.__path ) > 0 :
+				del self.__path[-1]
+			return True
+
+		elif event.key == "Home" :
+			self.__path.setFromString( self.__path.root() )
+			return True
+
+		return False
+
+	def __textContextMenu( self, widget ) :
+
+		self.__popupListing( self.__pathMenuDefinition( self.__path ), None )
+		return True
+
+	def __tabComplete( self ) :
+
+		position = self.__textWidget.getCursorPosition()
+		text = self.__textWidget.getText()
+
+		matches = [ x[-1] for x in self.__path.children() if x[-1].startswith( text[:position] ) ]
+
+		match = os.path.commonprefix( matches )
+		if match :
+			self.__textWidget.setText( match )
+		self.__popupListing( self.__pathMenuDefinition( self.__path, match or text ), self.__textWidget )
+
+		self.__textWidget.setCursorPosition( len( self.__textWidget.getText() ) )
+
+	def __setPathEntry( self, path ) :
+
+		if path == self.__path :
+			return
+
+		newPath = self.__path.copy()
+		newPath.setFromString( newPath.root() )
+		pathLength = len( path )
+		for i in range( 0, max( pathLength, len( self.__path ) ) ) :
+			newPath.append( path[i] if i < pathLength else self.__path[i] )
+
+		newPath.truncateUntilValid()
+		self.__path[:] = newPath[:]
+
+		self.__textWidget.grabFocus()
+
+	def __pathMenuDefinition( self, path, prefix = "" ) :
+
+		result = IECore.MenuDefinition()
+
+		sortedChildren = sorted( path.children(), key = lambda v : v[-1] )
+
+		pathPrefix = "/"
+		for i, childPath in enumerate( [ i for i in sortedChildren if i[-1].startswith( prefix ) ] ) :
+			result.append(
+				pathPrefix + childPath[-1],
+				{
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setPathEntry ), childPath ),
+					"active": childPath[:] != self.__path[:len( childPath )],
+				}
+			)
+
+			if i == 10 :
+				pathPrefix = "/More/"
+				result.append( "/Divider", { "divider" : True } )
+
+		if result.size() == 0 :
+			result.append( "/No viewable children", { "active" : False, } )
+
+		return result
+
+	def __popupListing( self, menuDefinition, parentWidget ) :
+
+		bound = None
+		if parentWidget is not None :
+			bound = parentWidget.bound()
+			xOffset = 0
+			if isinstance( parentWidget, GafferUI.TextWidget ) :
+				xOffset = parentWidget._qtWidget().cursorRect().left()
+
+		self.__popupMenu = GafferUI.Menu( menuDefinition )
+		self.__popupMenu.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__popupMenuVisibilityChanged ) )
+		self.__popupMenu.popup(
+			parent = self.ancestor( GafferUI.GadgetWidget ) or self.__textWidget,
+			position = imath.V2i( bound.min().x + xOffset, bound.max().y ) if bound is not None else None,
+		)
+
+		## \todo Expose KeyboardMode publicly in `popup()`?
+
+		## \todo Is this valid for uses outside the GraphEditor?
+		self.__popupMenu._qtWidget().keyboardMode = self.__popupMenu._qtWidget().KeyboardMode.Forward
+
+	def __popupMenuVisibilityChanged( self, widget ) :
+
+		# \todo Determine if `__textWidget` needs to be cleared. It should be if it
+		# no longer has focus after the popup is hidden.
+		pass
+
+	def __pathChanged( self, path ) :
+
+		self.__updateWidgets()

--- a/python/GafferUI/Editor.py
+++ b/python/GafferUI/Editor.py
@@ -243,7 +243,19 @@ class Editor( GafferUI.Widget ) :
 
 	def __enter( self, widget ) :
 
+		# \todo The same method for finding the focus of a `QGraphicsView`
+		# is used in `GadgetWidget`. Extract both to a common place?
 		currentFocusWidget = QtWidgets.QApplication.focusWidget()
+
+		if (
+			isinstance( currentFocusWidget, QtWidgets.QGraphicsView ) and
+			isinstance( nextWidget := currentFocusWidget.scene().focusItem(), QtWidgets.QGraphicsProxyWidget )
+		) :
+			nextWidget = nextWidget.widget()
+			currentFocusWidget = None
+			while nextWidget is not None and nextWidget != currentFocusWidget :
+				currentFocusWidget = nextWidget
+				nextWidget = nextWidget.focusWidget()
 
 		# Don't disrupt in-progress text edits
 		if isinstance( currentFocusWidget, ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -293,6 +293,7 @@ class _GLGraphicsScene( QtWidgets.QGraphicsScene ) :
 
 		self.__backgroundDrawFunction = backgroundDrawFunction
 		self.sceneRectChanged.connect( self.__sceneRectChanged )
+		self.focusItemChanged.connect( self.__focusItemChanged )
 
 		self.__overlays = {} # Mapping from GafferUI.Widget to _OverlayProxyWidget
 
@@ -348,6 +349,14 @@ class _GLGraphicsScene( QtWidgets.QGraphicsScene ) :
 
 		for proxy in self.__overlays.values() :
 			self.__updateItemGeometry( proxy, sceneRect )
+
+	def __focusItemChanged( self, newItem, oldItem, reason ) :
+
+		if newItem is None and reason == QtCore.Qt.PopupFocusReason :
+			# Don't lose the focus item for this view due to a popup menu.
+			# Losing that would prevent the `GLWidget` from forwarding events
+			# to overlay widgets.
+			self.setFocusItem( oldItem )
 
 	def __updateItemGeometry( self, item, sceneRect ) :
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -129,7 +129,19 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 	def __enter( self, widget ) :
 
-		if not isinstance( QtWidgets.QApplication.focusWidget(), ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :
+		focusWidget = QtWidgets.QApplication.focusWidget()
+
+		if (
+			isinstance( focusWidget, QtWidgets.QGraphicsView ) and
+			isinstance( nextWidget := focusWidget.scene().focusItem(), QtWidgets.QGraphicsProxyWidget )
+		) :
+			nextWidget = nextWidget.widget()
+			focusWidget = None
+			while nextWidget is not None and nextWidget != focusWidget :
+				focusWidget = nextWidget
+				nextWidget = nextWidget.focusWidget()
+
+		if not isinstance( focusWidget, ( QtWidgets.QLineEdit, QtWidgets.QPlainTextEdit ) ) :
 			self._qtWidget().setFocus()
 
 		## \todo Widget.enterSignal() should be providing this
@@ -151,7 +163,12 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 	def __leave( self, widget ) :
 
-		self._qtWidget().clearFocus()
+		focusWidget = QtWidgets.QApplication.focusWidget()
+		if self._qtWidget() == focusWidget :
+			if not isinstance( focusWidget.scene().focusItem(), QtWidgets.QGraphicsProxyWidget ) :
+				# Relinquish the focus we stole in `__enter`, unless the user has
+				# explicitly moved it to a specific widget in one of our overlays.
+				self._qtWidget().clearFocus()
 
 		p = self.mousePosition( relativeTo = self )
 		event = GafferUI.ButtonEvent(

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -218,6 +218,11 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 	def __buttonDoubleClick( self, widget, event ) :
 
+		# We get given button double clicks before they're given to the overlay items,
+		# so we must ignore them so they can be used by the overlay.
+		if self._qtWidget().itemAt( event.line.p0.x, event.line.p0.y ) is not None :
+			return False
+
 		if not self._makeCurrent() :
 			return False
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -225,15 +225,15 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 	def __mouseMove( self, widget, event ) :
 
+		# We get given mouse moves before they're given to the overlay items,
+		# so we must ignore them so they can be used by the overlay.
+		if self._qtWidget().itemAt( event.line.p0.x, event.line.p0.y ) is not None :
+			return False
+
 		if not self._makeCurrent() :
 			return False
 
-		self.__viewportGadget.mouseMoveSignal()( self.__viewportGadget, event )
-
-		# we always return false so that any overlay items will get appropriate
-		# move/enter/leave events, otherwise highlighting for buttons etc can go
-		# awry.
-		return False
+		return self.__viewportGadget.mouseMoveSignal()( self.__viewportGadget, event )
 
 	def __dragBegin( self, widget, event ) :
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -336,6 +336,9 @@ class _EventFilter( QtCore.QObject ) :
 			widget = GafferUI.Widget._owner( qObject )
 			assert( isinstance( widget, GadgetWidget ) )
 
+			if qObject.itemAt( qEvent.x(), qEvent.y() ) is not None :
+				return False
+
 			if not widget._makeCurrent() :
 				return False
 

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -37,7 +37,6 @@
 
 import functools
 import imath
-import weakref
 
 import IECore
 
@@ -61,6 +60,17 @@ class _ViewableChildrenPathFilter( Gaffer.PathFilter ) :
 				result.append( p )
 
 		return result
+
+def _currentFrame( viewportGadget ) :
+
+	rasterMin = viewportGadget.rasterToWorldSpace( imath.V2f( 0 ) ).p0
+	rasterMax = viewportGadget.rasterToWorldSpace( imath.V2f( viewportGadget.getViewport() ) ).p0
+
+	frame = imath.Box2f()
+	frame.extendBy( imath.V2f( rasterMin[0], rasterMin[1] ) )
+	frame.extendBy( imath.V2f( rasterMax[0], rasterMax[1] ) )
+
+	return frame
 
 class GraphEditor( GafferUI.Editor ) :
 
@@ -88,6 +98,7 @@ class GraphEditor( GafferUI.Editor ) :
 
 		with column :
 			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+				self.__historyWidget = _HistoryWidget( self.graphGadget(), self.scriptNode() )
 				crumbs = GafferUI.BreadCrumbsWidget( self.__rootPath )
 				crumbs.pathContextMenuSignal().connect( Gaffer.WeakMethod( self.__breadCrumbsPathContextMenu ) )
 
@@ -487,6 +498,12 @@ class GraphEditor( GafferUI.Editor ) :
 					enabledPlug.setValue( not enabled )
 
 			return True
+		elif event.key == "BracketLeft" and not event.modifiers :
+			self.__historyWidget.moveHistoryIndex( -1 )
+			return True
+		elif event.key == "BracketRight" and not event.modifiers :
+			self.__historyWidget.moveHistoryIndex( 1 )
+			return True
 
 		return False
 
@@ -519,7 +536,7 @@ class GraphEditor( GafferUI.Editor ) :
 			# we're extending the existing framing, which we assume the
 			# user was happy with other than it not showing the nodes in question.
 			# so we just take the union of the existing frame and the one for the nodes.
-			cb = self.__currentFrame()
+			cb = _currentFrame( self.graphGadgetWidget().getViewportGadget() )
 			bound.extendBy( imath.Box3f( imath.V3f( cb.min().x, cb.min().y, 0 ), imath.V3f( cb.max().x, cb.max().y, 0 ) ) )
 		else :
 			# we're reframing from scratch, so the frame for the nodes is all we need.
@@ -605,32 +622,7 @@ class GraphEditor( GafferUI.Editor ) :
 
 		return []
 
-	def __currentFrame( self ) :
-		viewportGadget = self.graphGadgetWidget().getViewportGadget()
-
-		rasterMin = viewportGadget.rasterToWorldSpace( imath.V2f( 0 ) ).p0
-		rasterMax = viewportGadget.rasterToWorldSpace( imath.V2f( viewportGadget.getViewport() ) ).p0
-
-		frame = imath.Box2f()
-		frame.extendBy( imath.V2f( rasterMin[0], rasterMin[1] ) )
-		frame.extendBy( imath.V2f( rasterMax[0], rasterMax[1] ) )
-
-		return frame
-
 	def __rootChanged( self, graphGadget, previousRoot ) :
-
-		# save/restore the current framing so jumping in
-		# and out of Boxes isn't a confusing experience.
-
-		Gaffer.Metadata.registerValue( previousRoot, "ui:graphEditor{}:framing".format( id( self ) ), self.__currentFrame(), persistent = False )
-
-		frame = Gaffer.Metadata.value( self.graphGadget().getRoot(), "ui:graphEditor{}:framing".format( id( self ) ) )
-		if frame is not None :
-			self.graphGadgetWidget().getViewportGadget().frame(
-				imath.Box3f( imath.V3f( frame.min().x, frame.min().y, 0 ), imath.V3f( frame.max().x, frame.max().y, 0 ) )
-			)
-		else :
-			self.__frame( self.graphGadget().getRoot().children( Gaffer.Node ) )
 
 		# do what we need to do to keep our title up to date.
 
@@ -887,3 +879,123 @@ class GraphEditor( GafferUI.Editor ) :
 		return enabledPlug
 
 GafferUI.Editor.registerType( "GraphEditor", GraphEditor )
+
+class _HistoryWidget( GafferUI.Widget ) :
+
+	def __init__( self, graphGadget, scriptNode, **kw ) :
+
+		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+
+		GafferUI.Widget.__init__( self, self.__row, **kw )
+
+		self.__graphGadget = graphGadget
+		self.__scriptNode = scriptNode
+
+		self.__rootChangedConnection = self.__graphGadget.rootChangedSignal().connectFront( Gaffer.WeakMethod( self.__rootChanged ), scoped = True )
+
+		with self.__row :
+			self.__backButton = GafferUI.Button( "", "historyBack.png", hasFrame = False, toolTip = "Go back. [<kbd>[</kbd>]<br>Right-click for history menu." )
+			self.__forwardButton = GafferUI.Button( "", "historyForward.png", hasFrame = False, toolTip = "Go forward. [<kbd>]</kbd>]<br>Right-click for history menu." )
+			self.__backButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__backButtonPressed ) )
+			self.__backButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__backButtonPressed ) )
+			self.__forwardButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__forwardButtonPressed ) )
+			self.__forwardButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__forwardButtonPressed ) )
+
+		# A list of tuples of the form `( rootNode, frame )`. A frame value of `None`
+		# indicates framing to fit all child nodes.
+		self.__history = [ ( self.__scriptNode, None ) ]
+		self.__historyIndex = 0
+		self.__historyPopup = None
+
+		self.__updateHistoryButtonsEnabled()
+
+	def moveHistoryIndex( self, delta ) :
+
+		if self.__historyIndex + delta < 0 or self.__historyIndex + delta >= len( self.__history ) :
+			return
+
+		self.__history[self.__historyIndex] = ( self.__history[self.__historyIndex][0], _currentFrame( self.__graphGadget.parent() ) )
+
+		self.__historyIndex += delta
+
+		# \todo Where do we go if the node has been deleted?
+		graphEditor = self.ancestor( GafferUI.GraphEditor )
+		assert( graphEditor is not None )
+		rootNode = self.__history[self.__historyIndex][0]
+		if rootNode.isSame( self.__scriptNode ) or self.__scriptNode.isAncestorOf( rootNode ) :
+			with Gaffer.Signals.BlockedConnection( self.__rootChangedConnection ) :
+				# We're blocking `__rootChangedConnection` so we don't append to history.
+				# That connection also handles framing, so we need to take care of that here.
+				self.__frame()
+				self.__graphGadget.setRoot( rootNode )
+
+		self.__updateHistoryButtonsEnabled()
+
+	def __backButtonPressed( self, button, event ) :
+
+		if event.buttons == event.Buttons.Left :
+			self.moveHistoryIndex( -1 )
+		elif event.buttons == event.Buttons.Right :
+			self.__showHistoryPopup( range( self.__historyIndex - 1, -1, -1 ), button )
+
+	def __forwardButtonPressed( self, button, event ) :
+
+		if event.buttons == event.Buttons.Left :
+			self.moveHistoryIndex( 1 )
+		elif event.buttons == event.Buttons.Right :
+			self.__showHistoryPopup( range( self.__historyIndex + 1, len( self.__history ), 1 ), button )
+
+	def __rootChanged( self, graphGadget, previousRoot ) :
+
+		self.__history = self.__history[:self.__historyIndex + 1]
+		self.__history[self.__historyIndex] = ( self.__history[self.__historyIndex][0], _currentFrame( self.__graphGadget.parent() ) )
+
+		self.__history.append( ( graphGadget.getRoot(), None ) )
+		self.__historyIndex += 1
+		self.__frame()
+		self.__updateHistoryButtonsEnabled()
+
+	def __frame( self ) :
+
+		rootNode = self.__history[self.__historyIndex][0]
+		frame = None
+		for i in range( self.__historyIndex, -1, -1 ) :
+			historyNode, historyFrame = self.__history[i]
+			if historyNode.isSame( rootNode ) and historyFrame is not None :
+				frame = historyFrame
+				break
+
+		graphEditor = self.ancestor( GafferUI.GraphEditor )
+		assert( graphEditor is not None )
+		if frame is not None :
+			graphEditor.graphGadgetWidget().getViewportGadget().frame(
+				imath.Box3f( imath.V3f( frame.min().x, frame.min().y, 0 ), imath.V3f( frame.max().x, frame.max().y, 0 ) )
+			)
+		else :
+			graphEditor.frame( graphEditor.graphGadget().getRoot().children( Gaffer.Node ) )
+
+	def __showHistoryPopup(self, historyRange, popupParent ) :
+
+		graphEditor = self.ancestor( GafferUI.GraphEditor )
+		menuDefinition = IECore.MenuDefinition()
+		prefix = "/"
+		for counter, i in enumerate( historyRange ) :
+			menuDefinition.append(
+				prefix + str( counter ),
+				{
+					"label" : ( "/" + self.__history[i][0].relativeName( self.__scriptNode ).replace( ".", "/" ) ) if not self.__history[i][0].isSame( self.__scriptNode ) else "/",
+					"command" : functools.partial( Gaffer.WeakMethod( self.moveHistoryIndex ), i - self.__historyIndex ),
+				}
+			)
+
+			if counter == 10 :
+				prefix = "/More/"
+				menuDefinition.append( "/Divider", { "divider" : True } )
+
+		self.__historyPopup = GafferUI.Menu( menuDefinition )
+		self.__historyPopup.popup( popupParent, position = imath.V2i( popupParent.bound().min().x, popupParent.bound().max().y ) )
+
+	def __updateHistoryButtonsEnabled( self ) :
+
+		self.__backButton.setEnabled( self.__historyIndex > 0 )
+		self.__forwardButton.setEnabled( self.__historyIndex < ( len( self.__history ) - 1 ) )

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -37,15 +37,38 @@
 
 import functools
 import imath
+import weakref
 
 import IECore
 
 import Gaffer
 import GafferUI
 
+class _ViewableChildrenPathFilter( Gaffer.PathFilter ) :
+
+	def __init__( self, scriptRoot, userData = {} ) :
+
+		Gaffer.PathFilter.__init__( self, userData )
+
+		self.__scriptRoot = scriptRoot
+
+	def _filter( self, paths, canceller ) :
+
+		result = []
+		for p in paths :
+			n = self.__scriptRoot.descendant( str( p ).lstrip( "/" ).replace( "/", "." ) )
+			if isinstance( n, Gaffer.Node ) and Gaffer.Metadata.value( n, "ui:childNodesAreViewable" ) :
+				result.append( p )
+
+		return result
+
 class GraphEditor( GafferUI.Editor ) :
 
 	def __init__( self, scriptNode, **kw ) :
+
+		column = GafferUI.ListContainer( borderWidth = 4, spacing = 4 )
+
+		GafferUI.Editor.__init__( self, column, scriptNode, **kw )
 
 		# We want to disable precise navigation motions as they interfere
 		# with our keyboard shortcuts and aren't that useful in the graph
@@ -55,18 +78,27 @@ class GraphEditor( GafferUI.Editor ) :
 
 		self.__gadgetWidget = GafferUI.GadgetWidget( gadget = viewportGadget )
 
-		GafferUI.Editor.__init__( self, self.__gadgetWidget, scriptNode, **kw )
-
 		graphGadget = GafferUI.GraphGadget( self.scriptNode() )
 		graphGadget.rootChangedSignal().connect( Gaffer.WeakMethod( self.__rootChanged ) )
 
 		self.__gadgetWidget.getViewportGadget().setPrimaryChild( graphGadget )
+
+		self.__rootPath = Gaffer.GraphComponentPath( self.scriptNode(), [], filter = _ViewableChildrenPathFilter( self.scriptNode() ) )
+		self.__rootPathChangedConnection = self.__rootPath.pathChangedSignal().connect( Gaffer.WeakMethod( self.__rootPathChanged ), scoped = True )
+
+		with column :
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+				crumbs = GafferUI.BreadCrumbsWidget( self.__rootPath )
+				crumbs.pathContextMenuSignal().connect( Gaffer.WeakMethod( self.__breadCrumbsPathContextMenu ) )
+
+		column.addChild( self.__gadgetWidget )
+
 		self.__gadgetWidget.getViewportGadget().setDragTracking( GafferUI.ViewportGadget.DragTracking.XDragTracking | GafferUI.ViewportGadget.DragTracking.YDragTracking )
 		self.__frame( scriptNode.selection() )
 
-		self.__gadgetWidget.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ) )
-		self.__gadgetWidget.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ) )
-		self.__gadgetWidget.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__buttonDoubleClick ) )
+		self.__gadgetWidget.getViewportGadget().buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ) )
+		self.__gadgetWidget.getViewportGadget().keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ) )
+		self.__gadgetWidget.getViewportGadget().buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__buttonDoubleClick ) )
 		self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ) )
 		self.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ) )
 		self.dropSignal().connect( Gaffer.WeakMethod( self.__drop ) )
@@ -120,7 +152,7 @@ class GraphEditor( GafferUI.Editor ) :
 
 		root = self.graphGadget().getRoot()
 		if not root.isSame( self.scriptNode() ) :
-			result += " : " + root.relativeName( self.scriptNode() ).replace( ".", " / " )
+			result += " : " + root.getName()
 
 		return result
 
@@ -614,7 +646,12 @@ class GraphEditor( GafferUI.Editor ) :
 
 		self.titleChangedSignal()( self )
 
+		self.__rootPath.setFromComponent( graphGadget.getRoot() )
+
 	def __rootNameChanged( self, root, oldName ) :
+
+		with Gaffer.Signals.BlockedConnection( self.__rootPathChangedConnection ) :
+			self.__rootPath.setFromComponent( self.graphGadget().getRoot() )
 
 		self.titleChangedSignal()( self )
 
@@ -623,6 +660,11 @@ class GraphEditor( GafferUI.Editor ) :
 		# This may be called for our root, or any of its parents
 		if node.parent() == None :
 			self.graphGadget().setRoot( self.scriptNode() )
+
+	def __rootPathChanged( self, path ) :
+
+		with Gaffer.Signals.BlockedConnection( self.__rootPathChangedConnection ) :
+			self.graphGadget().setRoot( path.property( "graphComponent:graphComponent" ) )
 
 	def __preRender( self, viewportGadget ) :
 
@@ -651,6 +693,22 @@ class GraphEditor( GafferUI.Editor ) :
 		# layout has gone off screen.
 
 		self.frame( nodes, extend = True )
+
+	def __acquireGraphEditorFromPath( self, pathString ) :
+
+		scriptNode = self.ancestor( GafferUI.ScriptWindow ).scriptNode()
+		n = scriptNode.descendant( pathString ) if pathString else scriptNode
+		GafferUI.GraphEditor.acquire( n )
+
+	def __breadCrumbsPathContextMenu( self, path, widget, menuDefinition ) :
+
+		menuDefinition.append(
+			"Open in new Graph Editor",
+			{
+				"command" : functools.partial( Gaffer.WeakMethod( self.__acquireGraphEditorFromPath ), pathString = str( path ) ),
+				"active" : path != self.__rootPath,
+			}
+		)
 
 	def __annotationsMenu( self ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1777,6 +1777,33 @@ _styleSheet = string.Template(
 		border: 1px solid $brightColor;
 	}
 
+	QWidget[gafferClass="GafferUI.BreadCrumbsWidget"] {
+		border: 1px solid transparent;
+		border-bottom-color: $tintDarkerStronger;
+		border-right-color: $tintDarkerStronger;
+		background-color: $backgroundLight;
+		border-radius: $widgetCornerRadius;
+	}
+
+	QWidget[gafferClass="GafferUI.BreadCrumbsWidget"] QLineEdit {
+		border: 0;
+		border-radius: 0;
+		background-color: transparent;
+	}
+
+	QWidget[gafferClass="GafferUI.BreadCrumbsWidget"] QPushButton {
+		margin: 1px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		padding-left: 5px;
+		padding-right: 5px;
+	}
+
+	QWidget[gafferClass="GafferUI.BreadCrumbsWidget"] QPushButton[hasIcon="false"]:hover {
+		background-color : $brightColorTransparent;
+		border-radius: 4px;
+	}
+
 	"""
 
 ).substitute( substitutions )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -181,6 +181,7 @@ from .RampWidget import RampWidget
 from .Bookmarks import Bookmarks
 from . import WidgetAlgo
 from .CodeWidget import CodeWidget
+from .BreadCrumbsWidget import BreadCrumbsWidget
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferUITest/BreadCrumbsWidgetTest.py
+++ b/python/GafferUITest/BreadCrumbsWidgetTest.py
@@ -1,0 +1,124 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class BreadCrumbsWidgetTest( GafferUITest.TestCase ) :
+
+	def __assertWidgets( self, widgets, path ) :
+
+		self.assertEqual( len( widgets ), 2 + len( path ) * 2 )
+
+		self.assertIsInstance( widgets[0], GafferUI.Button )
+		self.assertEqual( widgets[0].getText(), "" )
+		self.assertIsInstance( widgets[1], GafferUI.Label )
+		self.assertEqual( widgets[1].getText(), "/" )
+
+		for i, p in enumerate( path ) :
+			self.assertIsInstance( widgets[i * 2 + 2], GafferUI.Button )
+			self.assertEqual( widgets[i * 2 + 2].getText(), p )
+			self.assertIsInstance( widgets[i * 2 + 3], GafferUI.Label )
+			self.assertEqual( widgets[i * 2 + 3].getText(), "/" )
+
+	def testPathWidgets( self ) :
+
+		path = Gaffer.DictPath( { "parent" : { "child": "contents" }, "brother" : "contents" }, "/" )
+
+		crumbs = GafferUI.BreadCrumbsWidget( path )
+
+		self.__assertWidgets( crumbs._BreadCrumbsWidget__pathButtonContainer, path )
+
+		path.setFromString( "/parent" )
+		self.__assertWidgets( crumbs._BreadCrumbsWidget__pathButtonContainer, path )
+
+		path.append( "child" )
+		self.__assertWidgets( crumbs._BreadCrumbsWidget__pathButtonContainer, path )
+
+		path.setFromString( "/brother" )
+		self.__assertWidgets( crumbs._BreadCrumbsWidget__pathButtonContainer, path )
+
+	def testTextEntry( self ) :
+
+		path = Gaffer.DictPath( { "parent" : { "child": { "grandChild" : "contents" } }, "brother" : "contents" }, "/" )
+
+		crumbs = GafferUI.BreadCrumbsWidget( path )
+
+		t = crumbs._BreadCrumbsWidget__textWidget
+		self.assertEqual( t.getText(), "" )
+
+		t.setText( "parent/" )
+		self.assertEqual( t.getText(), "" )
+		self.assertEqual( str( path ), "/parent" )
+
+		t.setText( "child.grandChild/" )
+		self.assertEqual( t.getText(), "" )
+		self.assertEqual( str( path ), "/parent/child/grandChild" )
+
+		t.setText( "brother" )
+		self.assertEqual( t.getText(), "brother" )
+		self.assertEqual( str( path ), "/parent/child/grandChild" )
+
+		path.setFromString( "/" )
+		t.setText( "brother/" )
+		self.assertEqual( t.getText(), "" )
+		self.assertEqual( str( path ), "/brother" )
+
+	def testFilter( self ) :
+
+		filter = Gaffer.MatchPatternPathFilter( [ "a*" ] )
+		path = Gaffer.DictPath( { "abc" : "contents", "xyz" : "contents" }, "/", filter = filter )
+
+		crumbs = GafferUI.BreadCrumbsWidget( path )
+
+		t = crumbs._BreadCrumbsWidget__textWidget
+
+		t.setText( "abc/" )
+		self.assertEqual( t.getText(), "" )
+		self.assertEqual( str( path ), "/abc" )
+
+		path.setFromString( "/" )
+
+		t.setText( "xyz/" )
+		self.assertEqual( t.getText(), "xyz/" )
+		self.assertEqual( str( path ), "/" )
+
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferUITest/GraphEditorTest.py
+++ b/python/GafferUITest/GraphEditorTest.py
@@ -108,13 +108,13 @@ class GraphEditorTest( GafferUITest.TestCase ) :
 		self.assertEqual( self.__signalUpdatedTitle, "Graph Editor : a" )
 
 		g.graphGadget().setRoot( b2 )
-		self.assertEqual( self.__signalUpdatedTitle, "Graph Editor : a / b" )
+		self.assertEqual( self.__signalUpdatedTitle, "Graph Editor : b" )
 
 		b1.setName( "c" )
-		self.assertEqual( self.__signalUpdatedTitle, "Graph Editor : c / b" )
+		self.assertEqual( self.__signalUpdatedTitle, "Graph Editor : b" )
 
 		b2.setName( "d" )
-		self.assertEqual( self.__signalUpdatedTitle, "Graph Editor : c / d" )
+		self.assertEqual( self.__signalUpdatedTitle, "Graph Editor : d" )
 
 		g.setTitle( "This is a test!" )
 		self.assertEqual( self.__signalUpdatedTitle, "This is a test!" )

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -135,6 +135,7 @@ from .PopupWindowTest import PopupWindowTest
 from .ColorChooserTest import ColorChooserTest
 from .ContextTrackerTest import ContextTrackerTest
 from .MetadataAlgoTest import MetadataAlgoTest
+from .BreadCrumbsWidgetTest import BreadCrumbsWidgetTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -530,6 +530,7 @@
 				"searchFieldBackground",
 				"search",
 				"searchOn",
+				"home",
 			],
 
 		},

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -531,6 +531,8 @@
 				"search",
 				"searchOn",
 				"home",
+				"historyBack",
+				"historyForward",
 			],
 
 		},

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -175,7 +175,7 @@
     <linearGradient
        id="backgroundLighter"
        inkscape:swatch="solid"
-       gradientTransform="matrix(1.8190548,0,0,2.0056446,-986.3615,7605.2818)">
+       gradientTransform="matrix(1.8190548,0,0,-2.0056446,-782.97582,-2456.2251)">
       <stop
          style="stop-color:#9e9e9e;stop-opacity:1;"
          offset="0"
@@ -3253,14 +3253,34 @@
        x="15"
        y="2366"
        inkscape:label="tabScrollMenu" />
-    <rect
-       inkscape:label="annotations"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       id="annotations"
-       width="25"
-       height="25"
-       x="50"
-       y="2427.9998" />
+    <g
+       id="g2152"
+       inkscape:label="graph editor">
+      <rect
+         inkscape:label="annotations"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="annotations"
+         width="25"
+         height="25"
+         x="50"
+         y="2427.9998" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:1.04876;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="historyForward"
+         width="16"
+         height="16"
+         x="140"
+         y="3050"
+         inkscape:label="historyForward" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:1.04876;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="historyBack"
+         width="16"
+         height="16"
+         x="120"
+         y="3050"
+         inkscape:label="historyBack" />
+    </g>
     <rect
        id="rect1221"
        y="2612"
@@ -4016,6 +4036,18 @@
       <g
          id="g13042"
          inkscape:label="home" />
+      <path
+         id="path2303"
+         style="display:inline;fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.992157"
+         inkscape:label="historyBackArrow"
+         d="m 113.02994,2492.4077 h -6 v 3 l -9,-7 9,-7 v 3 h 6"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         id="path334"
+         style="display:inline;fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.992157"
+         inkscape:label="historyForwardArrow"
+         d="m 117.02994,2492.4077 h 6 v 3 l 9,-7 -9,-7 v 3 h -6"
+         sodipodi:nodetypes="ccccccc" />
     </g>
     <rect
        style="display:inline;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1.00011;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -7277,9 +7309,9 @@
            sodipodi:nodetypes="sccssssssssccss"
            inkscape:connector-curvature="0"
            id="path5277"
-           transform="translate(0,52.362183)"
            d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.70271,0.55404 H 243.5 c -1.662,0 -3.02703,1.36503 -3.02703,3.02703 v 6.91892 c 0,1.662 1.36502,3.02702 3.02703,3.02702 l 12.97297,-1e-5 c 1.662,0 3.02703,-1.36501 3.02703,-3.02701 v -6.91892 c -10e-6,-1.662 -1.36503,-3.02704 -3.02703,-3.02704 h -1.2973 L 254.5,200 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.864865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.864865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="translate(0,52.362183)" />
         <circle
            r="4.3243241"
            cy="258.97028"
@@ -8948,46 +8980,39 @@
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="sizeGuide" />
     <g
-       style="display:inline"
-       id="f"
-       transform="translate(40,144.00001)"
-       inkscape:label="#g5694">
-      <path
-         inkscape:connector-curvature="0"
-         id="rect1979"
-         transform="translate(0,52.362183)"
-         d="m 16,2286.5 c -1.938933,0 -3.5,1.5611 -3.5,3.5 v 8.5 c 0,1.9389 1.561067,3.5 3.5,3.5 h 3.5 l 3,5 3,-5 H 29 c 1.938933,0 3.5,-1.5611 3.5,-3.5 v -8.5 c 0,-1.9389 -1.561067,-3.5 -3.5,-3.5 z"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5680"
-         d="M 15,2343.3622 H 30"
-         style="fill:none;stroke:#535353;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         style="fill:none;stroke:#535353;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 15,2346.3622 H 30"
-         id="path5686"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path5688"
-         d="m 15,2349.3622 h 8"
-         style="fill:none;stroke:#535353;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         style="fill:#282828;fill-opacity:0.38"
-         d="m 41.5,2351.8622 v -9"
-         id="path2241" />
-      <path
-         style="fill:#282828;fill-opacity:0.38"
-         d="m 37.5,2342.8622 8,-6"
-         id="path2243" />
-    </g>
-    <g
        id="g3004"
        style="display:inline;stroke:#282828;stroke-opacity:1"
-       transform="translate(40,144.00001)"
-       inkscape:label="GraphEditor" />
+       transform="translate(42,142.00001)"
+       inkscape:label="GraphEditor">
+      <g
+         style="display:inline"
+         id="f"
+         transform="translate(-2,2)"
+         inkscape:label="#g5694">
+        <path
+           inkscape:connector-curvature="0"
+           id="rect1979"
+           transform="translate(0,52.362183)"
+           d="m 16,2286.5 c -1.938933,0 -3.5,1.5611 -3.5,3.5 v 8.5 c 0,1.9389 1.561067,3.5 3.5,3.5 h 3.5 l 3,5 3,-5 H 29 c 1.938933,0 3.5,-1.5611 3.5,-3.5 v -8.5 c 0,-1.9389 -1.561067,-3.5 -3.5,-3.5 z"
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path5680"
+           d="M 15,2343.3622 H 30"
+           style="fill:none;stroke:#535353;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#535353;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 15,2346.3622 H 30"
+           id="path5686"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path5688"
+           d="m 15,2349.3622 h 8"
+           style="fill:none;stroke:#535353;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
     <g
        id="focusOn"
        inkscape:label="focusOn"
@@ -11842,8 +11867,13 @@
     </g>
     <path
        id="path26397"
-       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1"
+       style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1"
        d="m 108,3103.8622 -6.5,6 h 1 v 7 h 4 v -4.5 h 3 v 4.5 h 4 v -7.0001 h 1 l -2,-1.9999 v -2.5 H 110 v 0.5 z"
        sodipodi:nodetypes="cccccccccccccccc" />
+    <g
+       id="g4735"
+       style="display:inline;stroke:#282828;stroke-opacity:1"
+       transform="matrix(-1,0,0,1,188,142.00001)"
+       inkscape:label="GraphEditor" />
   </g>
 </svg>

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -109,7 +109,7 @@
     </linearGradient>
     <linearGradient
        id="boundsTemplate"
-       gradientTransform="matrix(1.4488738,0,0,1.25,1285.8825,5285.1293)"
+       gradientTransform="matrix(0.92727923,0,0,0.8,893.5648,4275.413)"
        inkscape:swatch="solid">
       <stop
          style="stop-color:#ff0101;stop-opacity:0.0787037;"
@@ -1837,6 +1837,18 @@
      inkscape:label="ExportAreas"
      style="display:inline"
      inkscape:groupmode="layer">
+    <g
+       id="g2176"
+       inkscape:label="Miscellaneous">
+      <rect
+         y="3050"
+         x="100"
+         height="16"
+         width="16"
+         id="home"
+         style="display:inline;fill:none;fill-opacity:0.23999999;stroke:none;stroke-width:0.382473;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="home" />
+    </g>
     <g
        id="g2499"
        inkscape:label="LocalJobs">
@@ -3996,6 +4008,14 @@
          d="m 103.12888,2944.2346 h 3.32629 c 1.97062,0 3.494,-0.8246 3.494,-2.6834 0,-1.2159 -0.68482,-1.9007 -1.98459,-2.1383 v -0.056 c 1.07615,-0.2795 1.56531,-1.16 1.56531,-1.9706 0,-1.747 -1.4535,-2.2641 -3.34026,-2.2641 h -3.06075 z m 2.05447,-5.4506 v -2.0545 h 0.92242 c 0.96434,0 1.41158,0.2656 1.41158,0.9364 0,0.6988 -0.41928,1.1181 -1.42556,1.1181 z m 0,3.8434 v -2.362 h 1.10411 c 1.13205,0 1.64917,0.3355 1.64917,1.1321 0,0.8246 -0.53109,1.2299 -1.64917,1.2299 z"
          id="path20339"
          style="fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g12211"
+       inkscape:label="Miscellaneous"
+       transform="translate(22.97006,621.95452)">
+      <g
+         id="g13042"
+         inkscape:label="home" />
     </g>
     <rect
        style="display:inline;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:1.00011;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -8954,7 +8974,20 @@
          id="path5688"
          d="m 15,2349.3622 h 8"
          style="fill:none;stroke:#535353;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:#282828;fill-opacity:0.38"
+         d="m 41.5,2351.8622 v -9"
+         id="path2241" />
+      <path
+         style="fill:#282828;fill-opacity:0.38"
+         d="m 37.5,2342.8622 8,-6"
+         id="path2243" />
     </g>
+    <g
+       id="g3004"
+       style="display:inline;stroke:#282828;stroke-opacity:1"
+       transform="translate(40,144.00001)"
+       inkscape:label="GraphEditor" />
     <g
        id="focusOn"
        inkscape:label="focusOn"
@@ -11807,5 +11840,10 @@
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#787878;fill-opacity:0.38">A</tspan></text>
       </g>
     </g>
+    <path
+       id="path26397"
+       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-opacity:1"
+       d="m 108,3103.8622 -6.5,6 h 1 v 7 h 4 v -4.5 h 3 v 4.5 h 4 v -7.0001 h 1 l -2,-1.9999 v -2.5 H 110 v 0.5 z"
+       sodipodi:nodetypes="cccccccccccccccc" />
   </g>
 </svg>


### PR DESCRIPTION
This adds a few new navigation widgets to the Graph Editor. It adds a new `BreadCrumbsWidget` for working with paths and makes use of it in the Graph Editor. There are also forward and back buttons for navigating the history of locations the Graph Editor has been rooted to.

There's a known test failure in `GraphEditorTest`. This stems from the addition of `__rootPath` in the Graph Editor. This needs to be kept in sync with the actual node that is the root of the Graph Editor. But we've been switching that root using `GraphGadget.setRoot()`. This made for somewhat loose coupling between the two and setup two different methods for setting and responding to root changes - `GraphGadget.rootChangedSignal()` and `__rootPath.pathChangedSignal()`. The history navigation in particularly was difficult with this setup.

So for the Graph Editor, I've settled on modifying the root via the `__rootPath`. I didn't fix that test and add additional coverage yet so as to not put too much time into a change that may have a better solution.

I imagine besides the code, there are probably some discussions to be had on the widget styling as well.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
