### PR TITLE
Primitive Variable Inspector

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - ShaderTweaks : Added support for `{shaderType=someShaderType}` qualifiers in parameter names, allowing tweaking of a parameter on all shaders of a given type (#6838).
 - Scene Editors : The effects of the `render:inclusions`, `render:exclusions` and `render:additionalLights` options are now represented in the Scene Editors. As these options result in the RenderSetAdaptor pruning scene locations at render time, the Hierarchy View, Attribute Editor and Light Editor now display the same pruned scene hierarchy provided to the renderer.
 - SetEditor, PrimitiveInspector, UVInspector : Added inspection of scene edits performed by render adaptors registered to `client = "SceneEditor"`.
+- SceneInspector : Added double-click editing of primitive variable data when the source is a PrimitiveVariables or PrimitiveVariableTweaks node.
 
 Fixes
 -----
@@ -22,6 +23,7 @@ Fixes
   - Object Type, Primitive Topology and Primitive Variables
   - Camera and ExternalProcedural parameters
   - Globals
+- SceneInspector : Primitive variable history now correctly shows the effects of ShufflePrimitiveVariables and CopyPrimitiveVariables.
 - MotionPath : Fixed hashing bug preventing motion path curves from updating when their source transforms were modified.
 - Viewer : Added prevention and recovery for situations where framing large objects causes the camera matrix to become corrupted with nans (#6715).
 - OSLObject : Simplified internal network to make inspector history more accurate.

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Fixes
   - Globals
 - MotionPath : Fixed hashing bug preventing motion path curves from updating when their source transforms were modified.
 - Viewer : Added prevention and recovery for situations where framing large objects causes the camera matrix to become corrupted with nans (#6715).
+- OSLObject : Simplified internal network to make inspector history more accurate.
 
 1.6.16.0 (relative to 1.6.15.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,11 @@ Fixes
 - Viewer : Added prevention and recovery for situations where framing large objects causes the camera matrix to become corrupted with nans (#6715).
 - OSLObject : Simplified internal network to make inspector history more accurate.
 
+API
+---
+
+- SceneAlgo : Added `primitiveVariableHistory()` function.
+
 1.6.16.0 (relative to 1.6.15.0)
 ========
 

--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -130,8 +130,8 @@ class GAFFEROSL_API OSLObject : public GafferScene::Deformer
 		GafferScene::ShaderPlug *shaderPlug();
 		const GafferScene::ShaderPlug *shaderPlug() const;
 
-		GafferScene::ScenePlug *resampledInPlug();
-		const GafferScene::ScenePlug *resampledInPlug() const;
+		Gaffer::ObjectPlug *resampledInObjectPlug();
+		const Gaffer::ObjectPlug *resampledInObjectPlug() const;
 
 		Gaffer::StringPlug *resampledNamesPlug();
 		const Gaffer::StringPlug *resampledNamesPlug() const;

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -44,6 +44,7 @@
 #include "Gaffer/NumericPlug.h"
 
 #include "IECoreScene/Camera.h"
+#include "IECoreScene/PrimitiveVariable.h"
 
 #include "IECore/Export.h"
 
@@ -266,6 +267,27 @@ struct OptionHistory : public History
 /// `globalsHistory` should have been obtained from a previous call to
 /// `history( scene->globalsPlug() )`.
 GAFFERSCENE_API OptionHistory::Ptr optionHistory( const History *globalsHistory, const IECore::InternedString &option );
+
+/// Extends History to provide information on the history of a specific primitive variable.
+/// Primitive variables may be renamed by ShufflePrimitiveVariables nodes and this is reflected
+/// in the `primitiveVariableName` field.
+struct PrimitiveVariableHistory : public History
+{
+	IE_CORE_DECLAREMEMBERPTR( PrimitiveVariableHistory )
+	PrimitiveVariableHistory(
+		const ScenePlugPtr &scene, const Gaffer::ContextPtr &context,
+		const IECore::InternedString &primitiveVariableName, const IECoreScene::PrimitiveVariable &primitiveVariableValue
+	) :	History( scene, context ), primitiveVariableName( primitiveVariableName ), primitiveVariableValue( primitiveVariableValue ) {}
+	IECore::InternedString primitiveVariableName;
+	IECoreScene::PrimitiveVariable primitiveVariableValue;
+};
+
+/// Filters `objectHistory` and returns a history for the specific `primitiveVariable`.
+/// `objectHistory` should have been obtained from a previous call to
+/// `history( scene->objectPlug(), path )`. If the primitive variable doesn't exist then
+/// null is returned.
+GAFFERSCENE_API PrimitiveVariableHistory::Ptr primitiveVariableHistory( const History *objectHistory, const IECore::InternedString &primitiveVariable );
+
 
 /// Returns the upstream scene originally responsible for generating the specified location.
 GAFFERSCENE_API ScenePlug *source( const ScenePlug *scene, const ScenePlug::ScenePath &path );

--- a/include/GafferSceneUI/Private/PrimitiveVariableInspector.h
+++ b/include/GafferSceneUI/Private/PrimitiveVariableInspector.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,43 +36,57 @@
 
 #pragma once
 
+#include "GafferSceneUI/Export.h"
+
+#include "GafferSceneUI/Private/Inspector.h"
+
 namespace GafferSceneUI
 {
 
-enum TypeId
+namespace Private
 {
-	SceneViewTypeId = 121000,
-	SceneGadgetTypeId = 121001,
-	SelectionToolTypeId = 121002,
-	CropWindowToolTypeId = 121003,
-	ShaderViewTypeId = 121004,
-	ShaderNodeGadgetTypeId = 121005,
-	TransformToolTypeId = 121006,
-	TranslateToolTypeId = 121007,
-	ScaleToolTypeId = 121008,
-	RotateToolTypeId = 121009,
-	CameraToolTypeId = 121010,
-	UVViewTypeId = 121011,
-	UVSceneTypeId = 121012,
-	HistoryPathTypeId = 121013,
-	SetPathTypeId = 121014,
-	LightToolTypeId = 121015,
-	LightPositionToolTypeId = 121016,
-	RenderPassPathTypeId = 121017,
-	VisualiserToolTypeId = 121018,
-	ImageSelectionToolTypeId = 121019,
-	InspectorTypeId = 121020,
-	OptionInspectorTypeId = 121021,
-	AttributeInspectorTypeId = 121022,
-	ParameterInspectorTypeId = 121023,
-	SetMembershipInspectorTypeId = 121024,
-	BasicInspectorTypeId = 121025,
-	UniformPLocatorTypeId = 121026,  // Private to `VisualiserTool`
-	InspectorPathTypeId = 121027,
-	TransformInspectorTypeId = 121028,
-	PrimitiveVariableInspectorTypeId = 121029,
 
-	LastTypeId = 121199
+class GAFFERSCENEUI_API PrimitiveVariableInspector : public Inspector
+{
+
+	public :
+
+		enum class Property
+		{
+			Interpolation,
+			Type,
+			Interpretation,
+			Data,
+			Indices,
+		};
+
+		PrimitiveVariableInspector(
+			const GafferScene::ScenePlugPtr &scene,
+			const Gaffer::PlugPtr &editScope,
+			IECore::InternedString primitiveVariable,
+			Property property,
+			const std::string &name = "",
+			const std::string &type = "primitiveVariable"
+		);
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::Private::PrimitiveVariableInspector, PrimitiveVariableInspectorTypeId, Inspector );
+
+	protected :
+
+		GafferScene::SceneAlgo::History::ConstPtr history() const override;
+		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history) const override;
+		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
+
+	private :
+
+		const GafferScene::ScenePlugPtr m_scene;
+		const IECore::InternedString m_primitiveVariable;
+		const Property m_property;
+
 };
 
-} // namespace GafferSceneUI
+IE_CORE_DECLAREPTR( PrimitiveVariableInspector )
+
+}  // namespace Private
+
+}  // namespace GafferSceneUI

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -39,12 +39,15 @@ import inspect
 import unittest
 
 import IECore
+import IECoreScene
 
 import Gaffer
 import GafferTest
 import GafferImage
 import GafferScene
 import GafferSceneTest
+
+Interpolation = IECoreScene.PrimitiveVariable.Interpolation
 
 class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 
@@ -946,6 +949,18 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		else :
 			self.assertEqual( oh.optionValue.value, optionValue )
 		self.assertEqual( len( oh.predecessors ), numPredecessors )
+
+	def __assertPrimitiveVariableHistory( self, primitiveVariableHistory, predecessorIndices, scene, path, primitiveVariableName, primitiveVariableValue, numPredecessors ) :
+
+		h = self.__predecessor( primitiveVariableHistory, predecessorIndices )
+
+		self.assertIsInstance( h, GafferScene.SceneAlgo.PrimitiveVariableHistory )
+
+		self.assertEqual( h.scene, scene )
+		self.assertEqual( GafferScene.ScenePlug.pathToString( h.context["scene:path"] ), path )
+		self.assertEqual( h.primitiveVariableName, primitiveVariableName )
+		self.assertEqual( h.primitiveVariableValue, primitiveVariableValue )
+		self.assertEqual( len( h.predecessors ), numPredecessors )
 
 	def testAttributeHistory( self ) :
 
@@ -2134,6 +2149,280 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferScene.SceneAlgo.history( loop["out"]["globals"] )
+
+	def testPrimitiveVariableHistory( self ) :
+
+		# Build network
+		# -------------
+		#
+		#    plane       sphere
+		#      |           |
+		# primVars1   primVars2
+		#       \         /
+		#        \       /
+		#         \     /
+		#      copyPrimitiveVariables
+		#            |
+		#          group
+		#            |
+		#        primitiveVariables3
+
+		plane = GafferScene.Plane()
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		sphere = GafferScene.Sphere()
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		primVars1 = GafferScene.PrimitiveVariables()
+		primVars1["in"].setInput( plane["out"] )
+		primVars1["filter"].setInput( planeFilter["out"] )
+		primVars1["primitiveVariables"].addChild( Gaffer.NameValuePlug( "test", 1 ) )
+
+		primVars2 = GafferScene.PrimitiveVariables()
+		primVars2["in"].setInput( sphere["out"] )
+		primVars2["filter"].setInput( sphereFilter["out"] )
+		primVars2["primitiveVariables"].addChild( Gaffer.NameValuePlug( "test", 2 ) )
+
+		copyPrimitiveVariables = GafferScene.CopyPrimitiveVariables()
+		copyPrimitiveVariables["in"].setInput( primVars1["out"] )
+		copyPrimitiveVariables["source"].setInput( primVars2["out"] )
+		copyPrimitiveVariables["filter"].setInput( planeFilter["out"] )
+		copyPrimitiveVariables["sourceLocation"].setValue( "/sphere" )
+		copyPrimitiveVariables["primitiveVariables"].setValue( "te*" )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( copyPrimitiveVariables["out"] )
+
+		groupPlaneFilter = GafferScene.PathFilter()
+		groupPlaneFilter["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
+
+		primitiveVariables3 = GafferScene.PrimitiveVariables()
+		primitiveVariables3["in"].setInput( group["out"] )
+		primitiveVariables3["filter"].setInput( groupPlaneFilter["out"] )
+		primitiveVariables3["primitiveVariables"].addChild( Gaffer.NameValuePlug( "test", 3 ) )
+
+		# Sanity check `history()`
+
+		def predecessorScenes( h ) :
+
+			return [ p.scene for p in h.predecessors ]
+
+		history = GafferScene.SceneAlgo.history( primitiveVariables3["out"]["object"], "/group/plane" )
+		self.assertEqual( predecessorScenes( history ), [ primitiveVariables3["in"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0 ] ) ), [ group["out"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0 ] ) ), [ group["in"][0] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0 ] ) ), [ copyPrimitiveVariables["out"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0, 0 ] ) ), [ copyPrimitiveVariables["in"], copyPrimitiveVariables["source"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0, 0, 0 ] ) ), [ primVars1["out"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0, 0, 1 ] ) ), [ primVars2["out"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0, 0, 0, 0 ] ) ), [ primVars1["in"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0, 0, 1, 0 ] ) ), [ primVars2["in"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0, 0, 0, 0, 0 ] ) ), [ plane["out"] ] )
+		self.assertEqual( predecessorScenes( self.__predecessor( history, [ 0, 0, 0, 0, 1, 0, 0 ] ) ), [ sphere["out"] ] )
+
+		# Test `primitiveVariableHistory()`
+
+		primitiveVariableHistory = GafferScene.SceneAlgo.primitiveVariableHistory( history, "test" )
+
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [], primitiveVariables3["out"], "/group/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 3 ) ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0 ], primitiveVariables3["in"], "/group/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 2 ) ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0 ], group["out"], "/group/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 2 ) ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0 ], group["in"][0], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 2 ) ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0 ], copyPrimitiveVariables["out"], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 2 ) ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0 ], copyPrimitiveVariables["source"], "/sphere", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 2 ) ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0, 0 ], primVars2["out"], "/sphere", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 2 ) ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0, 0, 0 ], primVars2["in"], "/sphere", "test", IECoreScene.PrimitiveVariable( Interpolation.Invalid, None ), 1 )
+		self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0, 0, 0, 0 ], sphere["out"], "/sphere", "test", IECoreScene.PrimitiveVariable( Interpolation.Invalid, None ), 0 )
+
+		# Test `primitiveVariableHistory()` with missing source location in `copyPrimitiveVariables`
+
+		def assertFromPrimitiveVariables1() :
+
+			history = GafferScene.SceneAlgo.history( primitiveVariables3["out"]["object"], "/group/plane" )
+			primitiveVariableHistory = GafferScene.SceneAlgo.primitiveVariableHistory( history, "test" )
+
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [], primitiveVariables3["out"], "/group/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 3 ) ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0 ], primitiveVariables3["in"], "/group/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0 ], group["out"], "/group/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0 ], group["in"][0], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0 ], copyPrimitiveVariables["out"], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0 ], copyPrimitiveVariables["in"], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0, 0 ], primVars1["out"], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0, 0, 0 ], primVars1["in"], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Invalid, None ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0, 0, 0, 0, 0 ], plane["out"], "/plane", "test", IECoreScene.PrimitiveVariable( Interpolation.Invalid, None ), 0 )
+
+		copyPrimitiveVariables["sourceLocation"].setValue( "" )
+		assertFromPrimitiveVariables1()
+
+		copyPrimitiveVariables["sourceLocation"].setValue( "/road/to/nowhere" )
+		assertFromPrimitiveVariables1()
+
+		# Test `primitiveVariableHistory()` with missing source primitiveVariable in `copyPrimitiveVariables`
+
+		copyPrimitiveVariables["sourceLocation"].setValue( "/sphere" )
+		primVars2["enabled"].setValue( False )
+		assertFromPrimitiveVariables1()
+
+		# Test `primitiveVariableHistory()` with `copyPrimitiveVariables` disabled
+
+		primVars2["enabled"].setValue( True )
+		copyPrimitiveVariables["enabled"].setValue( False )
+		assertFromPrimitiveVariables1()
+
+		# Test `primitiveVariableHistory()` with `copyPrimitiveVariables` unfiltered
+
+		copyPrimitiveVariables["enabled"].setValue( True )
+		copyPrimitiveVariables["filter"].setInput( None )
+		assertFromPrimitiveVariables1()
+
+	def testPrimitiveVariableHistoryWithShufflePrimitiveVariables( self ) :
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		primitiveVariables = GafferScene.PrimitiveVariables()
+		primitiveVariables["in"].setInput( plane["out"] )
+		primitiveVariables["filter"].setInput( planeFilter["out"] )
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "a", "a_value" ) )
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "b", "b_value" ) )
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "c", "c_value" ) )
+
+		shufflePrimitiveVariables = GafferScene.ShufflePrimitiveVariables()
+		shufflePrimitiveVariables["in"].setInput( primitiveVariables["out"] )
+		shufflePrimitiveVariables["filter"].setInput( planeFilter["out"] )
+
+		def assertShuffledHistory( source, destination ) :
+
+			history = GafferScene.SceneAlgo.history( shufflePrimitiveVariables["out"]["object"], "/plane" )
+			primitiveVariableHistory = GafferScene.SceneAlgo.primitiveVariableHistory( history, destination )
+
+			if source is None :
+				sourceName = destination
+				sourceVariable = IECoreScene.PrimitiveVariable( Interpolation.Invalid, None )
+			else :
+				sourceName = source
+				sourceVariable = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.StringData( source + "_value" ) )
+
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [], shufflePrimitiveVariables["out"], "/plane", destination, sourceVariable, 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0 ], shufflePrimitiveVariables["in"], "/plane", sourceName, sourceVariable, 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0 ], primitiveVariables["out"], "/plane", sourceName, sourceVariable, 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0 ], primitiveVariables["in"], "/plane", sourceName, IECoreScene.PrimitiveVariable( Interpolation.Invalid, None ), 1 )
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0, 0, 0, 0 ], plane["out"], "/plane", sourceName, IECoreScene.PrimitiveVariable( Interpolation.Invalid, None ), 0 )
+
+		# No shuffles
+
+		assertShuffledHistory( "a", "a" )
+		assertShuffledHistory( "b", "b" )
+		assertShuffledHistory( "c", "c" )
+
+		# Shuffles
+
+		shufflePrimitiveVariables["shuffles"].addChild( Gaffer.ShufflePlug( source = "a", destination = "d" ) )
+		shufflePrimitiveVariables["shuffles"].addChild( Gaffer.ShufflePlug( source = "b", destination = "c" ) )
+
+		assertShuffledHistory( "a", "a" )
+		assertShuffledHistory( "b", "b" )
+		assertShuffledHistory( "b", "c" )
+		assertShuffledHistory( "a", "d" )
+
+		# Node disabled
+
+		shufflePrimitiveVariables["enabled"].setValue( False )
+
+		assertShuffledHistory( "a", "a" )
+		assertShuffledHistory( "b", "b" )
+		assertShuffledHistory( "c", "c" )
+		assertShuffledHistory( None, "d" )
+
+		# Filter disabled
+
+		shufflePrimitiveVariables["enabled"].setValue( True )
+		shufflePrimitiveVariables["filter"].setInput( None )
+
+		assertShuffledHistory( "a", "a" )
+		assertShuffledHistory( "b", "b" )
+		assertShuffledHistory( "c", "c" )
+		assertShuffledHistory( None, "d" )
+
+	def testPrimitiveVariableHistoryWithMergeScenes( self ) :
+
+		plane = GafferScene.Plane()
+
+		# For this very simple test, we're just looking at what input is pulled, so we don't
+		# really need different sources, except that the history compute won't include things
+		# if they're skipped because the hashes match
+		planeDifferentHash = GafferScene.Plane()
+		planeDifferentHash["dimensions"]["x"].setValue( 2 )
+
+		pPrimVar = plane["out"].object( "/plane" )["P"]
+
+		noObject = GafferScene.Group()
+		noObject["name"].setValue( "plane" )
+
+		mergeScenes = GafferScene.MergeScenes()
+		mergeScenes["in"][0].setInput( plane["out"] )
+		mergeScenes["in"][1].setInput( noObject["out"] )
+		mergeScenes["in"][2].setInput( noObject["out"] )
+
+		# Test Keep mode
+
+		mergeScenes["objectMode"].setValue( mergeScenes.Mode.Keep )
+
+		def assertPrimitiveVariableHistory( path, primitiveVariableName, mergeScenesInput, value, upstreamPredecessors = 1 ) :
+			history = GafferScene.SceneAlgo.history( mergeScenes["out"]["object"], path )
+			primitiveVariableHistory = GafferScene.SceneAlgo.primitiveVariableHistory( history, primitiveVariableName )
+
+			if value is None :
+				primVar = IECoreScene.PrimitiveVariable( Interpolation.Invalid, None )
+			else:
+				primVar = value
+
+
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [], mergeScenes["out"], path, primitiveVariableName, primVar, 1 )
+			if value is None :
+				return
+
+			self.__assertPrimitiveVariableHistory( primitiveVariableHistory, [ 0 ], mergeScenesInput, path, primitiveVariableName, primVar, upstreamPredecessors )
+
+		assertPrimitiveVariableHistory( "/plane", "P", mergeScenes["in"][0], pPrimVar )
+
+		mergeScenes["in"][0].setInput( plane["out"] )
+		mergeScenes["in"][1].setInput( planeDifferentHash["out"] )
+		mergeScenes["in"][2].setInput( plane["out"] )
+
+		assertPrimitiveVariableHistory( "/plane", "P", mergeScenes["in"][0], pPrimVar )
+
+		# Test Replace mode
+
+		mergeScenes["objectMode"].setValue( mergeScenes.Mode.Replace )
+
+		mergeScenes["in"][0].setInput( plane["out"] )
+		mergeScenes["in"][1].setInput( noObject["out"] )
+		mergeScenes["in"][2].setInput( noObject["out"] )
+
+		assertPrimitiveVariableHistory( "/plane", "P", mergeScenes["in"][0], pPrimVar )
+
+		mergeScenes["in"][0].setInput( noObject["out"] )
+		mergeScenes["in"][1].setInput( plane["out"] )
+		mergeScenes["in"][2].setInput( noObject["out"] )
+
+		assertPrimitiveVariableHistory( "/plane", "P", mergeScenes["in"][1], pPrimVar )
+
+		mergeScenes["in"][0].setInput( noObject["out"] )
+		mergeScenes["in"][1].setInput( noObject["out"] )
+		mergeScenes["in"][2].setInput( plane["out"] )
+
+		assertPrimitiveVariableHistory( "/plane", "P", mergeScenes["in"][2], pPrimVar )
+
+		mergeScenes["in"][0].setInput( plane["out"] )
+		mergeScenes["in"][1].setInput( planeDifferentHash["out"] )
+		mergeScenes["in"][2].setInput( plane["out"] )
+
+		assertPrimitiveVariableHistory( "/plane", "P", mergeScenes["in"][2], pPrimVar )
 
 	def testLinkingQueries( self ) :
 

--- a/python/GafferSceneUITest/PrimitiveVariableInspectorTest.py
+++ b/python/GafferSceneUITest/PrimitiveVariableInspectorTest.py
@@ -1,0 +1,456 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUITest
+import GafferScene
+import GafferSceneTest
+import GafferSceneUI
+
+# "Property" is a rather generic name, this would generally be a bad idea, but for
+# these tests specifically, this was getting rather verbose
+Property = GafferSceneUI.Private.PrimitiveVariableInspector.Property
+
+class PrimitiveVariableInspectorTest( GafferUITest.TestCase ) :
+
+	def testName( self ) :
+
+		plane = GafferScene.Plane()
+
+		inspector = GafferSceneUI.Private.PrimitiveVariableInspector( plane["out"], None, "P", Property.Data )
+		self.assertEqual( inspector.name(), "P" )
+
+	def testDirtiedSignal( self ) :
+
+		sphere = GafferScene.Sphere()
+		inspector = GafferSceneUI.Private.PrimitiveVariableInspector( sphere["out"], None, "P", Property.Data )
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		sphere["radius"].setValue( 2 )
+		self.assertEqual( len( cs ), 1 )
+
+		sphere["transform"]["translate"]["x"].setValue( 1 )
+		self.assertEqual( len( cs ), 1 )
+
+	@staticmethod
+	def __inspect( scene, path, primitiveVariable, parameter, editScope=None ) :
+
+		editScopePlug = Gaffer.Plug()
+		editScopePlug.setInput( editScope["enabled"] if editScope is not None else None )
+		inspector = GafferSceneUI.Private.PrimitiveVariableInspector( scene, editScopePlug, primitiveVariable, parameter )
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( path.split( "/" )[1:] )
+			return inspector.inspect()
+
+	def testInspectObject( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		inspection = self.__inspect( script["sphere"]["out"], "/sphere", "P", Property.Data )
+
+		self.assertEqual( inspection.value(), script["sphere"]["out"].object( "/sphere" )["P"].data )
+		self.assertEqual( inspection.source(), script["sphere"]["out"] )
+		self.assertEqual( inspection.sourceType(), inspection.SourceType.Other )
+		self.assertEqual( inspection.fallbackDescription(), "" )
+		self.assertFalse( inspection.editable() )
+		self.assertEqual( inspection.nonEditableReason(), "sphere.out is not editable." )
+		self.assertRaises( RuntimeError, inspection.acquireEdit )
+		self.assertFalse( inspection.canDisableEdit() )
+		self.assertEqual( inspection.nonDisableableReason(), "sphere.out is not editable." )
+		self.assertRaises( RuntimeError, inspection.disableEdit )
+		self.assertFalse( inspection.canEdit( inspection.value() ) )
+		self.assertRaises( RuntimeError, inspection.edit, inspection.value() )
+
+	def testNonExistentLocation( self ) :
+
+		plane = GafferScene.Plane()
+		self.assertIsNone( self.__inspect( plane["out"], "/nothingHere", "P", Property.Data ) )
+
+	def testNonExistentPrimitiveVariable( self ) :
+
+		plane = GafferScene.Plane()
+		self.assertIsNone( self.__inspect( plane["out"], "/plane", "badPrimVar", Property.Data ) )
+
+	def testHistory( self ) :
+
+		cube = GafferScene.Cube()
+
+		cubeFilter = GafferScene.PathFilter()
+		cubeFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		primitiveVariables = GafferScene.PrimitiveVariables()
+		primitiveVariables["in"].setInput( cube["out"] )
+		primitiveVariables["filter"].setInput( cubeFilter["out"] )
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "test", 10 ) )
+
+		meshTangents = GafferScene.MeshTangents()
+		meshTangents["in"].setInput( primitiveVariables["out"] )
+		meshTangents["filter"].setInput( cubeFilter["out"] )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( meshTangents["out"] )
+
+		self.assertEqual( set( group["out"].object( "/group/cube" ).keys() ), { "N", "P", "test", "uTangent", "uv", "vTangent" } )
+
+		self.ignoreMessage( IECore.Msg.Level.Warning, "HistoryPath", "Path evaluated on unexpected thread" )
+
+		inspector = GafferSceneUI.Private.PrimitiveVariableInspector( group["out"], None, "P", Property.Data )
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/group/cube" )
+			historyPath = inspector.historyPath()
+
+		children = historyPath.children()
+		self.assertEqual(
+			[ c.property( "history:node" ) for c in children ],
+			[ cube, group ]
+		)
+
+		inspector = GafferSceneUI.Private.PrimitiveVariableInspector( group["out"], None, "test", Property.Data )
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/group/cube" )
+			historyPath = inspector.historyPath()
+
+		children = historyPath.children()
+		self.assertEqual(
+			[ c.property( "history:node" ) for c in children ],
+			[ cube, primitiveVariables, group ]
+		)
+
+		inspector = GafferSceneUI.Private.PrimitiveVariableInspector( group["out"], None, "uTangent", Property.Data )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/group/cube" )
+			historyPath = inspector.historyPath()
+
+		children = historyPath.children()
+		self.assertEqual(
+			[ c.property( "history:node" ) for c in children ],
+			[ cube, meshTangents, group ]
+		)
+
+	def testSourceAndSourceType( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["cube"] = GafferScene.Cube()
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		script["primitiveVariables1"] = GafferScene.PrimitiveVariables()
+		script["primitiveVariables1"]["in"].setInput( script["cube"]["out"] )
+		script["primitiveVariables1"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["primitiveVariables1"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "beforeEditScope", 10 ) )
+
+		script["editScope"] = Gaffer.EditScope()
+		script["editScope"].setup( script["primitiveVariables1"]["out"] )
+		script["editScope"]["in"].setInput( script["primitiveVariables1"]["out"] )
+
+		script["editScope"]["primitiveVariables"] = GafferScene.PrimitiveVariables()
+		script["editScope"]["primitiveVariables"]["in"].setInput( script["editScope"]["in"] )
+		script["editScope"]["primitiveVariables"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["editScope"]["primitiveVariables"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "insideEditScope", 10 ) )
+
+		script["editScope"]["out"].setInput( script["editScope"]["primitiveVariables"]["out"] )
+
+		script["primitiveVariables2"] = GafferScene.PrimitiveVariables()
+		script["primitiveVariables2"]["in"].setInput( script["editScope"]["out"] )
+		script["primitiveVariables2"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["primitiveVariables2"]["primitiveVariables"].addChild( Gaffer.NameValuePlug( "afterEditScope", 10 ) )
+
+		def assertExpectedSource( scene, primitiveVariable, source, sourceType = None, editScope = None, editable = True ) :
+
+			inspection = self.__inspect(
+				scene, "/cube", primitiveVariable, Property.Data, editScope = editScope
+			)
+
+			if source is None :
+				self.assertIsNone( inspection )
+				return
+
+			self.assertIsNotNone( inspection )
+			self.assertEqual( inspection.source(), source )
+			self.assertEqual( inspection.sourceType(), sourceType )
+			if editable:
+				self.assertEqual( inspection.acquireEdit(), source )
+			else:
+				with self.assertRaisesRegex( RuntimeError, "Not editable.*" ) :
+					inspection.acquireEdit()
+			self.assertEqual( inspection.editable(), editable )
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		assertExpectedSource( script["primitiveVariables2"]["out"], "afterEditScope", script["primitiveVariables2"]["primitiveVariables"][0], SourceType.Other )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "afterEditScope", script["primitiveVariables2"]["primitiveVariables"][0], SourceType.Downstream, editScope = script["editScope"], editable = False )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["primitiveVariables"][0], SourceType.Other, editable = False )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["primitiveVariables"][0], SourceType.EditScope, editScope = script["editScope"] )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "beforeEditScope", script["primitiveVariables1"]["primitiveVariables"][0], SourceType.Other )
+		assertExpectedSource( script["primitiveVariables2"]["out"], "beforeEditScope", script["primitiveVariables1"]["primitiveVariables"][0], SourceType.Upstream, editScope = script["editScope"], editable = False )
+
+		assertExpectedSource( script["editScope"]["out"], "afterEditScope", None )
+		assertExpectedSource( script["editScope"]["out"], "afterEditScope", None, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["primitiveVariables"][0], SourceType.Other, editable = False )
+		assertExpectedSource( script["editScope"]["out"], "insideEditScope", script["editScope"]["primitiveVariables"]["primitiveVariables"][0], SourceType.EditScope, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["out"], "beforeEditScope", script["primitiveVariables1"]["primitiveVariables"][0], SourceType.Other )
+		assertExpectedSource( script["editScope"]["out"], "beforeEditScope", script["primitiveVariables1"]["primitiveVariables"][0], SourceType.Upstream, editScope = script["editScope"], editable = False )
+
+		assertExpectedSource( script["editScope"]["in"], "afterEditScope", None )
+		assertExpectedSource( script["editScope"]["in"], "afterEditScope", None, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["in"], "insideEditScope", None )
+		assertExpectedSource( script["editScope"]["in"], "insideEditScope", None, editScope = script["editScope"] )
+		assertExpectedSource( script["editScope"]["in"], "beforeEditScope", script["primitiveVariables1"]["primitiveVariables"][0], SourceType.Other )
+		assertExpectedSource( script["editScope"]["in"], "beforeEditScope", script["primitiveVariables1"]["primitiveVariables"][0], SourceType.Upstream, editScope = script["editScope"], editable = False )
+
+
+
+	def __setupBasicConstant( self, parent ):
+		parent["plane"] = GafferScene.Plane()
+
+		parent["filter"] = GafferScene.PathFilter()
+		parent["filter"]["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		parent["primitiveVariables"] = GafferScene.PrimitiveVariables()
+		parent["primitiveVariables"]["in"].setInput( parent["plane"]["out"] )
+		parent["primitiveVariables"]["filter"].setInput( parent["filter"]["out"] )
+		parent["primitiveVariables"]["primitiveVariables"].addChild(
+			Gaffer.NameValuePlug(
+				"testConstant",
+				IECore.Color3fData( imath.Color3f( 0, 1, 2 ) ),
+				Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+				"testPlug"
+			)
+		)
+
+	def testValue( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		self.__setupBasicConstant( s )
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "P", Property.Interpolation ).value(),
+			IECore.StringData( "Vertex" )
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "P", Property.Type ).value(),
+			IECore.StringData( "V3fVectorData" )
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "P", Property.Interpretation ).value(),
+			IECore.StringData( "Point" )
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "uv", Property.Interpretation ).value(),
+			IECore.StringData( "UV" )
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "testConstant", Property.Interpretation ).value(),
+			IECore.StringData( "None" )
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "P", Property.Data ).value(),
+			IECore.V3fVectorData( [ imath.V3f( -0.5, -0.5, 0 ), imath.V3f( 0.5, -0.5, 0 ), imath.V3f( -0.5, 0.5, 0 ), imath.V3f( 0.5, 0.5, 0 ) ], IECore.GeometricData.Interpretation.Point )
+		)
+
+		self.assertIsNone( self.__inspect( s["primitiveVariables"]["out"], "/plane", "P", Property.Indices ) )
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "uv", Property.Indices ).value(),
+			IECore.IntVectorData( [ 0, 1, 3, 2 ] )
+		)
+
+	def testValueNotFound( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		self.__setupBasicConstant( s )
+
+		# TODO - this is inconsistent
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "badPrimVar", Property.Interpolation ).value(),
+			IECore.StringData( "Invalid" )
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "badPrimVar", Property.Type ),
+			None
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "badPrimVar", Property.Interpretation ),
+			None
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "badPrimVar", Property.Data ),
+			None
+		)
+
+		self.assertEqual(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "badPrimVar", Property.Indices ),
+			None
+		)
+
+	def __assertExpectedResult(
+		self,
+		result,
+		source,
+		sourceType,
+		editable,
+		nonEditableReason = "",
+		edit = None,
+		editWarning = ""
+	) :
+		self.assertEqual( result.source(), source )
+		self.assertEqual( result.sourceType(), sourceType )
+		self.assertEqual( result.editable(), editable )
+		self.assertEqual( result.fallbackDescription(), "" )
+
+		if editable :
+			self.assertEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), "" )
+
+			acquiredEdit = result.acquireEdit()
+			self.assertIsNotNone( acquiredEdit )
+			if result.editScope() :
+				self.assertTrue( result.editScope().isAncestorOf( acquiredEdit ) )
+
+			if edit is not None :
+				self.assertEqual(
+					acquiredEdit.fullName() if acquiredEdit is not None else "",
+					edit.fullName() if edit is not None else ""
+				)
+
+			self.assertEqual( result.editWarning(), editWarning )
+
+		else :
+			self.assertIsNone( edit )
+			self.assertEqual( editWarning, "" )
+			self.assertEqual( result.editWarning(), "" )
+			self.assertNotEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), nonEditableReason )
+			self.assertRaises( RuntimeError, result.acquireEdit )
+
+	def testDisabledTweaks( self ) :
+
+
+		s = Gaffer.ScriptNode()
+
+		self.__setupBasicConstant( s )
+
+		s["plane"] = GafferScene.Plane()
+
+		s["planeFilter"] = GafferScene.PathFilter()
+		s["planeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		s["primitiveVariableTweaks1"] = GafferScene.PrimitiveVariableTweaks()
+		s["primitiveVariableTweaks1"]["in"].setInput( s["plane"]["out"] )
+		s["primitiveVariableTweaks1"]["filter"].setInput( s["planeFilter"]["out"] )
+		scaleTweak1 = Gaffer.TweakPlug( "P", IECore.V3fData( imath.V3f( 2.0 ) ) )
+		s["primitiveVariableTweaks1"]["tweaks"].addChild( scaleTweak1 )
+
+		s["primitiveVariableTweaks2"] = GafferScene.PrimitiveVariableTweaks()
+		s["primitiveVariableTweaks2"]["in"].setInput( s["primitiveVariableTweaks1"]["out"] )
+		s["primitiveVariableTweaks2"]["filter"].setInput( s["planeFilter"]["out"] )
+		scaleTweak2 = Gaffer.TweakPlug( "P", IECore.V3fData( imath.V3f( 3.0 ) ) )
+		s["primitiveVariableTweaks2"]["tweaks"].addChild( scaleTweak2 )
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		self.__assertExpectedResult(
+			self.__inspect( s["primitiveVariableTweaks2"]["out"], "/plane", "P", Property.Data ),
+			source = scaleTweak2,
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = scaleTweak2
+		)
+
+		scaleTweak2["enabled"].setValue( False )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["primitiveVariableTweaks2"]["out"], "/plane", "P", Property.Data ),
+			source = scaleTweak1,
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = scaleTweak1
+		)
+
+	def testExternalSourceType( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		self.__setupBasicConstant( s )
+
+		externalPrimitiveVariableTweaks = GafferScene.PrimitiveVariableTweaks()
+		externalPrimitiveVariableTweaks["in"].setInput( s["primitiveVariables"]["out"] )
+		externalPrimitiveVariableTweaks["filter"].setInput( s["filter"]["out"] )
+		tweak2 = Gaffer.TweakPlug( "testConstant", imath.Color3f( 4.0 ) )
+		externalPrimitiveVariableTweaks["tweaks"].addChild( tweak2 )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "testConstant", Property.Data ),
+			source = s["primitiveVariables"]["primitiveVariables"][0],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = None,
+			editWarning = 'Edits to "testConstant" may affect other locations in the scene.'
+		)
+
+		self.__assertExpectedResult(
+			self.__inspect( externalPrimitiveVariableTweaks["out"], "/plane", "testConstant", Property.Data ),
+			source = tweak2,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.External,
+			editable = False,
+			edit = None,
+			editWarning = "",
+			nonEditableReason = "{} is external to the script.".format( externalPrimitiveVariableTweaks.fullName() )
+		)
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -69,6 +69,7 @@ from .CatalogueUITest import CatalogueUITest
 from .BasicInspectorTest import BasicInspectorTest
 from .VisibilityColumnTest import VisibilityColumnTest
 from .TransformInspectorTest import TransformInspectorTest
+from .PrimitiveVariableInspectorTest import PrimitiveVariableInspectorTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -51,6 +51,7 @@
 #include "IECoreImage/OpenImageIOAlgo.h"
 
 #include "IECore/MessageHandler.h"
+#include "IECore/NullObject.h"
 
 #include "boost/bind/bind.hpp"
 
@@ -232,7 +233,7 @@ OSLObject::OSLObject( const std::string &name )
 		)
 	);
 	addChild( new BoolPlug( "ignoreMissingSourceLocations" ) );
-	addChild( new ScenePlug( "__resampledIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
+	addChild( new ObjectPlug( "__resampledInObject", Plug::In, new IECore::NullObject(), Plug::Default & ~Plug::Serialisable ) );
 	addChild( new StringPlug( "__resampleNames", Plug::Out ) );
 	addChild( new Plug( "primitiveVariables", Plug::In, Plug::Default & ~Plug::AcceptsInputs ) );
 	addChild( new OSLCode( "__oslCode" ) );
@@ -249,7 +250,7 @@ OSLObject::OSLObject( const std::string &name )
 	resample->interpolationPlug()->setInput( interpolationPlug() );
 	resample->filterPlug()->setInput( filterPlug() );
 
-	resampledInPlug()->setInput( resample->outPlug() );
+	resampledInObjectPlug()->setInput( resample->outPlug()->objectPlug() );
 }
 
 OSLObject::~OSLObject()
@@ -326,14 +327,14 @@ const Gaffer::BoolPlug *OSLObject::ignoreMissingSourceLocationsPlug() const
 	return getChild<BoolPlug>( g_firstPlugIndex + 6 );
 }
 
-ScenePlug *OSLObject::resampledInPlug()
+ObjectPlug *OSLObject::resampledInObjectPlug()
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 7 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 7 );
 }
 
-const ScenePlug *OSLObject::resampledInPlug() const
+const ObjectPlug *OSLObject::resampledInObjectPlug() const
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 7 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 7 );
 }
 
 StringPlug *OSLObject::resampledNamesPlug()
@@ -409,7 +410,7 @@ bool OSLObject::affectsProcessedObject( const Gaffer::Plug *input ) const
 		( input == inPlug()->transformPlug() && !useTransformPlug()->isSetToDefault() ) ||
 		input == useAttributesPlug() ||
 		( input == inPlug()->attributesPlug() && !useAttributesPlug()->isSetToDefault() ) ||
-		input == resampledInPlug()->objectPlug() ||
+		input == resampledInObjectPlug() ||
 		sourceLocationsPlug()->isAncestorOf( input ) ||
 		input == ignoreMissingSourceLocationsPlug() ||
 		( sourceLocationsUseTransform && input == sourcePlug()->transformPlug() ) ||
@@ -437,7 +438,7 @@ void OSLObject::hashProcessedObject( const ScenePath &path, const Gaffer::Contex
 
 	shadingEngine->hash( h );
 	interpolationPlug()->hash( h );
-	h.append( resampledInPlug()->objectPlug()->hash() );
+	h.append( resampledInObjectPlug()->hash() );
 
 	if( useTransformPlug()->getValue() )
 	{
@@ -519,7 +520,7 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 	PrimitiveVariable::Interpolation interpolation = static_cast<PrimitiveVariable::Interpolation>( interpolationPlug()->getValue() );
 
 
-	IECoreScene::ConstPrimitivePtr resampledObject = IECore::runTimeCast<const IECoreScene::Primitive>( resampledInPlug()->objectPlug()->getValue() );
+	IECoreScene::ConstPrimitivePtr resampledObject = IECore::runTimeCast<const IECoreScene::Primitive>( resampledInObjectPlug()->getValue() );
 	CompoundDataPtr shadingPoints = prepareShadingPoints( resampledObject.get(), shadingEngine.get(), gafferAttributes.get() );
 
 	PrimitivePtr outputPrimitive = inputPrimitive->copy();

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -40,6 +40,7 @@
 #include "GafferScene/CameraTweaks.h"
 #include "GafferScene/CopyAttributes.h"
 #include "GafferScene/CopyOptions.h"
+#include "GafferScene/CopyPrimitiveVariables.h"
 #include "GafferScene/Filter.h"
 #include "GafferScene/FilterProcessor.h"
 #include "GafferScene/LocaliseAttributes.h"
@@ -49,6 +50,7 @@
 #include "GafferScene/SetAlgo.h"
 #include "GafferScene/ShaderTweaks.h"
 #include "GafferScene/ShuffleAttributes.h"
+#include "GafferScene/ShufflePrimitiveVariables.h"
 
 #include "Gaffer/ArrayPlug.h"
 #include "Gaffer/Context.h"
@@ -62,6 +64,7 @@
 #include "IECoreScene/Camera.h"
 #include "IECoreScene/ClippingPlane.h"
 #include "IECoreScene/CoordinateSystem.h"
+#include "IECoreScene/Primitive.h"
 #include "IECoreScene/VisibleRenderable.h"
 
 #include "IECore/MessageHandler.h"
@@ -556,6 +559,7 @@ SceneAlgo::History::Ptr historyWalk( const CapturedProcess *process, InternedStr
 
 	SceneAlgo::History::Ptr result;
 	Plug *plug = const_cast<Plug *>( process->destinationPlug.get() );
+
 	while( plug )
 	{
 		ScenePlug *scene = plug->parent<ScenePlug>();
@@ -818,6 +822,123 @@ void addMergeScenesPredecessors( const MergeScenes *mergeScenes, const SceneAlgo
 	destination->predecessors.push_back( predecessor );
 }
 
+void addMergeScenesPredecessors( const MergeScenes *mergeScenes, const SceneAlgo::History::Predecessors &source, SceneAlgo::PrimitiveVariableHistory *destination )
+{
+	// MergeScenes only evaluates input locations that exist, and in an order
+	// whereby the last input with the object wins.
+
+	SceneAlgo::PrimitiveVariableHistory::Ptr predecessor;
+
+	for( auto &h : source )
+	{
+		if( !runTimeCast<const NullObject>( h->scene->objectPlug()->getValue().get() ) )
+		{
+			predecessor = primitiveVariableHistory( h.get(), destination->primitiveVariableName );
+
+			// The MergeScenes hashObject takes the first match, rather than the last
+			// match ( it uses a special traversal order to support this ). We need to
+			// match that
+
+			break;
+		}
+	}
+
+	if( !predecessor )
+	{
+		if( !source.size() )
+		{
+			return;
+		}
+		// We didn't find a source with a primitiveVariable to merge. Add the first
+		// source as a predecessor so the history is not truncated.
+		predecessor = primitiveVariableHistory( source[0].get(), destination->primitiveVariableName );
+	}
+
+	assert( predecessor );
+	destination->predecessors.push_back( predecessor );
+}
+
+void addGenericPrimitiveVariablePredecessors( const SceneAlgo::History::Predecessors &source, SceneAlgo::PrimitiveVariableHistory *destination )
+{
+	for( auto &h : source )
+	{
+		if( auto ah = SceneAlgo::primitiveVariableHistory( h.get(), destination->primitiveVariableName ) )
+		{
+			destination->predecessors.push_back( ah );
+		}
+	}
+}
+
+void addCopyPrimitiveVariablesPredecessors( const CopyPrimitiveVariables *copyPrimitiveVariables, const SceneAlgo::History::Predecessors &source, SceneAlgo::PrimitiveVariableHistory *destination )
+{
+	const ScenePlug *sourceScene = copyPrimitiveVariables->inPlug();
+	if(
+		( copyPrimitiveVariables->filterPlug()->match( copyPrimitiveVariables->inPlug() ) & PathMatcher::ExactMatch ) &&
+		StringAlgo::matchMultiple( destination->primitiveVariableName, copyPrimitiveVariables->primitiveVariablesPlug()->getValue() )
+	)
+	{
+		ConstObjectPtr sourceObject;
+		const std::string sourceLocation = copyPrimitiveVariables->sourceLocationPlug()->getValue();
+		if( sourceLocation.empty() )
+		{
+			if( copyPrimitiveVariables->sourcePlug()->exists() )
+			{
+				sourceObject = copyPrimitiveVariables->sourcePlug()->objectPlug()->getValue();
+			}
+		}
+		else
+		{
+			ScenePlug::ScenePath sourcePath; ScenePlug::stringToPath( sourceLocation, sourcePath );
+			if( copyPrimitiveVariables->sourcePlug()->exists( sourcePath ) )
+			{
+				sourceObject = copyPrimitiveVariables->sourcePlug()->object( sourcePath );
+			}
+		}
+
+		const Primitive *sourcePrimitive = IECore::runTimeCast< const Primitive >( sourceObject.get() );
+
+		if( sourcePrimitive && sourcePrimitive->variables.count( destination->primitiveVariableName ) )
+		{
+			sourceScene = copyPrimitiveVariables->sourcePlug();
+		}
+	}
+
+	for( auto &h : source )
+	{
+		if( h->scene == sourceScene )
+		{
+			destination->predecessors.push_back( SceneAlgo::primitiveVariableHistory( h.get(), destination->primitiveVariableName ) );
+		}
+	}
+}
+
+void addShufflePrimitiveVariablesPredecessors( const ShufflePrimitiveVariables *shufflePrimitiveVariables, const SceneAlgo::History::Predecessors &source, SceneAlgo::PrimitiveVariableHistory *destination )
+{
+	// We have no way of introspecting the operation of a ShufflePlug, so we resort
+	// to shuffling	`name = name, value = name` pairs to figure out where the primitive
+	// variable has come from.
+
+	InternedString sourcePrimitiveVariableName = destination->primitiveVariableName;
+	if( shufflePrimitiveVariables->filterPlug()->match( shufflePrimitiveVariables->inPlug() ) & PathMatcher::ExactMatch )
+	{
+		ConstPrimitivePtr primitive = IECore::runTimeCast<const Primitive>( shufflePrimitiveVariables->inPlug()->objectPlug()->getValue() );
+		if( primitive )
+		{
+			map<InternedString, InternedString> shuffledNames;
+			for( auto &v : primitive->variables )
+			{
+				shuffledNames.insert( { v.first, v.first } );
+			}
+			shuffledNames = shufflePrimitiveVariables->shufflesPlug()->shuffle( shuffledNames );
+			sourcePrimitiveVariableName = shuffledNames[destination->primitiveVariableName];
+		}
+	}
+
+	assert( source.size() == 1 );
+	destination->predecessors.push_back( SceneAlgo::primitiveVariableHistory( source[0].get(), sourcePrimitiveVariableName ) );
+}
+
+
 SceneProcessor *objectTweaksWalk( const SceneAlgo::History *h )
 {
 	if( auto tweaks = h->scene->parent<CameraTweaks>() )
@@ -1024,6 +1145,59 @@ SceneAlgo::OptionHistory::Ptr SceneAlgo::optionHistory( const SceneAlgo::History
 	else
 	{
 		addGenericOptionPredecessors( globalsHistory->predecessors, result.get() );
+	}
+
+	return result;
+}
+
+SceneAlgo::PrimitiveVariableHistory::Ptr SceneAlgo::primitiveVariableHistory( const SceneAlgo::History *objectHistory, const IECore::InternedString &primitiveVariable )
+{
+	Context::Scope scopedContext( objectHistory->context.get() );
+	IECoreScene::ConstPrimitivePtr primitive = IECore::runTimeCast<const Primitive>( objectHistory->scene->objectPlug()->getValue() );
+
+	if( !primitive )
+	{
+		return nullptr;
+	}
+
+	auto varIt = primitive->variables.find( primitiveVariable );
+
+	SceneAlgo::PrimitiveVariableHistory::Ptr result = new PrimitiveVariableHistory(
+		objectHistory->scene, objectHistory->context,
+		primitiveVariable, varIt == primitive->variables.end() ? PrimitiveVariable() : varIt->second
+	);
+
+	// Filter the object history to include only predecessors which
+	// contribute specifically to our single primitive variable. In the absence of
+	// a SceneNode-level API for querying primitive variable sources, we resort to
+	// special case code for backtracking through certain node types.
+	/// \todo Consider an official API that allows the nodes themselves to
+	/// take responsibility for this backtracking.
+
+	auto node = runTimeCast<const SceneNode>( objectHistory->scene->node() );
+	if( node && node->enabledPlug()->getValue() && objectHistory->scene == node->outPlug() )
+	{
+		if( auto copyPrimitiveVariables = runTimeCast<const CopyPrimitiveVariables>( node ) )
+		{
+			addCopyPrimitiveVariablesPredecessors( copyPrimitiveVariables, objectHistory->predecessors, result.get() );
+		}
+		else
+		if( auto shufflePrimitiveVariables = runTimeCast<const ShufflePrimitiveVariables>( node ) )
+		{
+			addShufflePrimitiveVariablesPredecessors( shufflePrimitiveVariables, objectHistory->predecessors, result.get() );
+		}
+		else if( auto mergeScenes = runTimeCast<const MergeScenes>( node ) )
+		{
+			addMergeScenesPredecessors( mergeScenes, objectHistory->predecessors, result.get() );
+		}
+		else
+		{
+			addGenericPrimitiveVariablePredecessors( objectHistory->predecessors, result.get() );
+		}
+	}
+	else
+	{
+		addGenericPrimitiveVariablePredecessors( objectHistory->predecessors, result.get() );
 	}
 
 	return result;

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -46,6 +46,7 @@
 #include "GafferImage/ImagePlug.h"
 
 #include "IECoreScene/Camera.h"
+#include "IECoreScene/PrimitiveVariable.h"
 
 #include "IECorePython/ExceptionAlgo.h"
 #include "IECorePython/RefCountedBinding.h"
@@ -309,6 +310,34 @@ SceneAlgo::OptionHistory::Ptr optionHistoryWrapper( const SceneAlgo::History &gl
 	return SceneAlgo::optionHistory( &globalsHistory, optionName );
 }
 
+std::string primitiveVariableHistoryGetPrimitiveVariableName( const SceneAlgo::PrimitiveVariableHistory &h )
+{
+	return h.primitiveVariableName.string();
+}
+
+void primitiveVariableHistorySetPrimitiveVariableName( SceneAlgo::PrimitiveVariableHistory &h, IECore::InternedString n )
+{
+	h.primitiveVariableName = n;
+}
+
+IECoreScene::PrimitiveVariable primitiveVariableHistoryGetPrimitiveVariableValue( const SceneAlgo::PrimitiveVariableHistory &h )
+{
+	// Returning a copy because `primitiveVariableValue` is const, and owned by Gaffer's cache.
+	// Allowing modification in Python would be catastrophic and hard to debug.
+	return IECoreScene::PrimitiveVariable( h.primitiveVariableValue, true );
+}
+
+void primitiveVariableHistorySetPrimitiveVariableValue( SceneAlgo::PrimitiveVariableHistory &h, const IECoreScene::PrimitiveVariable &v )
+{
+	h.primitiveVariableValue = v;
+}
+
+SceneAlgo::PrimitiveVariableHistory::Ptr primitiveVariableHistoryWrapper( const SceneAlgo::History &primitiveVariablesHistory, const InternedString &primitiveVariableName )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::primitiveVariableHistory( &primitiveVariablesHistory, primitiveVariableName );
+}
+
 ScenePlugPtr sourceWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &path )
 {
 	IECorePython::ScopedGILRelease r;
@@ -482,6 +511,13 @@ void bindSceneAlgo()
 	;
 
 	def( "optionHistory", &optionHistoryWrapper );
+
+	IECorePython::RefCountedClass<SceneAlgo::PrimitiveVariableHistory, SceneAlgo::History>( "PrimitiveVariableHistory" )
+		.add_property( "primitiveVariableName", &primitiveVariableHistoryGetPrimitiveVariableName, &primitiveVariableHistorySetPrimitiveVariableName )
+		.add_property( "primitiveVariableValue", &primitiveVariableHistoryGetPrimitiveVariableValue, &primitiveVariableHistorySetPrimitiveVariableValue )
+	;
+
+	def( "primitiveVariableHistory", &primitiveVariableHistoryWrapper );
 
 	def( "source", &sourceWrapper );
 	def( "objectTweaks", &objectTweaksWrapper );

--- a/src/GafferSceneUI/PrimitiveVariableInspector.cpp
+++ b/src/GafferSceneUI/PrimitiveVariableInspector.cpp
@@ -1,0 +1,360 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/Private/PrimitiveVariableInspector.h"
+
+#include "GafferScene/PrimitiveVariables.h"
+#include "GafferScene/PrimitiveVariableTweaks.h"
+#include "GafferScene/Camera.h"
+#include "GafferScene/EditScopeAlgo.h"
+#include "GafferScene/Light.h"
+#include "GafferScene/LightFilter.h"
+#include "GafferScene/SceneAlgo.h"
+#include "GafferScene/SceneNode.h"
+
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/NameValuePlug.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/ParallelAlgo.h"
+#include "Gaffer/ValuePlug.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/NullObject.h"
+
+#include "fmt/format.h"
+
+using namespace boost::placeholders;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferSceneUI::Private;
+
+//////////////////////////////////////////////////////////////////////////
+// History cache
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+const std::string g_attributePrefix( "attribute:" );
+const InternedString g_defaultValue( "defaultValue" );
+
+// This uses the same strategy that ValuePlug uses for the hash cache,
+// using `plug->dirtyCount()` to invalidate previous cache entries when
+// a plug is dirtied.
+struct HistoryCacheKey
+{
+	HistoryCacheKey() {};
+	HistoryCacheKey( const ValuePlug *plug )
+		:	plug( plug ), contextHash( Context::current()->hash() ), dirtyCount( plug->dirtyCount() )
+	{
+	}
+
+	bool operator==( const HistoryCacheKey &rhs ) const
+	{
+		return
+			plug == rhs.plug &&
+			contextHash == rhs.contextHash &&
+			dirtyCount == rhs.dirtyCount
+		;
+	}
+
+	const ValuePlug *plug;
+	IECore::MurmurHash contextHash;
+	uint64_t dirtyCount;
+};
+
+size_t hash_value( const HistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, key.plug );
+	boost::hash_combine( result, key.contextHash );
+	boost::hash_combine( result, key.dirtyCount );
+	return result;
+}
+
+using HistoryCache = IECorePreview::LRUCache<HistoryCacheKey, SceneAlgo::History::ConstPtr>;
+
+HistoryCache g_historyCache(
+	// Getter
+	[] ( const HistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		return SceneAlgo::history(
+			key.plug, Context::current()->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName )
+		);
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const HistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
+		// Histories contain PlugPtrs, which could potentially be the sole
+		// owners. Destroying plugs can trigger dirty propagation, so as a
+		// precaution we destroy the history on the UI thread, where this would
+		// be OK.
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+struct PrimitiveVariableHistoryCacheKey : public HistoryCacheKey
+{
+	PrimitiveVariableHistoryCacheKey() {};
+	PrimitiveVariableHistoryCacheKey( const ScenePlug *plug, IECore::InternedString primitiveVariable )
+		:	HistoryCacheKey( plug->objectPlug() ), primitiveVariable( primitiveVariable )
+	{
+	}
+
+	bool operator==( const PrimitiveVariableHistoryCacheKey &rhs ) const
+	{
+		return HistoryCacheKey::operator==( rhs ) && primitiveVariable == rhs.primitiveVariable;
+	}
+
+	IECore::InternedString primitiveVariable;
+};
+
+size_t hash_value( const PrimitiveVariableHistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, static_cast<const HistoryCacheKey &>( key ) );
+	boost::hash_combine( result, key.primitiveVariable.c_str() );
+	return result;
+}
+
+using PrimitiveVariableHistoryCache = IECorePreview::LRUCache<PrimitiveVariableHistoryCacheKey, SceneAlgo::History::ConstPtr>;
+
+PrimitiveVariableHistoryCache g_primitiveVariableHistoryCache(
+	// Getter
+	[] ( const PrimitiveVariableHistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) -> SceneAlgo::History::ConstPtr {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		SceneAlgo::History::ConstPtr primitiveVariablesHistory = g_historyCache.get( key, canceller );
+		if( auto h = SceneAlgo::primitiveVariableHistory( primitiveVariablesHistory.get(), key.primitiveVariable ) )
+		{
+			return h;
+		}
+		else
+		{
+			// The specific primitive variable doesn't exist. But we return the history for the
+			// whole Primitive so we get a chance to discover nodes that could
+			// _create_ the primvar.
+			return primitiveVariablesHistory;
+		}
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const PrimitiveVariableHistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
+		// See comment in g_historyCache
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+// \todo : Duplicated from src/GafferSceneUIModule/SceneInspectorBinding.cpp
+const boost::container::flat_map<IECoreScene::PrimitiveVariable::Interpolation, IECore::ConstStringDataPtr> g_primitiveVariableInterpolations = {
+	{ PrimitiveVariable::Invalid, new IECore::StringData( "Invalid" ) },
+	{ PrimitiveVariable::Constant, new IECore::StringData( "Constant" ) },
+	{ PrimitiveVariable::Uniform, new IECore::StringData( "Uniform" ) },
+	{ PrimitiveVariable::Vertex, new IECore::StringData( "Vertex" ) },
+	{ PrimitiveVariable::Varying, new IECore::StringData( "Varying" ) },
+	{ PrimitiveVariable::FaceVarying, new IECore::StringData( "FaceVarying" ) }
+};
+
+const boost::container::flat_map<IECore::GeometricData::Interpretation, IECore::ConstStringDataPtr> g_geometricInterpretations = {
+	{ GeometricData::None, new IECore::StringData( "None" ) },
+	{ GeometricData::Point, new IECore::StringData( "Point" ) },
+	{ GeometricData::Normal, new IECore::StringData( "Normal" ) },
+	{ GeometricData::Vector, new IECore::StringData( "Vector" ) },
+	{ GeometricData::Color, new IECore::StringData( "Color" ) },
+	{ GeometricData::UV, new IECore::StringData( "UV" ) },
+	{ GeometricData::Rational, new IECore::StringData( "Rational" ) }
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// PrimitiveVariableInspector
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( PrimitiveVariableInspector )
+
+PrimitiveVariableInspector::PrimitiveVariableInspector(
+	const GafferScene::ScenePlugPtr &scene,
+	const Gaffer::PlugPtr &editScope,
+	IECore::InternedString primitiveVariable,
+	Property property,
+	const std::string &name,
+	const std::string &type
+)
+	:	Inspector( { scene->objectPlug() }, type, name == "" ? primitiveVariable.string() : name, editScope ),
+		m_scene( scene ), m_primitiveVariable( primitiveVariable ), m_property( property )
+{
+}
+
+GafferScene::SceneAlgo::History::ConstPtr PrimitiveVariableInspector::history() const
+{
+	if( !m_scene->existsPlug()->getValue() )
+	{
+		return nullptr;
+	}
+
+	return g_primitiveVariableHistoryCache.get( PrimitiveVariableHistoryCacheKey( m_scene.get(), m_primitiveVariable ), Context::current()->canceller() );
+}
+
+IECore::ConstObjectPtr PrimitiveVariableInspector::value( const GafferScene::SceneAlgo::History *history ) const
+{
+	auto primitiveVariableHistory = dynamic_cast<const SceneAlgo::PrimitiveVariableHistory *>( history );
+	if( !primitiveVariableHistory )
+	{
+		// Primitive variable doesn't exist.
+		return nullptr;
+	}
+
+	if( m_property == Property::Interpolation )
+	{
+		auto it = g_primitiveVariableInterpolations.find( primitiveVariableHistory->primitiveVariableValue.interpolation );
+		return it != g_primitiveVariableInterpolations.end() ? it->second : nullptr;
+	}
+	else if( m_property == Property::Type )
+	{
+		if( !primitiveVariableHistory->primitiveVariableValue.data )
+		{
+			return nullptr;
+		}
+
+		return new StringData( primitiveVariableHistory->primitiveVariableValue.data->typeName() );
+	}
+	else if( m_property == Property::Interpretation )
+	{
+		if( !primitiveVariableHistory->primitiveVariableValue.data )
+		{
+			return nullptr;
+		}
+
+		auto it = g_geometricInterpretations.find( IECore::getGeometricInterpretation( primitiveVariableHistory->primitiveVariableValue.data.get() ) );
+		return it != g_geometricInterpretations.end() ? it->second : nullptr;
+	}
+	else if( m_property == Property::Data )
+	{
+		return primitiveVariableHistory->primitiveVariableValue.data;
+	}
+	else if( m_property == Property::Indices )
+	{
+		return primitiveVariableHistory->primitiveVariableValue.indices;
+	}
+
+	throw IECore::Exception( fmt::format( "Unsupported primitive variable Property {}.", (int)m_property ) );
+}
+
+Gaffer::ValuePlugPtr PrimitiveVariableInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const
+{
+	if( m_property != Property::Data )
+	{
+		return nullptr;
+	}
+
+	auto sceneNode = runTimeCast<SceneNode>( history->scene->node() );
+	if( !sceneNode || history->scene != sceneNode->outPlug() )
+	{
+		return nullptr;
+	}
+	else if( auto primitiveVariablesNode = runTimeCast<GafferScene::PrimitiveVariables>( sceneNode ) )
+	{
+		if( !(primitiveVariablesNode->filterPlug()->match( primitiveVariablesNode->inPlug() ) & PathMatcher::ExactMatch ) )
+		{
+			return nullptr;
+		}
+
+		for( const auto &plug : NameValuePlug::Range( *primitiveVariablesNode->primitiveVariablesPlug() ) )
+		{
+			if(
+				plug->namePlug()->getValue() == m_primitiveVariable.string() &&
+				( !plug->enabledPlug() || plug->enabledPlug()->getValue() )
+			)
+			{
+				/// \todo This is overly conservative. We should test to see if there is more than
+				/// one filter match (but make sure to early-out once two are found, rather than test
+				/// the rest of the scene).
+				editWarning = fmt::format(
+					"Edits to \"{}\" may affect other locations in the scene.",
+					m_primitiveVariable.string()
+				);
+				return plug;
+			}
+		}
+	}
+	else if( auto primitiveVariableTweaks = runTimeCast<PrimitiveVariableTweaks>( sceneNode ) )
+	{
+		if( !( primitiveVariableTweaks->filterPlug()->match( primitiveVariableTweaks->inPlug() ) & PathMatcher::ExactMatch ) )
+		{
+			return nullptr;
+		}
+
+		for( const auto &tweak : TweakPlug::Range( *primitiveVariableTweaks->tweaksPlug() ) )
+		{
+			if(
+				tweak->namePlug()->getValue() == m_primitiveVariable.string() &&
+				tweak->enabledPlug()->getValue()
+			)
+			{
+				return tweak;
+			}
+		}
+	}
+	else if( history->scene->direction() == Plug::Out )
+	{
+		ConstObjectPtr v = value( history );
+		ConstObjectPtr previousValue;
+		if( history->predecessors.size() )
+		{
+			previousValue = value( history->predecessors.front().get() );
+		}
+		if( (bool)v != bool(previousValue) || (v && !v->isEqualTo( previousValue.get() )) )
+		{
+			return sceneNode->outPlug();
+		}
+	}
+
+	return nullptr;
+}

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -45,6 +45,7 @@
 #include "GafferSceneUI/Private/SetMembershipInspector.h"
 #include "GafferSceneUI/Private/TransformInspector.h"
 #include "GafferSceneUI/Private/OptionInspector.h"
+#include "GafferSceneUI/Private/PrimitiveVariableInspector.h"
 
 #include "GafferBindings/PathBinding.h"
 #include "GafferBindings/SignalBinding.h"
@@ -256,6 +257,24 @@ void GafferSceneUIModule::bindInspector()
 			.value( "Rotate", TransformInspector::Component::Rotate )
 			.value( "Scale", TransformInspector::Component::Scale )
 			.value( "Shear", TransformInspector::Component::Shear )
+		;
+	}
+
+	{
+		scope scope = RunTimeTypedClass<PrimitiveVariableInspector>( "PrimitiveVariableInspector" )
+			.def(
+				init<const ScenePlugPtr &, const PlugPtr &, IECore::InternedString, PrimitiveVariableInspector::Property, const std::string &>(
+					( arg( "scene" ), arg( "editScope" ), arg( "attribute" ), arg( "property" ), arg( "name" ) = "" )
+				)
+			)
+		;
+
+		enum_<PrimitiveVariableInspector::Property>( "Property" )
+			.value( "Interpolation", PrimitiveVariableInspector::Property::Interpolation )
+			.value( "Type", PrimitiveVariableInspector::Property::Type )
+			.value( "Interpretation", PrimitiveVariableInspector::Property::Interpretation )
+			.value( "Data", PrimitiveVariableInspector::Property::Data )
+			.value( "Indices", PrimitiveVariableInspector::Property::Indices )
 		;
 	}
 

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -43,6 +43,7 @@
 #include "GafferSceneUI/Private/InspectorColumn.h"
 #include "GafferSceneUI/Private/OptionInspector.h"
 #include "GafferSceneUI/Private/ParameterInspector.h"
+#include "GafferSceneUI/Private/PrimitiveVariableInspector.h"
 #include "GafferSceneUI/Private/TransformInspector.h"
 #include "GafferSceneUI/TypeIds.h"
 
@@ -1189,105 +1190,6 @@ InspectorTree::Inspections objectParametersInspectionProvider( ScenePlug *scene,
 
 const InspectorTree::Registration g_objectParametersInspectionRegistration( { "Location", "Object", "Parameters" }, objectParametersInspectionProvider );
 
-ConstStringDataPtr g_invalidStringData = new StringData( "Invalid" );
-ConstStringDataPtr g_constantStringData = new StringData( "Constant" );
-ConstStringDataPtr g_uniformStringData = new StringData( "Uniform" );
-ConstStringDataPtr g_vertexStringData = new StringData( "Vertex" );
-ConstStringDataPtr g_varyingStringData = new StringData( "Varying" );
-ConstStringDataPtr g_faceVaryingStringData = new StringData( "FaceVarying" );
-
-const PrimitiveVariable *primitiveVariable( const Object *object, const std::string &name )
-{
-	auto primitive = runTimeCast<const Primitive>( object );
-	if( !primitive )
-	{
-		return nullptr;
-	}
-
-	auto it = primitive->variables.find( name );
-	return it != primitive->variables.end() ? &it->second : nullptr;
-}
-
-ConstStringDataPtr primitiveVariableInterpolation( const std::string &name, const ObjectPlug *objectPlug )
-{
-	ConstObjectPtr object = objectPlug->getValue();
-	auto variable = primitiveVariable( object.get(), name );
-	if( !variable )
-	{
-		return nullptr;
-	}
-
-	switch( variable->interpolation )
-	{
-		case PrimitiveVariable::Invalid : return g_invalidStringData;
-		case PrimitiveVariable::Constant : return g_constantStringData;
-		case PrimitiveVariable::Uniform : return g_uniformStringData;
-		case PrimitiveVariable::Vertex : return g_vertexStringData;
-		case PrimitiveVariable::Varying : return g_varyingStringData;
-		case PrimitiveVariable::FaceVarying : return g_faceVaryingStringData;
-		default : return nullptr;
-	}
-}
-
-ConstStringDataPtr primitiveVariableType( const std::string &name, const ObjectPlug *objectPlug )
-{
-	ConstObjectPtr object = objectPlug->getValue();
-	auto variable = primitiveVariable( object.get(), name );
-	if( !variable || !variable->data )
-	{
-		return nullptr;
-	}
-
-	return new StringData( variable->data->typeName() );
-}
-
-const boost::container::flat_map<IECore::GeometricData::Interpretation, IECore::ConstStringDataPtr> g_geometricInterpretations = {
-	{ GeometricData::None, new IECore::StringData( "None" ) },
-	{ GeometricData::Point, new IECore::StringData( "Point" ) },
-	{ GeometricData::Normal, new IECore::StringData( "Normal" ) },
-	{ GeometricData::Vector, new IECore::StringData( "Vector" ) },
-	{ GeometricData::Color, new IECore::StringData( "Color" ) },
-	{ GeometricData::UV, new IECore::StringData( "UV" ) },
-	{ GeometricData::Rational, new IECore::StringData( "Rational" ) }
-};
-
-ConstStringDataPtr primitiveVariableInterpretation( const std::string &name, const ObjectPlug *objectPlug )
-{
-	ConstObjectPtr object = objectPlug->getValue();
-	auto variable = primitiveVariable( object.get(), name );
-	if( !variable || !variable->data )
-	{
-		return nullptr;
-	}
-
-	auto it = g_geometricInterpretations.find( IECore::getGeometricInterpretation( variable->data.get() ) );
-	return it != g_geometricInterpretations.end() ? it->second : nullptr;
-}
-
-ConstDataPtr primitiveVariableData( const std::string &name, const ObjectPlug *objectPlug )
-{
-	ConstObjectPtr object = objectPlug->getValue();
-	auto variable = primitiveVariable( object.get(), name );
-	if( !variable )
-	{
-		return nullptr;
-	}
-
-	return variable->data;
-}
-
-ConstDataPtr primitiveVariableIndices( const std::string &name, const ObjectPlug *objectPlug )
-{
-	ConstObjectPtr object = objectPlug->getValue();
-	auto variable = primitiveVariable( object.get(), name );
-	if( !variable )
-	{
-		return nullptr;
-	}
-
-	return variable->indices;
-}
-
 InspectorTree::Inspections primitiveVariablesInspectionProvider( ScenePlug *scene, const Gaffer::PlugPtr &editScope )
 {
 	InspectorTree::Inspections result;
@@ -1303,20 +1205,14 @@ InspectorTree::Inspections primitiveVariablesInspectionProvider( ScenePlug *scen
 	{
 		result.push_back( {
 			{ name, "Interpolation" },
-			new GafferSceneUI::Private::BasicInspector(
-				scene->objectPlug(), editScope,
-				[ name = name ] ( const ObjectPlug *objectPlug ) {
-					return primitiveVariableInterpolation( name, objectPlug );
-				}
+			new GafferSceneUI::Private::PrimitiveVariableInspector(
+				scene, editScope, name, PrimitiveVariableInspector::Property::Interpolation
 			)
 		} );
 		result.push_back( {
 			{ name, "Type" },
-			new GafferSceneUI::Private::BasicInspector(
-				scene->objectPlug(), editScope,
-				[ name = name ] ( const ObjectPlug *objectPlug ) {
-					return primitiveVariableType( name, objectPlug );
-				}
+			new GafferSceneUI::Private::PrimitiveVariableInspector(
+				scene, editScope, name, PrimitiveVariableInspector::Property::Type
 			)
 		} );
 
@@ -1325,31 +1221,22 @@ InspectorTree::Inspections primitiveVariablesInspectionProvider( ScenePlug *scen
 		{
 			result.push_back( {
 				{ name, "Interpretation" },
-				new GafferSceneUI::Private::BasicInspector(
-					scene->objectPlug(), editScope,
-					[ name = name ] ( const ObjectPlug *objectPlug ) {
-						return primitiveVariableInterpretation( name, objectPlug );
-					}
+				new GafferSceneUI::Private::PrimitiveVariableInspector(
+					scene, editScope, name, PrimitiveVariableInspector::Property::Interpretation
 				)
 			} );
 		}
 
 		result.push_back( {
 			{ name, "Data" },
-			new GafferSceneUI::Private::BasicInspector(
-				scene->objectPlug(), editScope,
-				[ name = name ] ( const ObjectPlug *objectPlug ) {
-					return primitiveVariableData( name, objectPlug );
-				}
+			new GafferSceneUI::Private::PrimitiveVariableInspector(
+				scene, editScope, name, PrimitiveVariableInspector::Property::Data
 			)
 		} );
 		result.push_back( {
 			{ name, "Indices" },
-			new GafferSceneUI::Private::BasicInspector(
-				scene->objectPlug(), editScope,
-				[ name = name ] ( const ObjectPlug *objectPlug ) {
-					return primitiveVariableIndices( name, objectPlug );
-				}
+			new GafferSceneUI::Private::PrimitiveVariableInspector(
+				scene, editScope, name, PrimitiveVariableInspector::Property::Indices
 			)
 		} );
 	}


### PR DESCRIPTION
This is ready for review, the only known issues:

* Currently, I'm still not consistently returning a result from inspect() when the primitive variable isn't found. We discussed how we do want to return a result, so that the history will be available to find an edit scope where we might want to create the primitive variable, as AttributeInspector does. However, as far as I can, the mechanism that AttributeInspector uses to accomplish this is by always having a fallback value ... and we previously discussed how you didn't think it made sense to use fallback values for PrimitiveVariableInspector. Is it better to always return a NullObject or something from value(), instead of having a fallback value?
* The tests for PrimitiveVariableInspectorTest are bit oddly structured, since they're mostly based on BasicInspectorTest, but there are still a few at the end that were based on AttributeInspectorTest before BasicInspectorTest existed ... they still seem kinda useful, so I've left them for now, but they could be thrown out if it's too rendundant.


