### PR TITLE
PopupWindow : Possible fix for obscure segfault

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Plug : Fixed bug which meant nodes would fail to update if a newly created plug was renamed before being parented to the node.
+- PopupWindow : Fixed reference cycle that could trigger crashes in certain circumstances, including the usage of custom render pass name widgets in the RenderPassEditor.
 - Metadata : Fixed handling of exceptions thrown from value functions implemented in Python. These are now correctly translated into C++ exceptions.
 - Cycles, OSLObject, OSLImage, Expression : Fixed crashes when using OSL on macOS.
 - Dispatcher : Removed `dispatcher:scriptFileName` from labels for isolated tasks.

--- a/python/GafferUI/PopupWindow.py
+++ b/python/GafferUI/PopupWindow.py
@@ -54,7 +54,7 @@ class PopupWindow( GafferUI.Window ) :
 
 		self._qtWidget().setWindowFlags( QtCore.Qt.Popup | QtCore.Qt.FramelessWindowHint )
 		self._qtWidget().setAttribute( QtCore.Qt.WA_TranslucentBackground )
-		self._qtWidget().paintEvent = _paintWindowBackground.__get__( self._qtWidget() )
+		self._qtWidget().paintEvent = Gaffer.WeakMethod( self.__paintEvent, fallbackResult = None )
 
 		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ) )
 
@@ -94,6 +94,18 @@ class PopupWindow( GafferUI.Window ) :
 
 		cls.__warningPopup.popup( parent = parent, center = center )
 
+	def __paintEvent( self, event ) :
+
+		painter = QtGui.QPainter( self._qtWidget() )
+		painter.setRenderHint( QtGui.QPainter.Antialiasing )
+
+		painter.setBrush( QtGui.QColor( 35, 35, 35 ) )
+		painter.setPen( QtGui.QColor( 0, 0, 0, 0 ) )
+
+		radius = self._qtWidget().layout().contentsMargins().left()
+		size = self.size()
+		painter.drawRoundedRect( QtCore.QRectF( 0, 0, size.x, size.y ), radius, radius )
+
 	def __keyPress( self, widget, event ) :
 
 		## \todo This automatic-close behaviour is not always wanted.
@@ -106,14 +118,3 @@ class PopupWindow( GafferUI.Window ) :
 			# itself, and gets upset if we do it first.
 			if self.ancestor( GafferUI.VectorDataWidget ) is None :
 				self.close()
-
-def _paintWindowBackground( qWidget, event ) :
-
-	painter = QtGui.QPainter( qWidget )
-	painter.setRenderHint( QtGui.QPainter.Antialiasing )
-
-	painter.setBrush( QtGui.QColor( 35, 35, 35 ) )
-	painter.setPen( QtGui.QColor( 0, 0, 0, 0 ) )
-
-	radius = qWidget.layout().contentsMargins().left()
-	painter.drawRoundedRect( QtCore.QRectF( 0, 0, qWidget.width(), qWidget.height() ), radius, radius )

--- a/python/GafferUITest/PopupWindowTest.py
+++ b/python/GafferUITest/PopupWindowTest.py
@@ -34,9 +34,13 @@
 #
 ##########################################################################
 
+import gc
 import unittest
 import weakref
 
+import IECore
+
+import Gaffer
 import GafferUI
 import GafferUITest
 
@@ -75,6 +79,25 @@ class PopupWindowTest( GafferUITest.TestCase ) :
 
 		self.assertIsNone( weakWindow() )
 		self.assertIsNone( weakPopup() )
+
+	def testGarbageCollectionOnBackgroundThread( self ) :
+
+		# Make a PopupWindow, and delete it.
+		with GafferUI.PopupWindow() as p :
+			p = GafferUI.VectorDataWidget( IECore.IntVectorData() )
+		del p
+
+		# If the above were to create any reference cycles involving a QWidget,
+		# then the QWidget will eventually be destroyed by Python's garbage
+		# collector. We don't control when that runs, and if it runs on a
+		# background thread then PySide will attempt to send the C++ QWidget to
+		# the main thread using `Py_AddPendingCall()`, to be deleted there later.
+		# That causes crashes in `~QObject` in `Shiboken::BindingManager::runDeletionInMainThread()`,
+		# potentially due to double-deletion of the QObject. Our conclusion :
+		# PySide is buggy, and we must never make reference cycles involving
+		# QWidget.
+		b = Gaffer.ParallelAlgo.callOnBackgroundThread( None, gc.collect )
+		b.wait()
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
ImageEngine has found a weird crash in a specific UI, which has been fairly frequently causing problems. It involves using the Spreadsheet editor to create a popup window containing a VectorDataWidget, closing that, and then pressing a button that reloads the contents of a complicated dynamic box, triggering UI refreshes that take quite a while to complete.

I've emailed John some crash logs to look at.

Martin and Ivan were able to track this down to having started happening in 1.6.4, and more specifically, this commit:
https://github.com/GafferHQ/gaffer/commit/a13abf4d6d5d3a78e3f7239b0be24ede20d06fe7

Looking at that without much context, and not being that familiar with this use of `__get__`, it looks to me like it is creating a circular reference to _qtWidget() that would result in being kept alive until garbage collection. I'm not sure whether that should be a problem, but it seems plausible that it could be at least the trigger for this crash, even if it isn't wrong.

The result of a `__get__` seems a lot like a method, so I suggested wrapping it in a WeakMethod to see what happens. In Ivan's testing, that seems to have stopped him seeing the crash. I have no idea if this is actually correct, or if it could cause other problems, but I figured I'd PR it in case it seems reasonable. If we can find a fix for this issue, it would be great to release it quickly.

If we're completely barking up the wrong tree here, and John doesn't spot anything likely in the crash logs, then we might need to try and reproduce this outside the IE env, but that could be quite tricky, given that it seems to be dependent on the specific timing of loading a complex setup using a custom UI.