### PR TITLE
PrimitiveVariableInspector : Cleanup

### DIFF
--- a/src/GafferSceneUI/PrimitiveVariableInspector.cpp
+++ b/src/GafferSceneUI/PrimitiveVariableInspector.cpp
@@ -38,23 +38,16 @@
 
 #include "GafferScene/PrimitiveVariables.h"
 #include "GafferScene/PrimitiveVariableTweaks.h"
-#include "GafferScene/Camera.h"
-#include "GafferScene/EditScopeAlgo.h"
-#include "GafferScene/Light.h"
-#include "GafferScene/LightFilter.h"
 #include "GafferScene/SceneAlgo.h"
 #include "GafferScene/SceneNode.h"
 
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
-#include "Gaffer/Metadata.h"
-#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/NameValuePlug.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/ParallelAlgo.h"
 #include "Gaffer/ValuePlug.h"
 
 #include "IECore/DataAlgo.h"
-#include "IECore/NullObject.h"
 
 #include "fmt/format.h"
 

--- a/src/GafferSceneUI/PrimitiveVariableInspector.cpp
+++ b/src/GafferSceneUI/PrimitiveVariableInspector.cpp
@@ -72,9 +72,6 @@ using namespace GafferSceneUI::Private;
 namespace
 {
 
-const std::string g_attributePrefix( "attribute:" );
-const InternedString g_defaultValue( "defaultValue" );
-
 // This uses the same strategy that ValuePlug uses for the hash cache,
 // using `plug->dirtyCount()` to invalidate previous cache entries when
 // a plug is dirtied.


### PR DESCRIPTION
A little bit of tidying of things noticed while I was squinting at diffs when merging `1.6_maintenance` forward to `main`.