### PR TITLE
LightEditor config : Add USD extension parameters for RenderMan

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - ShaderTweaks, ShaderQuery : Added `RenderMan Light Filter` preset for the `shader` plug.
+- LightEditor : Added columns for RenderMan-specific parameters on USD lights.
 
 Fixes
 -----

--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -328,6 +328,18 @@ if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
 		GafferSceneUI.LightEditor.registerParameter( "ri:light", "msApproxBleed", "Multi-Scattering Approx" )
 		GafferSceneUI.LightEditor.registerParameter( "ri:light", "msApproxContribution", "Multi-Scattering Approx" )
 
+		# Register RenderMan-specific parameters for USD lights.
+		for parameter in [
+			"colorMapGamma", "colorMapSaturation", "emissionFocusNormalize", "intensityNearDist", "diffuseNearDist",
+			"specularNearDist", "traceLightPaths", "thinShadow", "visibleInRefractionPath", "cheapCaustics",
+			"cheapCausticsExcludeGroup", "fixedSampleCount", "lightGroup", "importanceMultiplier", "msApprox",
+			"msApproxBleed", "msApproxContribution", "cameraVisibleAlpha"
+		] :
+			GafferSceneUI.LightEditor.registerParameter(
+				"light", f"ri:light:{parameter}", "RenderMan",
+				columnName = parameter.replace( "ri:light:", "" )
+			)
+
 # Register generic light attributes
 for attributeName in [
 	"gl:visualiser:scale",


### PR DESCRIPTION
These are ordered to match the column order of the equivalent "ri:light" parameter registration in the Light Editor.

I diffed the 26.x and 27.x schemas and only the "cameraVisibleAlpha" parameter is new in 27.0. It only applies to DomeLight so I've registered that one last.
