### PR TITLE
LabelPlugValueWidget Icons

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,10 +4,17 @@
 Improvements
 ------------
 
+- USDLight : Added icon indicating which renderer a renderer-specific parameter applies to and removed the renderer text from the plug label.
+
+API
+---
 - ShaderTweaks, ShaderQuery : Added `RenderMan Light Filter` preset for the `shader` plug.
 - LightEditor :
   - Added columns for RenderMan-specific parameters on USD lights.
   - Added columns for RenderMan light filters.
+- LabelPlugValueWidget :
+  - Added support for icons on plug names using `labelPlugValueWidget:icon`.
+  - Added `setFixedWidth()` method.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -13,7 +13,7 @@ API
   - Added columns for RenderMan-specific parameters on USD lights.
   - Added columns for RenderMan light filters.
 - LabelPlugValueWidget :
-  - Added support for icons on plug names using `labelPlugValueWidget:icon`.
+  - Added support for icons and icon toolTips on plug names using `labelPlugValueWidget:icon` and `labelPlugValueWidget:iconToolTip` metadata, respectively.
   - Added `setFixedWidth()` method.
 
 Fixes

--- a/python/GafferSceneUI/CameraQueryUI.py
+++ b/python/GafferSceneUI/CameraQueryUI.py
@@ -80,7 +80,7 @@ class _QueryWidget( GafferUI.PlugValueWidget ) :
 			{ plug.node().sourcePlugFromQuery( plug ) for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		sourceLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		sourceLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			sourceLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -95,7 +95,7 @@ class _QueryWidget( GafferUI.PlugValueWidget ) :
 			{ plug.node().valuePlugFromQuery( plug ) for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		valueLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		valueLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			valueLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top

--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -64,7 +64,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 					horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,
 					verticalAlignment = GafferUI.Label.VerticalAlignment.Top,
 				)
-				label.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+				label.setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 
 				self.__menuButton = GafferUI.MenuButton()
 				self.__menuButton.setMenu( GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -149,6 +149,7 @@ Gaffer.Metadata.registerNode(
 			"presetValues" : functools.partial( __parameterMetadata, key = "presetValues" ),
 			"nodule:type" : functools.partial( __parameterMetadata, key = "nodule:type" ),
 			"noduleLayout:visible" : functools.partial( __parameterMetadata, key = "noduleLayout:visible" ),
+			"labelPlugValueWidget:icon" : functools.partial( __parameterMetadata, key = "labelPlugValueWidget:icon" ),
 
 			# Although the parameters plug is positioned
 			# as we want above, we must also register

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -150,6 +150,7 @@ Gaffer.Metadata.registerNode(
 			"nodule:type" : functools.partial( __parameterMetadata, key = "nodule:type" ),
 			"noduleLayout:visible" : functools.partial( __parameterMetadata, key = "noduleLayout:visible" ),
 			"labelPlugValueWidget:icon" : functools.partial( __parameterMetadata, key = "labelPlugValueWidget:icon" ),
+			"labelPlugValueWidget:iconToolTip" : functools.partial( __parameterMetadata, key = "labelPlugValueWidget:iconToolTip" ),
 
 			# Although the parameters plug is positioned
 			# as we want above, we must also register

--- a/python/GafferSceneUI/OptionQueryUI.py
+++ b/python/GafferSceneUI/OptionQueryUI.py
@@ -87,7 +87,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			self.getPlugs(),
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		nameWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+		nameWidget.setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 		self.__row.append(
 			nameWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -97,7 +97,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["exists"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		existsLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		existsLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			existsLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -112,7 +112,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["value"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		valueLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		valueLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			valueLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top

--- a/python/GafferSceneUI/PrimitiveVariableQueryUI.py
+++ b/python/GafferSceneUI/PrimitiveVariableQueryUI.py
@@ -95,7 +95,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			self.getPlugs(),
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		nameWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+		nameWidget.setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 		self.__column[0].append(
 			nameWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -105,7 +105,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["exists"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		existsLabelWidget.label()._qtWidget().setFixedWidth( 35 )
+		existsLabelWidget.setFixedWidth( 35 )
 		self.__column[0].append(
 			existsLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -120,7 +120,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug['type'] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		typeLabelWidget.label()._qtWidget().setFixedWidth( 30 )
+		typeLabelWidget.setFixedWidth( 30 )
 		self.__column[0].append(
 			typeLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -135,7 +135,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["interpolation"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		interpLabelWidget.label()._qtWidget().setFixedWidth( 80 )
+		interpLabelWidget.setFixedWidth( 80 )
 		self.__column[0].append(
 			interpLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -149,7 +149,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["value"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		valueLabelWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+		valueLabelWidget.setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 		self.__column[1].append(
 			valueLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -93,7 +93,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			self.getPlugs(),
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		nameWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+		nameWidget.setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 		self.__row.append(
 			nameWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -103,7 +103,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["exists"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		existsLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		existsLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			existsLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -118,7 +118,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["value"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		valueLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		valueLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			valueLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -165,6 +165,7 @@ Gaffer.Metadata.registerNode(
 			"nodule:type" : functools.partial( __parameterMetadata, key = "nodule:type" ),
 			"noduleLayout:visible" : functools.partial( __parameterMetadata, key = "noduleLayout:visible", shaderFallbackKey = "noduleLayout:defaultVisibility" ),
 			"labelPlugValueWidget:icon" : functools.partial( __parameterMetadata, key = "labelPlugValueWidget:icon" ),
+			"labelPlugValueWidget:iconToolTip" : functools.partial( __parameterMetadata, key = "labelPlugValueWidget:iconToolTip" ),
 
 		},
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -164,6 +164,7 @@ Gaffer.Metadata.registerNode(
 			"presetValues" : functools.partial( __parameterMetadata, key = "presetValues" ),
 			"nodule:type" : functools.partial( __parameterMetadata, key = "nodule:type" ),
 			"noduleLayout:visible" : functools.partial( __parameterMetadata, key = "noduleLayout:visible", shaderFallbackKey = "noduleLayout:defaultVisibility" ),
+			"labelPlugValueWidget:icon" : functools.partial( __parameterMetadata, key = "labelPlugValueWidget:icon" ),
 
 		},
 

--- a/python/GafferUI/ContextQueryUI.py
+++ b/python/GafferUI/ContextQueryUI.py
@@ -90,7 +90,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			self.getPlugs(),
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		nameWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+		nameWidget.setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 		self.__row.append(
 			nameWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -100,7 +100,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["exists"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		existsLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		existsLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			existsLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
@@ -115,7 +115,7 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 			{ plug["value"] for plug in self.getPlugs() },
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
 		)
-		valueLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		valueLabelWidget.setFixedWidth( 40 )
 		self.__row.append(
 			valueLabelWidget,
 			verticalAlignment = GafferUI.Label.VerticalAlignment.Top

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -37,6 +37,8 @@
 import Gaffer
 import GafferUI
 
+from GafferUI.PlugValueWidget import sole
+
 from Qt import QtWidgets
 
 ## A simple PlugValueWidget which just displays the name of the plug,
@@ -47,6 +49,7 @@ from Qt import QtWidgets
 #  - "renameable"
 #  - "labelPlugValueWidget:showValueChangedIndicator" : If `False`, the indicator that the
 #  plug value has changed will not be shown. Defaults to `True` if not set.
+#  - "labelPlugValueWidget:icon" : An icon to display next to the plug label.
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	## \todo Remove alignment arguments. Vertically the only alignment that looks good is `Center`, and
@@ -87,6 +90,9 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__editableLabel = None # we'll make this lazily as needed
 
+		self.__iconWidget = None
+		self.__updateIcon()
+
 		# Connecting at front so we're called before the slots
 		# connected by the NameLabel class.
 		self.__label.dragBeginSignal().connectFront( Gaffer.WeakMethod( self.__dragBegin ) )
@@ -113,6 +119,8 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			else :
 				self.__editableLabel.setGraphComponent( None )
 
+		self.__updateIcon()
+
 		self.__updatePlugMetadataChangedConnections()
 		self.__updateDoubleClickConnection()
 
@@ -135,6 +143,12 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 				result += "- Shift+left or middle drag to transfer value"
 
 		return result
+
+	def setFixedWidth( self, width ) :
+
+		self._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
+		self._qtWidget().setFixedWidth( width )
+		self.__label._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred )
 
 	@staticmethod
 	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
@@ -287,6 +301,19 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			# The NameLabel doesn't know that our formatter is sensitive
 			# to the metadata, so give it a little kick.
 			self.__label.setFormatter( self.__formatter )
+		elif key == "labelPlugValueWidget:icon" :
+			self.__updateIcon()
+
+	def __updateIcon( self ) :
+
+		layout = self._qtWidget().layout()
+		if self.__iconWidget is not None :
+			self.__iconWidget._qtWidget().setParent( None )
+			self.__iconWidget = None
+
+		if ( icon := sole( Gaffer.Metadata.value( p, "labelPlugValueWidget:icon" ) for p in self.getPlugs() )  ) is not None :
+			self.__iconWidget = GafferUI.Image( icon )
+			layout.addWidget( self.__iconWidget._qtWidget() )
 
 	@staticmethod
 	def __formatter( graphComponents ) :

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -50,6 +50,7 @@ from Qt import QtWidgets
 #  - "labelPlugValueWidget:showValueChangedIndicator" : If `False`, the indicator that the
 #  plug value has changed will not be shown. Defaults to `True` if not set.
 #  - "labelPlugValueWidget:icon" : An icon to display next to the plug label.
+#  - "labelPlugValueWidget:iconToolTip" : A toolTip to show for the icon.
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	## \todo Remove alignment arguments. Vertically the only alignment that looks good is `Center`, and
@@ -303,6 +304,8 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__label.setFormatter( self.__formatter )
 		elif key == "labelPlugValueWidget:icon" :
 			self.__updateIcon()
+		elif key == "labelPlugValueWidget:iconToolTip" :
+			self.__updateIcon()
 
 	def __updateIcon( self ) :
 
@@ -313,6 +316,9 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if ( icon := sole( Gaffer.Metadata.value( p, "labelPlugValueWidget:icon" ) for p in self.getPlugs() )  ) is not None :
 			self.__iconWidget = GafferUI.Image( icon )
+			toolTip = sole( Gaffer.Metadata.value( p, "labelPlugValueWidget:iconToolTip" ) for p in self.getPlugs() )
+			if toolTip is not None :
+				self.__iconWidget.setToolTip( toolTip )
 			layout.addWidget( self.__iconWidget._qtWidget() )
 
 	@staticmethod

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -44,6 +44,8 @@ import GafferUI.SpreadsheetUI
 
 from GafferUI.PlugValueWidget import sole
 
+from Qt import QtWidgets
+
 ## Supported plug metadata :
 #
 # - "nameValuePlugPlugValueWidget:ignoreNamePlug", set to True to ignore the name plug and instead show a
@@ -66,7 +68,7 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 				self.getPlugs(),
 				horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,
 			)
-			nameWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+			nameWidget.setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 			nameWidget.dropSignal().connectFront( Gaffer.WeakMethod( self.__drop ) )
 		else :
 			nameWidget = GafferUI.StringPlugValueWidget( { plug["name"] for plug in self.getPlugs() } )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -464,8 +464,8 @@ class PlugLayout( GafferUI.Widget ) :
 				# to the label.
 				## \todo Shift all the label size fixing out of PlugWidget and just fix the
 				# widget here if we're in a vertical orientation.
-				QWIDGETSIZE_MAX = 16777215 # qt #define not exposed by PyQt or PySide
-				result.labelPlugValueWidget().label()._qtWidget().setFixedWidth( QWIDGETSIZE_MAX )
+				result.labelPlugValueWidget().label()._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed )
+				result.labelPlugValueWidget()._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 
 		# Store the metadata value that controlled the type created, so we can compare to it
 		# in the future to determine if we can reuse the widget.

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -74,9 +74,7 @@ class PlugWidget( GafferUI.Widget ) :
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,
 		)
 
-		## \todo Decide how we allow this sort of tweak using the public
-		# interface. Perhaps we should have a SizeableContainer or something?
-		self.__label.label()._qtWidget().setFixedWidth( self.labelWidth() )
+		self.__label.setFixedWidth( self.labelWidth() )
 
 		if label is not None :
 			warnings.warn(

--- a/python/GafferUSDUI/USDLightUI.py
+++ b/python/GafferUSDUI/USDLightUI.py
@@ -98,6 +98,12 @@ def __registerIcons() :
 			"labelPlugValueWidget:icon",
 			"renderer" + renderer + "OnIcon.png"
 		)
+		Gaffer.Metadata.registerValue(
+			GafferUSD.USDLight.staticTypeId(),
+			f"parameters.{prefix}*",
+			"labelPlugValueWidget:iconToolTip",
+			f"Parameter is specific to {renderer}."
+		)
 		visited.add( prefix )
 
 __registerIcons()

--- a/python/GafferUSDUI/USDLightUI.py
+++ b/python/GafferUSDUI/USDLightUI.py
@@ -75,6 +75,33 @@ Gaffer.Metadata.registerNode(
 	}
 )
 
+# \todo Remove this method when merging to `1.7`. Instead, register
+# dynamic metadata methods to `light:*:*` and determine the renderer
+# in that method. This will be consistent with `ShaderUI` and `LightUI`
+# registrations of the form `{shaderType}:{shaderName}:{parameterName}`.
+def __registerIcons() :
+
+	visited = set()
+	for rendererTarget in Gaffer.Metadata.targetsWithMetadata( "renderer:*", "optionPrefix" ) :
+		renderer = rendererTarget[9:]  # Trim off "renderer:"
+		# \todo Once we standardize on `arnold:` prefix instead of `ai:`, we can remove this special case.
+		prefix = "arnold:" if renderer == "Arnold" else Gaffer.Metadata.value( rendererTarget, "optionPrefix" )
+
+		if prefix in visited :
+			# A prefix can be registered for multiple renderers. We register them in
+			# order of importance, so skip all but the first.
+			continue
+
+		Gaffer.Metadata.registerValue(
+			GafferUSD.USDLight.staticTypeId(),
+			f"parameters.{prefix}*",
+			"labelPlugValueWidget:icon",
+			"renderer" + renderer + "OnIcon.png"
+		)
+		visited.add( prefix )
+
+__registerIcons()
+
 class _RendererFilter( GafferUI.Widget ) :
 
 	def __init__( self, plug, **kw ) :

--- a/python/GafferUSDUI/USDShaderUI.py
+++ b/python/GafferUSDUI/USDShaderUI.py
@@ -114,7 +114,7 @@ def __label( plug ) :
 
 	property = __primProperty( plug )
 	if property :
-		return property.GetMetadata( "displayName" ) + ( " (RenderMan)" if plug.getName().startswith( "ri:" ) else "" )
+		return property.GetMetadata( "displayName" )
 
 	return __sdrProperty( plug ).GetLabel() or None
 

--- a/usdSchemas/GafferArnold.usda
+++ b/usdSchemas/GafferArnold.usda
@@ -47,47 +47,47 @@ class "GafferArnoldLightAPI" (
 
 	string inputs:arnold:aov = "default" (
 		displayGroup = "Basic"
-		displayName = "AOV (Arnold)"
+		displayName = "AOV"
 	)
 
 	int inputs:arnold:samples = 1 (
 		displayGroup = "Sampling"
-		displayName = "Samples (Arnold)"
+		displayName = "Samples"
 	)
 
 	int inputs:arnold:volume_samples = 2 (
 		displayGroup = "Sampling"
-		displayName = "Volume Samples (Arnold)"
+		displayName = "Volume Samples"
 	)
 
 	float inputs:arnold:sss = 1.0 (
 		displayGroup = "Refine"
-		displayName = "SSS (Arnold)"
+		displayName = "SSS"
 	)
 
 	float inputs:arnold:indirect = 1.0(
 		displayGroup = "Refine"
-		displayName = "Indirect (Arnold)"
+		displayName = "Indirect"
 	)
 
 	float inputs:arnold:volume = 1.0 (
 		displayGroup = "Refine"
-		displayName = "Volume (Arnold)"
+		displayName = "Volume"
 	)
 
 	bool inputs:arnold:cast_volumetric_shadows = true (
 		displayGroup = "Shadows"
-		displayName = "Cast Volumetric (Arnold)"
+		displayName = "Cast Volumetric"
 	)
 
 	float inputs:arnold:shadow_density = 1.0 (
 		displayGroup = "Shadows"
-		displayName = "Shadow Density (Arnold)"
+		displayName = "Shadow Density"
 	)
 
 	int inputs:arnold:max_bounces = 999 (
 		displayGroup = "Refine"
-		displayName = "Max Bounces (Arnold)"
+		displayName = "Max Bounces"
 	)
 
 }
@@ -104,12 +104,12 @@ class "GafferArnoldCylinderLightAPI" (
 
 	float inputs:arnold:camera = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Camera (Arnold)"
+		displayName = "Camera"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Transmission (Arnold)"
+		displayName = "Transmission"
 	)
 
 }
@@ -126,17 +126,17 @@ class "GafferArnoldDiskLightAPI" (
 
 	float inputs:arnold:spread = 1.0 (
 		displayGroup = "Geometry"
-		displayName = "Spread (Arnold)"
+		displayName = "Spread"
 	)
 
 	float inputs:arnold:camera = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Camera (Arnold)"
+		displayName = "Camera"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Transmission (Arnold)"
+		displayName = "Transmission"
 	)
 
 }
@@ -153,12 +153,12 @@ class "GafferArnoldPointLightAPI" (
 
 	float inputs:arnold:camera = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Camera (Arnold)"
+		displayName = "Camera"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Transmission (Arnold)"
+		displayName = "Transmission"
 	)
 
 }
@@ -175,32 +175,32 @@ class "GafferArnoldQuadLightAPI" (
 
 	float inputs:arnold:roundness = 0.0 (
 		displayGroup = "Geometry"
-		displayName = "Roundness (Arnold)"
+		displayName = "Roundness"
 	)
 
 	float inputs:arnold:soft_edge = 0.0 (
 		displayGroup = "Geometry"
-		displayName = "Soft Edge (Arnold)"
+		displayName = "Soft Edge"
 	)
 
 	float inputs:arnold:spread = 1.0 (
 		displayGroup = "Geometry"
-		displayName = "Spread (Arnold)"
+		displayName = "Spread"
 	)
 
 	int inputs:arnold:resolution = 512 (
 		displayGroup = "Sampling"
-		displayName = "Resolution (Arnold)"
+		displayName = "Resolution"
 	)
 
 	float inputs:arnold:camera = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Camera (Arnold)"
+		displayName = "Camera"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
 		displayGroup = "Refine"
-		displayName = "Transmission (Arnold)"
+		displayName = "Transmission"
 	)
 
 }
@@ -218,27 +218,27 @@ class "GafferArnoldSkydomeLightAPI" (
 	token inputs:arnold:portal_mode = "interior_only" (
 		allowedTokens = [ "off", "interior_only", "interior_exterior" ]
 		displayGroup = "Basic"
-		displayName = "Portal Mode (Arnold)"
+		displayName = "Portal Mode"
 	)
 
 	bool inputs:arnold:aov_indirect = false (
 		displayGroup = "Basic"
-		displayName = "AOV Indirect (Arnold)"
+		displayName = "AOV Indirect"
 	)
 
 	int inputs:arnold:resolution = 1000 (
 		displayGroup = "Sampling"
-		displayName = "Resolution (Arnold)"
+		displayName = "Resolution"
 	)
 
 	float inputs:arnold:camera = 1.0 (
 		displayGroup = "Refine"
-		displayName = "Camera (Arnold)"
+		displayName = "Camera"
 	)
 
 	float inputs:arnold:transmission = 1.0 (
 		displayGroup = "Refine"
-		displayName = "Transmission (Arnold)"
+		displayName = "Transmission"
 	)
 
 }
@@ -255,12 +255,12 @@ class "GafferArnoldSpotLightAPI" (
 
 	float inputs:arnold:lens_radius = 0.0 (
 		displayGroup = "Shaping"
-		displayName = "Lens Radius (Arnold)"
+		displayName = "Lens Radius"
 	)
 
 	float inputs:arnold:aspect_ratio = 1.0 (
 		displayGroup = "Shaping"
-		displayName = "Aspect Ratio (Arnold)"
+		displayName = "Aspect Ratio"
 	)
 
 }

--- a/usdSchemas/GafferCycles.usda
+++ b/usdSchemas/GafferCycles.usda
@@ -33,47 +33,47 @@ class "GafferCyclesLightAPI" (
 
 	string inputs:cycles:lightgroup = "" (
 		displayGroup = "Basic"
-		displayName = "Light Group (Cycles)"
+		displayName = "Light Group"
 	)
 
 	bool inputs:cycles:use_mis = true (
 		displayGroup = "Refine"
-		displayName = "MIS (Cycles)"
+		displayName = "MIS"
 	)
 
 	bool inputs:cycles:use_camera = true (
 		displayGroup = "Refine"
-		displayName = "Camera (Cycles)"
+		displayName = "Camera"
 	)
 
 	bool inputs:cycles:use_diffuse = true (
 		displayGroup = "Refine"
-		displayName = "Diffuse (Cycles)"
+		displayName = "Diffuse"
 	)
 
 	bool inputs:cycles:use_glossy = true (
 		displayGroup = "Refine"
-		displayName = "Glossy (Cycles)"
+		displayName = "Glossy"
 	)
 
 	bool inputs:cycles:use_transmission = true (
 		displayGroup = "Refine"
-		displayName = "Transmission (Cycles)"
+		displayName = "Transmission"
 	)
 
 	bool inputs:cycles:use_scatter = true (
 		displayGroup = "Refine"
-		displayName = "Volume Scatter (Cycles)"
+		displayName = "Volume Scatter"
 	)
 
 	bool inputs:cycles:use_caustics = false (
 		displayGroup = "Refine"
-		displayName = "Shadow Caustics (Cycles)"
+		displayName = "Shadow Caustics"
 	)
 
 	int inputs:cycles:max_bounces = 1024 (
 		displayGroup = "Refine"
-		displayName = "Max Bounces (Cycles)"
+		displayName = "Max Bounces"
 	)
 
 }
@@ -90,7 +90,7 @@ class "GafferCyclesDiskLightAPI" (
 
 	float inputs:cycles:spread = 180.0 (
 		displayGroup = "Geometry"
-		displayName = "Spread (Cycles)"
+		displayName = "Spread"
 	)
 
 }
@@ -107,7 +107,7 @@ class "GafferCyclesQuadLightAPI" (
 
 	float inputs:cycles:spread = 180.0 (
 		displayGroup = "Geometry"
-		displayName = "Spread (Cycles)"
+		displayName = "Spread"
 	)
 
 }
@@ -124,7 +124,7 @@ class "GafferCyclesBackgroundLightAPI" (
 
 	int inputs:cycles:map_resolution = 1024 (
 		displayGroup = "Sampling"
-		displayName = "Map Resolution (Cycles)"
+		displayName = "Map Resolution"
 	)
 
 }


### PR DESCRIPTION
This allows adding an icon to `LabelPlugValueWidget`. It was originally motivated by the names for renderer-specific parameters on USD lights getting pretty long with redundant information, and uses those as the labels to get icons.

I added the same sizing change made to the `PlugWidget` to `NameValuePlugValueWidget` as well. I don't think this should be applied to all `LabelPlugValueWidget` uses since some use slightly different layouts to achieve their goals (like the use in `EditScopeUI`).

There are a few places where the `LabelPlugValueWidget` is set very similarly to `PlugWidget` but I've not added this treatment to those because I'm guessing their not likely to get icons. Those are `FilterPlugValueWidget` and the outputs of the various query nodes like `OptionsQueryUI`.

Is it worth modifying more of these uses of `LabelPlugValueWidget` where we set a size so that they are all using the same sizing method? That is to say sizing the full `LabelPlugValueWidget` rather than that widget's `label()` text.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
