### PR TITLE
RenderSetAdaptor : Register to all clients

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ Improvements
 
 - ShaderTweaks : Added support for `{shaderType=someShaderType}` qualifiers in parameter names, allowing tweaking of a parameter on all shaders of a given type (#6838).
 - Scene Editors : The effects of the `render:inclusions`, `render:exclusions` and `render:additionalLights` options are now represented in the Scene Editors. As these options result in the RenderSetAdaptor pruning scene locations at render time, the Hierarchy View, Attribute Editor and Light Editor now display the same pruned scene hierarchy provided to the renderer.
-- SetEditor : Added inspection of scene edits performed by render adaptors registered to `client = "SceneEditor"`.
+- SetEditor, PrimitiveInspector : Added inspection of scene edits performed by render adaptors registered to `client = "SceneEditor"`.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - ShaderTweaks : Added support for `{shaderType=someShaderType}` qualifiers in parameter names, allowing tweaking of a parameter on all shaders of a given type (#6838).
+- Scene Editors : The effects of the `render:inclusions`, `render:exclusions` and `render:additionalLights` options are now represented in the Scene Editors. As these options result in the RenderSetAdaptor pruning scene locations at render time, the Hierarchy View, Attribute Editor and Light Editor now display the same pruned scene hierarchy provided to the renderer.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ Improvements
 
 - ShaderTweaks : Added support for `{shaderType=someShaderType}` qualifiers in parameter names, allowing tweaking of a parameter on all shaders of a given type (#6838).
 - Scene Editors : The effects of the `render:inclusions`, `render:exclusions` and `render:additionalLights` options are now represented in the Scene Editors. As these options result in the RenderSetAdaptor pruning scene locations at render time, the Hierarchy View, Attribute Editor and Light Editor now display the same pruned scene hierarchy provided to the renderer.
-- SetEditor, PrimitiveInspector : Added inspection of scene edits performed by render adaptors registered to `client = "SceneEditor"`.
+- SetEditor, PrimitiveInspector, UVInspector : Added inspection of scene edits performed by render adaptors registered to `client = "SceneEditor"`.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - ShaderTweaks : Added support for `{shaderType=someShaderType}` qualifiers in parameter names, allowing tweaking of a parameter on all shaders of a given type (#6838).
 - Scene Editors : The effects of the `render:inclusions`, `render:exclusions` and `render:additionalLights` options are now represented in the Scene Editors. As these options result in the RenderSetAdaptor pruning scene locations at render time, the Hierarchy View, Attribute Editor and Light Editor now display the same pruned scene hierarchy provided to the renderer.
+- SetEditor : Added inspection of scene edits performed by render adaptors registered to `client = "SceneEditor"`.
 
 Fixes
 -----

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -210,7 +210,7 @@ class PrimitiveInspector( GafferSceneUI.SceneEditor ) :
 			)
 
 		if plug in (
-			self.settings()["in"]["object"], self.settings()["in"]["exists"],
+			self.settings()["__adaptedIn"]["object"], self.settings()["__adaptedIn"]["exists"],
 			self.settings()["location"]
 		) :
 			self.__updateLazily()
@@ -233,15 +233,15 @@ class PrimitiveInspector( GafferSceneUI.SceneEditor ) :
 		if not targetPath :
 			return None
 
-		if not self.settings()["in"].exists( targetPath ) :
+		if not self.settings()["__adaptedIn"].exists( targetPath ) :
 			return None
 
-		return self.settings()["in"].object( targetPath )
+		return self.settings()["__adaptedIn"].object( targetPath )
 
 	@__backgroundUpdate.plug
 	def __backgroundUpdatePlug( self ) :
 
-		return self.settings()["in"]
+		return self.settings()["__adaptedIn"]
 
 	@__backgroundUpdate.preCall
 	def __backgroundUpdatePreCall( self ) :

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -84,7 +84,7 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 			self.__excludedSetMembersColumn = _GafferSceneUI._SetEditor.VisibleSetExclusionsColumn( scriptNode )
 			self.__pathListing = GafferUI.PathListingWidget(
 				_GafferSceneUI._SetEditor.SetPath(
-					self.settings()["in"], self.context(), "/",
+					self.settings()["__adaptedIn"], self.context(), "/",
 					filter = Gaffer.CompoundPathFilter( [ self.__searchFilter, self.__emptySetFilter, self.__emptySelectionFilter ] ),
 				),
 				columns = [
@@ -227,7 +227,7 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 		result = IECore.PathMatcher()
 		with Gaffer.Context( self.context() ) :
 			for setName in setNames :
-				result.addPaths( self.settings()["in"].set( setName ).value )
+				result.addPaths( self.settings()["__adaptedIn"].set( setName ).value )
 
 		return result
 
@@ -330,7 +330,7 @@ class _FilterPlugValueWidget( GafferUI.StringPlugValueWidget ) :
 
 	def __scene( self ) :
 
-		return self.getPlug().node()["in"]
+		return self.getPlug().node()["__adaptedIn"]
 
 	def __setLookup( self, paths ) :
 

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -50,7 +50,7 @@ class UVInspector( GafferSceneUI.SceneEditor ) :
 		GafferSceneUI.SceneEditor.__init__( self, column, scriptNode, **kw )
 
 		self.__uvView = GafferSceneUI.UVView( scriptNode )
-		self.__uvView["in"].setInput( self.settings()["in"] )
+		self.__uvView["in"].setInput( self.settings()["__adaptedIn"] )
 		Gaffer.NodeAlgo.applyUserDefaults( self.__uvView )
 
 		with column :

--- a/startup/GafferScene/renderSetAdaptor.py
+++ b/startup/GafferScene/renderSetAdaptor.py
@@ -95,4 +95,4 @@ def __renderSetAdaptor() :
 
 	return processor
 
-GafferScene.SceneAlgo.registerRenderAdaptor( "RenderSetAdaptor", __renderSetAdaptor, "SceneView *Render", "*" )
+GafferScene.SceneAlgo.registerRenderAdaptor( "RenderSetAdaptor", __renderSetAdaptor )


### PR DESCRIPTION
When we introduced the Render Adaptors in Scene Editors functionality in Gaffer 1.6.16.0, we took the conservative approach of deliberately excluding the RenderSetAdaptor. As pruning is destructive, we thought it might be a bit counterproductive if you couldn't always see everything in the Hierarchy View in case you wanted to find a currently excluded (and therefore pruned) location in order to re-include it in the render set.

After some production use and testing, we've received user feedback stating the preference for seeing the pruned scene in the Hierarchy View as that more accurately represents the true state of the rendered scene, we now revert the previous change and register the RenderSetAdaptor to again affect all clients.

This PR also configures the SetEditor, PrimitiveInspector and UVInspector to inspect the scene through the render adaptors, as they may be affected by the pruned output of the RenderSetAdaptor.