### PR TITLE
SceneAlgo : Fix performance regression in `[option|attribute]History()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 -----
 
 - RenderMan : Fixed interactive edits to volume transforms.
+- Scene Editors : Fixed performance regression introduced in 1.6.15.0. This could significantly affect refresh times for certain scenes.
 
 1.6.17.0 (relative to 1.6.16.0)
 ========

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -36,6 +36,7 @@
 
 import imath
 import inspect
+import time
 import unittest
 
 import IECore
@@ -1716,6 +1717,56 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.__assertAttributeHistory( attributeHistory, [ 0, 0 ], deleteAttributes["out"], "/light", "gl:visualiser:scale", None, 1 )
 		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0 ], deleteAttributes["in"], "/light", "gl:visualiser:scale", IECore.FloatData( 2.0 ), 1 )
 		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0 ], testLight["out"], "/light", "gl:visualiser:scale", IECore.FloatData( 2.0 ), 0 )
+
+	def testAttributeHistoryScaling( self ) :
+
+		plane = GafferScene.Plane()
+
+		for nodeType in ( GafferScene.CustomAttributes, GafferScene.LocaliseAttributes, GafferScene.MergeScenes ) :
+
+			with self.subTest( nodeType = nodeType ) :
+
+				out = plane["out"]
+				nodes = []
+				for i in range( 0, 1000 ) :
+					nodes.append( nodeType() )
+					# Connect to `in` or `in[0]`.
+					next( GafferScene.ScenePlug.RecursiveInputRange( nodes[-1] ) ).setInput( out )
+					out = nodes[-1]["out"]
+
+				history = GafferScene.SceneAlgo.history( out["attributes"], "/plane" )
+				t = time.perf_counter()
+				GafferScene.SceneAlgo.attributeHistory( history, "scene:visible" )
+				# We actually expect this to return immediately - the limit of 1s
+				# is just in case we hit a CI machine under load. The bug this
+				# test case is protecting against meant that the test wouldn't return
+				# in any kind of practical time at all.
+				self.assertLess( time.perf_counter() - t, 1 )
+
+	def testOptionHistoryScaling( self ) :
+
+		plane = GafferScene.Plane()
+
+		for nodeType in ( GafferScene.CustomOptions, GafferScene.MergeScenes ) :
+
+			with self.subTest( nodeType = nodeType ) :
+
+				out = plane["out"]
+				nodes = []
+				for i in range( 0, 1000 ) :
+					nodes.append( nodeType() )
+					# Connect to `in` or `in[0]`.
+					next( GafferScene.ScenePlug.RecursiveInputRange( nodes[-1] ) ).setInput( out )
+					out = nodes[-1]["out"]
+
+				history = GafferScene.SceneAlgo.history( out["globals"] )
+				t = time.perf_counter()
+				GafferScene.SceneAlgo.optionHistory( history, "render:defaultRenderer" )
+				# We actually expect this to return immediately - the limit of 1s
+				# is just in case we hit a CI machine under load. The bug this
+				# test case is protecting against meant that the test wouldn't return
+				# in any kind of practical time at all.
+				self.assertLess( time.perf_counter() - t, 1 )
 
 	def testOptionHistory( self ) :
 

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -1241,7 +1241,7 @@ ShaderTweaks *SceneAlgo::shaderTweaks( const ScenePlug *scene, const ScenePlug::
 	{
 		History::ConstPtr h = history( scene->attributesPlug(), inheritancePath );
 		auto ah = attributeHistory( h.get(), attributeName );
-		if( ah && ah->attributeValue )
+		if( ah->attributeValue )
 		{
 			return shaderTweaksWalk( ah.get() );
 		}

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -699,39 +699,29 @@ void addLocaliseAttributesPredecessors( const SceneAlgo::History::Predecessors &
 {
 	// No need to check if the node is filtered to this location.
 	// Filtered or unfiltered, it's all the same : the predecessor
-	// we want is the most local one. i.e. the one with the longest
+	// we want is the most local one. i.e. the one with a value and
+	// the longest path. If none have a value, then we take the longest
 	// path.
 
-	int longestPath = -1;
+	using Priority = std::tuple<bool, int>;
+	Priority highestPriority = { false, -1 };
 	SceneAlgo::AttributeHistory::Ptr predecessor;
 	for( auto &h : source )
 	{
-		const auto &sourcePath = h->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
-		if( (int)sourcePath.size() <= longestPath )
-		{
-			continue;
-		}
 		auto p = attributeHistory( h.get(), destination->attributeName );
-		if( p && p->attributeValue )
+		const auto &sourcePath = h->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+		const Priority priority = { (bool)p->attributeValue, sourcePath.size() };
+		if( priority > highestPriority )
 		{
 			predecessor = p;
-			longestPath = sourcePath.size();
+			highestPriority = priority;
 		}
 	}
 
-	if( !predecessor )
+	if( predecessor )
 	{
-		if( !source.size() )
-		{
-			return;
-		}
-		// We didn't find a source with an attribute to localise. Add the first
-		// source as a predecessor so the history is not truncated.
-		predecessor = attributeHistory( source[0].get(), destination->attributeName );
+		destination->predecessors.push_back( predecessor );
 	}
-
-	assert( predecessor );
-	destination->predecessors.push_back( predecessor );
 }
 
 void addAttributeTweaksPredecessors( const AttributeTweaks *attributeTweaks, const SceneAlgo::History::Predecessors &source, SceneAlgo::AttributeHistory *destination )
@@ -771,25 +761,16 @@ void addMergeScenesPredecessors( const MergeScenes *mergeScenes, const SceneAlgo
 	for( auto &h : source )
 	{
 		auto p = attributeHistory( h.get(), destination->attributeName );
-		if( p && p->attributeValue )
+		if( !predecessor || p->attributeValue )
 		{
 			predecessor = p;
 		}
 	}
 
-	if( !predecessor )
+	if( predecessor )
 	{
-		if( !source.size() )
-		{
-			return;
-		}
-		// We didn't find a source with an attribute to merge. Add the first
-		// source as a predecessor so the history is not truncated.
-		predecessor = attributeHistory( source[0].get(), destination->attributeName );
+		destination->predecessors.push_back( predecessor );
 	}
-
-	assert( predecessor );
-	destination->predecessors.push_back( predecessor );
 }
 
 void addMergeScenesPredecessors( const MergeScenes *mergeScenes, const SceneAlgo::History::Predecessors &source, SceneAlgo::OptionHistory *destination )
@@ -801,25 +782,16 @@ void addMergeScenesPredecessors( const MergeScenes *mergeScenes, const SceneAlgo
 	for( auto &h : source )
 	{
 		auto p = optionHistory( h.get(), destination->optionName );
-		if( p && p->optionValue )
+		if( !predecessor || p->optionValue )
 		{
 			predecessor = p;
 		}
 	}
 
-	if( !predecessor )
+	if( predecessor )
 	{
-		if( !source.size() )
-		{
-			return;
-		}
-		// We didn't find a source with an option to merge. Add the first
-		// source as a predecessor so the history is not truncated.
-		predecessor = optionHistory( source[0].get(), destination->optionName );
+		destination->predecessors.push_back( predecessor );
 	}
-
-	assert( predecessor );
-	destination->predecessors.push_back( predecessor );
 }
 
 void addMergeScenesPredecessors( const MergeScenes *mergeScenes, const SceneAlgo::History::Predecessors &source, SceneAlgo::PrimitiveVariableHistory *destination )


### PR DESCRIPTION
This was introduced in https://github.com/GafferHQ/gaffer/commit/aff9fde767d6f09e692c4097b17bba1a057c19a0, where we made changes to ensure that we returned a history even for missing options or attributes. The problem was that the fallback to `source[0]` meant that we were visiting the first source twice when the option or attribute didn't exist. And that source would be visiting its first source twice. And so on - leading to a big exponential explosion where depth N in the history would be visited 2^N times.

The solution is simple - just take `source[0]` in the main iteration over sources, replacing it if we find a better candidate. This gets us back to the performance we had before.

There is some similar logic for `primitiveVariableHistory()`, but I haven't been able to trigger any pathological behaviour with it. I think this is because `primitiveVariableHistory()` still returns `nullptr` when a primitive doesn't exist, and we wouldn't hit the fallback in `addMergeScenesPredecessors()` unless we discovered a `NullObject`. I suspect that can be refactored to make more sense, but in the meantime I want to get these critical fixes into code review.