### PR TITLE
Improved processing of attributes/shaders in scene globals

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
 ------------
 
 - AttributeTweaks, AttributeVisualiser, ShaderAssignment, ShaderTweaks, ShuffleAttributes : Added `global` plug, to allow global attributes to be processed instead of using `filter` to process per-location attributes.
+- ShaderTweaks : Added tweaking of integrators, background shaders, atmosphere shaders and render pass shaders.
 - ArnoldShader : The `standard_volume` shader is now assigned via an `ai:volume` attribute instead of `ai:surface`. This matches volume assignments imported from USD, and means that Gaffer now exports materials to USD using the same convention.
 - InteractiveRender : Added `useVisibleSet` plug. When on, only the scene locations contained in the Visible Set will be rendered.
 - Application :

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Features
 Improvements
 ------------
 
+- AttributeTweaks, AttributeVisualiser, ShaderAssignment, ShaderTweaks, ShuffleAttributes : Added `global` plug, to allow global attributes to be processed instead of using `filter` to process per-location attributes.
 - ArnoldShader : The `standard_volume` shader is now assigned via an `ai:volume` attribute instead of `ai:surface`. This matches volume assignments imported from USD, and means that Gaffer now exports materials to USD using the same convention.
 - InteractiveRender : Added `useVisibleSet` plug. When on, only the scene locations contained in the Visible Set will be rendered.
 - Application :

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -51,6 +51,9 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::AttributeProcessor, AttributeProcessorTypeId, FilteredSceneProcessor );
 
+		Gaffer::BoolPlug *globalPlug();
+		const Gaffer::BoolPlug *globalPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
@@ -67,20 +70,22 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 		/// by `computeProcessedAttributes()`. Overrides must start by calling the base
 		/// class first, and return true if it returns true.
 		virtual bool affectsProcessedAttributes( const Gaffer::Plug *input ) const = 0;
-		/// Must be implemented by derived classes to do one of the following :
-		///
-		/// - Call `AttributeProcessor::hashProcessedAttributes()` and then append to the hash
-		///   with all plugs used in `computeProcessedAttributes()`.
-		/// - Assign `h = inPlug()->attributesPlug()->hash()` to signify that
-		///   `computeProcessedAttributes()` will pass through `inputAttributes`
-		///   unchanged.
-		virtual void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		/// Must be implemented by derived classes to form a hash representing the
+		/// work done by `computeProcessedAttributes()`. If `computeProcessedAttributes()`
+		/// will be a no-op, then `h` should be left unchanged.
+		virtual void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
 		/// Must be implemented by derived classes to return the processed attributes.
-		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const = 0;
+		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const = 0;
 
 	private :
 
 		void init();
+		void plugSet( Gaffer::Plug *plug );
+		void plugInputChanged( Gaffer::Plug *plug );
+		void updateInternalConnections();
+
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const final;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const final;
 
 		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const final;
 		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const final;
@@ -93,6 +98,8 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 		friend class ShaderAssignment;
 		friend class Attributes;
 		friend class AttributeVisualiser;
+
+		static size_t g_firstPlugIndex;
 
 };
 

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -77,6 +77,9 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 		/// Must be implemented by derived classes to return the processed attributes.
 		virtual IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const = 0;
 
+		/// Would be better as private and final, but needs to be protected so that it can be called by ShaderTweaks.
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+
 	private :
 
 		void init();
@@ -85,7 +88,6 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 		void updateInternalConnections();
 
 		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const final;
-		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const final;
 
 		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const final;
 		IECore::ConstCompoundObjectPtr computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const final;

--- a/include/GafferScene/AttributeTweaks.h
+++ b/include/GafferScene/AttributeTweaks.h
@@ -67,8 +67,8 @@ class GAFFERSCENE_API AttributeTweaks : public AttributeProcessor
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 		static size_t g_firstPlugIndex;
 };

--- a/include/GafferScene/AttributeVisualiser.h
+++ b/include/GafferScene/AttributeVisualiser.h
@@ -96,8 +96,8 @@ class GAFFERSCENE_API AttributeVisualiser : public AttributeProcessor
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/Attributes.h
+++ b/include/GafferScene/Attributes.h
@@ -58,13 +58,8 @@ class GAFFERSCENE_API Attributes : public AttributeProcessor
 		Gaffer::CompoundDataPlug *attributesPlug();
 		const Gaffer::CompoundDataPlug *attributesPlug() const;
 
-		Gaffer::BoolPlug *globalPlug();
-		const Gaffer::BoolPlug *globalPlug() const;
-
 		Gaffer::CompoundObjectPlug *extraAttributesPlug();
 		const Gaffer::CompoundObjectPlug *extraAttributesPlug() const;
-
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
 
@@ -72,18 +67,11 @@ class GAFFERSCENE_API Attributes : public AttributeProcessor
 		/// on `attribute:{rendererPrefix}:*` metadata registrations.
 		Attributes( const std::string &name, const std::string &rendererPrefix );
 
-		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
-
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
-
-		void plugSet( Gaffer::Plug *plug );
-		void plugInputChanged( Gaffer::Plug *plug );
-		void updateInternalConnections();
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/CollectTransforms.h
+++ b/include/GafferScene/CollectTransforms.h
@@ -81,8 +81,8 @@ class GAFFERSCENE_API CollectTransforms : public AttributeProcessor
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/LocaliseAttributes.h
+++ b/include/GafferScene/LocaliseAttributes.h
@@ -62,8 +62,8 @@ class GAFFERSCENE_API LocaliseAttributes : public AttributeProcessor
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/SetVisualiser.h
+++ b/include/GafferScene/SetVisualiser.h
@@ -89,8 +89,8 @@ class GAFFERSCENE_API SetVisualiser : public AttributeProcessor
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/ShaderAssignment.h
+++ b/include/GafferScene/ShaderAssignment.h
@@ -64,8 +64,8 @@ class GAFFERSCENE_API ShaderAssignment : public AttributeProcessor
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/include/GafferScene/ShaderTweaks.h
+++ b/include/GafferScene/ShaderTweaks.h
@@ -74,6 +74,9 @@ class GAFFERSCENE_API ShaderTweaks : public AttributeProcessor
 		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
+		// Overridden from AttributeProcessor so that we can tweak shaders stored as options as well as attributes.
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
+
 		static size_t g_firstPlugIndex;
 
 	private :

--- a/include/GafferScene/ShaderTweaks.h
+++ b/include/GafferScene/ShaderTweaks.h
@@ -71,8 +71,8 @@ class GAFFERSCENE_API ShaderTweaks : public AttributeProcessor
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/ShuffleAttributes.h
+++ b/include/GafferScene/ShuffleAttributes.h
@@ -59,8 +59,8 @@ class GAFFERSCENE_API ShuffleAttributes : public AttributeProcessor
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;
-		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+		void hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
 
 	private :
 

--- a/python/GafferSceneTest/CollectTransformsTest.py
+++ b/python/GafferSceneTest/CollectTransformsTest.py
@@ -147,6 +147,18 @@ parent["Transform"]["transform"]["translate"] = imath.V3f( i )
 		with context:
 			self.assertEqual( script["CollectTransforms"]["transforms"].getValue(), ref )
 
+	def testGlobal( self ) :
+
+		# We don't expect this to be exercised in practice because the `__global` plug
+		# is private, but check that we at least get sensible behaviour if it is
+		# turned on.
+
+		collect = GafferScene.CollectTransforms()
+		collect["attributes"].setValue( IECore.StringVectorData( [ "a" ] ) )
+		collect["__global"].setValue( True )
+
+		self.assertEqual( collect["out"].globalsHash(), collect["in"].globalsHash() )
+		self.assertEqual( collect["out"].globals(), collect["in"].globals() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -397,7 +397,8 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		attributes = GafferScene.CustomAttributes()
 		cs = GafferTest.CapturingSlot( attributes.plugDirtiedSignal() )
 
-		# Adding or removing an attribute should dirty `out.attributes`
+		# Adding or removing an attribute should dirty `out.attributes`,
+		# but not `out.globals`.
 
 		attributes["attributes"].addChild(
 			Gaffer.NameValuePlug( "test", 10, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
@@ -407,6 +408,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		del cs[:]
 		del attributes["attributes"][0]
 		self.assertIn( attributes["out"]["attributes"], { x[0] for x in cs } )
+		self.assertNotIn( attributes["out"]["globals"], { x[0] for x in cs } )
 
 		# And although the Dynamic flag is currently required for proper serialisation
 		# of CustomAttributes nodes, its absence shouldn't prevent dirty propagation.
@@ -415,10 +417,12 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		del cs[:]
 		attributes["attributes"].addChild( Gaffer.NameValuePlug( "test2", 10 ) )
 		self.assertIn( attributes["out"]["attributes"], { x[0] for x in cs } )
+		self.assertNotIn( attributes["out"]["globals"], { x[0] for x in cs } )
 
 		del cs[:]
 		del attributes["attributes"][0]
 		self.assertIn( attributes["out"]["attributes"], { x[0] for x in cs } )
+		self.assertNotIn( attributes["out"]["globals"], { x[0] for x in cs } )
 
 	def testGlobalsDirtyPropagation( self ) :
 
@@ -434,6 +438,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 		options["options"]["render:camera"]["enabled"].setValue( True )
 
 		self.assertIn( attributes["out"]["globals"], { x[0] for x in cs } )
+		self.assertNotIn( attributes["out"]["attributes"], { x[0] for x in cs } )
 		self.assertEqual( attributes["out"].globals(), IECore.CompoundObject( { "option:render:camera" : IECore.StringData( "" ) } ) )
 
 	def testLoadExtraAttributesFrom0_59( self ) :

--- a/python/GafferSceneTest/LocaliseAttributesTest.py
+++ b/python/GafferSceneTest/LocaliseAttributesTest.py
@@ -213,5 +213,23 @@ class LocaliseAttributesTest( GafferSceneTest.SceneTestCase ) :
 		localiseAttributes["attributes"].setValue( "x" )
 		self.assertIn( localiseAttributes["out"]["attributes"], { x[0] for x in cs } )
 
+	def testGlobal( self ) :
+
+		globalAttributes = GafferScene.StandardAttributes()
+		globalAttributes["global"].setValue( True )
+		globalAttributes["attributes"]["doubleSided"]["enabled"].setValue( True )
+
+		localiseAttributes = GafferScene.LocaliseAttributes()
+		localiseAttributes["in"].setInput( globalAttributes["out"] )
+		self.assertEqual( localiseAttributes["out"].globalsHash(), localiseAttributes["in"].globalsHash() )
+		self.assertEqual( localiseAttributes["out"].globals(), localiseAttributes["in"].globals() )
+
+		# The plug is private, so folks shouldn't turn it on. But if they do,
+		# they should get a well-behaved no-op.
+
+		localiseAttributes["__global"].setValue( True )
+		self.assertEqual( localiseAttributes["out"].globalsHash(), localiseAttributes["in"].globalsHash() )
+		self.assertEqual( localiseAttributes["out"].globals(), localiseAttributes["in"].globals() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -1164,6 +1164,37 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		assertShuffledHistory( "c", "c" )
 		assertShuffledHistory( None, "d" )
 
+	def testAttributeHistoryWithGlobalShuffleAttributes( self ) :
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		attributes = GafferScene.CustomAttributes()
+		attributes["in"].setInput( plane["out"] )
+		attributes["filter"].setInput( planeFilter["out"] )
+		attributes["attributes"].addChild( Gaffer.NameValuePlug( "a", "a_value" ) )
+		attributes["attributes"].addChild( Gaffer.NameValuePlug( "b", "b_value" ) )
+
+		shuffleAttributes = GafferScene.ShuffleAttributes()
+		shuffleAttributes["in"].setInput( attributes["out"] )
+		shuffleAttributes["filter"].setInput( planeFilter["out"] )
+		shuffleAttributes["global"].setValue( True ) # Overrides filter
+		shuffleAttributes["shuffles"].addChild( Gaffer.ShufflePlug( source = "a", destination = "b" ) )
+
+		# Not shuffled, because `shuffleAttributes` filtered to globals.
+		self.assertEqual( shuffleAttributes["out"].attributes( "/plane" )["b"].value, "b_value" )
+
+		# So shouldn't appear shuffled in history.
+		history = GafferScene.SceneAlgo.history( shuffleAttributes["out"]["attributes"], "/plane" )
+		attributeHistory = GafferScene.SceneAlgo.attributeHistory( history, "b" )
+		self.__assertAttributeHistory( attributeHistory, [], shuffleAttributes["out"], "/plane", "b", IECore.StringData( "b_value" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0 ], shuffleAttributes["in"], "/plane", "b", IECore.StringData( "b_value" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0 ], attributes["out"], "/plane", "b", IECore.StringData( "b_value" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0 ], attributes["in"], "/plane", "b", None, 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0 ], plane["out"], "/plane", "b", None, 0 )
+
 	def testAttributeHistoryWithMergeScenes( self ) :
 
 		#               plane                    sphere

--- a/python/GafferSceneTest/SetVisualiserTest.py
+++ b/python/GafferSceneTest/SetVisualiserTest.py
@@ -238,6 +238,17 @@ class SetVisualiserTest( GafferSceneTest.SceneTestCase ) :
 		visualiser["colorOverrides"].addChild( Gaffer.NameValuePlug( "setB", "notAColor", True, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
 		self.assertRaises( RuntimeError, visualiser["__outSets"].getValue )
 
+	def testGlobal( self ) :
+
+		# The `__global` plug is private so nobody should use it. But if
+		# they do, check we get sensible no-op behaviour.
+
+		visualiser = GafferScene.SetVisualiser()
+		visualiser["__global"].setValue( True )
+
+		self.assertEqual( visualiser["out"].globalsHash(), visualiser["in"].globalsHash() )
+		self.assertEqual( visualiser["out"].globals(), visualiser["in"].globals() )
+
 	__testSetNames = [ 'setA', 'setB', 'setC' ]
 
 	def __basicSphereScene( self ) :

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -99,6 +99,38 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 		t["shader"].setValue( "" )
 		self.assertScenesEqual( t["out"], l["out"] )
 
+	def testGlobal( self ) :
+
+		shader = GafferSceneTest.TestShader()
+		shader.loadShader( "simpleShader" )
+		shader["type"].setValue( "surface" )
+
+		shaderAssignment = GafferScene.ShaderAssignment()
+		shaderAssignment["shader"].setInput( shader["out"] )
+		shaderAssignment["global"].setValue( True )
+
+		self.assertIn( "attribute:surface", shaderAssignment["out"].globals() )
+		self.assertEqual( shaderAssignment["out"].globals()["attribute:surface"].outputShader().parameters["i"], IECore.IntData( 0 ) )
+
+		tweaks = GafferScene.ShaderTweaks()
+		tweaks["in"].setInput( shaderAssignment["out"] )
+		tweaks["global"].setValue( True )
+		tweaks["shader"].setValue( "surface" )
+
+		self.assertEqual( tweaks["out"].globalsHash(), tweaks["in"].globalsHash() )
+		self.assertEqual( tweaks["out"].globals(), tweaks["in"].globals() )
+
+		tweaks["tweaks"].addChild( Gaffer.TweakPlug( "i", 2 ) )
+		tweaks["tweaks"][0]["mode"].setValue( Gaffer.TweakPlug.Mode.Add )
+		self.assertNotEqual( tweaks["out"].globalsHash(), tweaks["in"].globalsHash() )
+		self.assertEqual( tweaks["out"].globals()["attribute:surface"].outputShader().parameters["i"], IECore.IntData( 2 ) )
+
+		shader["parameters"]["i"].setValue( 10 )
+		self.assertEqual( tweaks["out"].globals()["attribute:surface"].outputShader().parameters["i"], IECore.IntData( 12 ) )
+
+		tweaks["localise"].setValue( True ) # Nothing to localise, so should be same as before
+		self.assertEqual( tweaks["out"].globals()["attribute:surface"].outputShader().parameters["i"], IECore.IntData( 12 ) )
+
 	def testSerialisation( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -131,6 +131,32 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 		tweaks["localise"].setValue( True ) # Nothing to localise, so should be same as before
 		self.assertEqual( tweaks["out"].globals()["attribute:surface"].outputShader().parameters["i"], IECore.IntData( 12 ) )
 
+	def testOption( self ) :
+
+		shader = GafferSceneTest.TestShader()
+		shader.loadShader( "simpleShader" )
+
+		renderPassShader = GafferScene.RenderPassShader()
+		renderPassShader["shader"].setInput( shader["out"] )
+		renderPassShader["usage"].setValue( "shadowCatcher" )
+		renderPassShader["renderer"].setValue( "Cycles" )
+
+		self.assertIn( "option:renderPass:shader:shadowCatcher:Cycles", renderPassShader["out"].globals() )
+		self.assertEqual( renderPassShader["out"].globals()["option:renderPass:shader:shadowCatcher:Cycles"].outputShader().parameters["i"], IECore.IntData( 0 ) )
+
+		tweaks = GafferScene.ShaderTweaks()
+		tweaks["in"].setInput( renderPassShader["out"] )
+		tweaks["global"].setValue( True )
+		tweaks["shader"].setValue( "renderPass:shader:shadowCatcher:Cycles" )
+
+		self.assertEqual( tweaks["out"].globalsHash(), tweaks["in"].globalsHash() )
+		self.assertEqual( tweaks["out"].globals(), tweaks["in"].globals() )
+
+		tweaks["tweaks"].addChild( Gaffer.TweakPlug( "i", 2 ) )
+		tweaks["tweaks"][0]["mode"].setValue( Gaffer.TweakPlug.Mode.Add )
+		self.assertNotEqual( tweaks["out"].globalsHash(), tweaks["in"].globalsHash() )
+		self.assertEqual( tweaks["out"].globals()["option:renderPass:shader:shadowCatcher:Cycles"].outputShader().parameters["i"], IECore.IntData( 2 ) )
+
 	def testSerialisation( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferSceneUI/AttributeProcessorUI.py
+++ b/python/GafferSceneUI/AttributeProcessorUI.py
@@ -41,7 +41,7 @@ Gaffer.Metadata.registerNode(
 
 	GafferScene.AttributeProcessor,
 
-	"layout:activator:isNotGlobal", lambda node : not node["global"].getValue(),
+	"layout:activator:isNotGlobal", lambda node : "global" not in node or not node["global"].getValue(),
 
 	plugs = {
 

--- a/python/GafferSceneUI/AttributeProcessorUI.py
+++ b/python/GafferSceneUI/AttributeProcessorUI.py
@@ -1,0 +1,69 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.AttributeProcessor,
+
+	"layout:activator:isNotGlobal", lambda node : not node["global"].getValue(),
+
+	plugs = {
+
+		"global" : {
+
+			"description" :
+			"""
+			Causes the node to be applied to the scene globals
+			instead of the individual locations defined by the `filter`.
+			""",
+
+			"layout:section" : "Filter",
+			"layout:index" : -4,
+
+		},
+
+		"filter" : {
+
+			"layout:activator" : "isNotGlobal",
+
+		},
+
+	}
+
+)

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -61,7 +61,11 @@ Gaffer.Metadata.registerNode(
 			inherited from ancestors or the scene globals. Attributes will be
 			localised to locations matching the node's filter prior to tweaking.
 			The original inherited attributes will remain untouched.
-			"""
+
+			> Note : Has no effect when `global` is on.
+			""",
+
+			"layout:activator" : "isNotGlobal",
 
 		},
 

--- a/python/GafferSceneUI/AttributesUI.py
+++ b/python/GafferSceneUI/AttributesUI.py
@@ -122,18 +122,6 @@ Gaffer.Metadata.registerNode(
 
 		},
 
-		"global" : {
-
-			"description" :
-			"""
-			Causes the attributes to be applied to the scene globals
-			instead of the individual locations defined by the filter.
-			""",
-
-			"layout:section" : "Filter",
-
-		},
-
 		"filter" : {
 
 			"layout:activator" : "isNotGlobal",

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -95,9 +95,13 @@ Gaffer.Metadata.registerNode(
 			shaders. Shaders will be localised to locations matching the
 			node's filter prior to tweaking. The original inherited shader will
 			remain untouched.
+
+			> Note : Has no effect when `global` is on.
 			""",
 
-			"layout:index" : 1
+			"layout:index" : 1,
+			"layout:activator" : "isNotGlobal",
+
 		},
 
 		"ignoreMissing" : {

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -215,6 +215,7 @@ from . import CameraQueryUI
 from . import ReflectionConstraintUI
 from . import CurvesInterpolationUI
 from . import MeshLightUI
+from . import AttributeProcessorUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -1596,6 +1596,55 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		inspection = self.__inspect( s["assign"]["out"], "/cube", ( "srf", "b" ), attribute = "test:surface" )
 		self.assertEqual( connectionSource( inspection.value() ), ( "", "" ) )
 
+	def testSourceIgnoresGlobaShaderTweaks( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["light"] = GafferSceneTest.TestLight()
+		script["light"].loadShader( "simpleLight" )
+
+		script["bogusFilter"] = GafferScene.PathFilter()
+		script["bogusFilter"]["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		script["shaderTweaks"] = GafferScene.ShaderTweaks()
+		script["shaderTweaks"]["in"].setInput( script["light"]["out"] )
+		script["shaderTweaks"]["filter"].setInput( script["bogusFilter"]["out"] )
+		script["shaderTweaks"]["global"].setValue( True )
+		script["shaderTweaks"]["tweaks"].addChild( Gaffer.TweakPlug( "exposure", 10 ) )
+
+		inspection = self.__inspect( script["shaderTweaks"]["out"], "/light", "exposure" )
+		self.assertEqual( inspection.source(), script["light"]["parameters"]["exposure"] )
+
+	def testSourceIgnoresGlobalShaderAssignment( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["cube"] = GafferScene.Cube()
+
+		script["localShader"] = GafferSceneTest.TestShader()
+		script["localShader"].loadShader( "simpleShader" )
+		script["localShader"]["type"].setValue( "test:surface" )
+
+		script["globalShader"] = GafferSceneTest.TestShader()
+		script["globalShader"].loadShader( "simpleShader" )
+		script["globalShader"]["type"].setValue( "test:surface" )
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		script["localAssignment"] = GafferScene.ShaderAssignment()
+		script["localAssignment"]["in"].setInput( script["cube"]["out"] )
+		script["localAssignment"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["localAssignment"]["shader"].setInput( script["localShader"]["out"] )
+
+		script["globalAssignment"] = GafferScene.ShaderAssignment()
+		script["globalAssignment"]["in"].setInput( script["localAssignment"]["out"] )
+		script["globalAssignment"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["globalAssignment"]["global"].setValue( True )
+		script["globalAssignment"]["shader"].setInput( script["globalShader"]["out"] )
+
+		inspection = self.__inspect( script["globalAssignment"]["out"], "/cube", "c", attribute="test:surface" )
+		self.assertEqual( inspection.source(), script["localShader"]["parameters"]["c"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/AttributeProcessor.cpp
+++ b/src/GafferScene/AttributeProcessor.cpp
@@ -36,11 +36,26 @@
 
 #include "GafferScene/AttributeProcessor.h"
 
+#include "Gaffer/PlugAlgo.h"
+
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/bind.hpp"
+#include "boost/logic/tribool.hpp"
+
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 
+namespace
+{
+
+const std::string g_attributePrefix( "attribute:" );
+
+} // namespace
+
 GAFFER_NODE_DEFINE_TYPE( AttributeProcessor );
+
+size_t AttributeProcessor::g_firstPlugIndex = 0;
 
 AttributeProcessor::AttributeProcessor( const std::string &name, IECore::PathMatcher::Result filterDefault )
 	:	FilteredSceneProcessor( name, filterDefault )
@@ -61,6 +76,9 @@ AttributeProcessor::AttributeProcessor( const std::string &name, size_t minInput
 
 void AttributeProcessor::init()
 {
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new BoolPlug( "global", Plug::In, false ) );
+
 	// Fast pass-throughs for things we don't modify
 	for( auto &p : Plug::Range( *outPlug() ) )
 	{
@@ -69,38 +87,173 @@ void AttributeProcessor::init()
 			p->setInput( inPlug()->getChild<Plug>( p->getName() ) );
 		}
 	}
+
+	// Connect to signals we use to manage pass-throughs for globals
+	// and attributes based on the value of `globalPlug()`.
+	plugSetSignal().connect( boost::bind( &AttributeProcessor::plugSet, this, ::_1 ) );
+	plugInputChangedSignal().connect( boost::bind( &AttributeProcessor::plugInputChanged, this, ::_1 ) );
 }
 
 AttributeProcessor::~AttributeProcessor()
 {
 }
 
+Gaffer::BoolPlug *AttributeProcessor::globalPlug()
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::BoolPlug *AttributeProcessor::globalPlug() const
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
+}
+
 void AttributeProcessor::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	FilteredSceneProcessor::affects( input, outputs );
 
-	if( affectsProcessedAttributes( input ) )
+	if(
+		input == globalPlug() ||
+		input == filterPlug() ||
+		input == inPlug()->attributesPlug() ||
+		affectsProcessedAttributes( input )
+	)
 	{
-		outputs.push_back( outPlug()->attributesPlug() );
+		// We can only affect a particular output if we haven't
+		// connected it as a pass-through in `updateInternalConnections()`.
+		if( !outPlug()->attributesPlug()->getInput() )
+		{
+			outputs.push_back( outPlug()->attributesPlug() );
+		}
+	}
+
+	if(
+		input == globalPlug() ||
+		input == inPlug()->globalsPlug() ||
+		affectsProcessedAttributes( input )
+	)
+	{
+		// See above.
+		if( !outPlug()->globalsPlug()->getInput() )
+		{
+			outputs.push_back( outPlug()->globalsPlug() );
+		}
 	}
 }
 
 bool AttributeProcessor::affectsProcessedAttributes( const Gaffer::Plug *input ) const
 {
-	return input == filterPlug() || input == inPlug()->attributesPlug();
+	return false;
 }
 
-void AttributeProcessor::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void AttributeProcessor::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	FilteredSceneProcessor::hashAttributes( path, context, outPlug(), h );
-	inPlug()->attributesPlug()->hash( h );
+}
+
+void AttributeProcessor::plugSet( Gaffer::Plug *plug )
+{
+	if( plug == globalPlug() )
+	{
+		updateInternalConnections();
+	}
+}
+
+void AttributeProcessor::plugInputChanged( Gaffer::Plug *plug )
+{
+	if( plug == globalPlug() )
+	{
+		updateInternalConnections();
+	}
+}
+
+void AttributeProcessor::updateInternalConnections()
+{
+	// Manage internal pass-throughs based on the value of the `globalPlug()`.
+	boost::tribool global;
+	if( PlugAlgo::dependsOnCompute( globalPlug() ) )
+	{
+		// Can vary from compute to compute.
+		global = boost::indeterminate;
+	}
+	else
+	{
+		global = globalPlug()->getValue();
+	}
+
+	outPlug()->globalsPlug()->setInput(
+		global || boost::indeterminate( global ) ? nullptr : inPlug()->globalsPlug()
+	);
+	outPlug()->attributesPlug()->setInput(
+		!global || boost::indeterminate( global ) ? nullptr : inPlug()->attributesPlug()
+	);
+}
+
+void AttributeProcessor::hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	MurmurHash processedAttributesHash;
+	if( globalPlug()->getValue() )
+	{
+		hashProcessedAttributes( context, processedAttributesHash );
+	}
+
+	if( processedAttributesHash != MurmurHash() )
+	{
+		FilteredSceneProcessor::hashGlobals( context, parent, h );
+		inPlug()->globalsPlug()->hash( h );
+		h.append( processedAttributesHash );
+	}
+	else
+	{
+		// We won't modify the globals - pass through the hash.
+		h = inPlug()->globalsPlug()->hash();
+	}
+}
+
+IECore::ConstCompoundObjectPtr AttributeProcessor::computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	ConstCompoundObjectPtr inputGlobals = inPlug()->globalsPlug()->getValue();
+	if( !globalPlug()->getValue() )
+	{
+		return inputGlobals;
+	}
+
+	IECore::CompoundObjectPtr result = new CompoundObject;
+	IECore::CompoundObjectPtr attributesToProcess = new CompoundObject;
+
+	for( const auto &[name, value] : inputGlobals->members() )
+	{
+		if( boost::starts_with( name.string(), g_attributePrefix ) )
+		{
+			attributesToProcess->members()[name.string().substr( g_attributePrefix.size())] = value;
+		}
+		else
+		{
+			result->members()[name] = value;
+		}
+	}
+
+	IECore::ConstCompoundObjectPtr processedAttributes = computeProcessedAttributes( context, attributesToProcess.get() );
+	for( const auto &[name, value] : processedAttributes->members() )
+	{
+		result->members()[g_attributePrefix+name.string()] = value;
+	}
+
+	return result;
 }
 
 void AttributeProcessor::hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	if( filterValue( context ) & IECore::PathMatcher::ExactMatch )
+	MurmurHash processedAttributesHash;
+	if( !globalPlug()->getValue() && ( filterValue( context ) & IECore::PathMatcher::ExactMatch ) )
 	{
-		hashProcessedAttributes( path, context, h );
+		hashProcessedAttributes( context, processedAttributesHash );
+	}
+
+	if( processedAttributesHash != MurmurHash() )
+	{
+		FilteredSceneProcessor::hashAttributes( path, context, parent, h );
+		inPlug()->attributesPlug()->hash( h );
+		h.append( processedAttributesHash );
 	}
 	else
 	{
@@ -111,10 +264,10 @@ void AttributeProcessor::hashAttributes( const ScenePath &path, const Gaffer::Co
 
 IECore::ConstCompoundObjectPtr AttributeProcessor::computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	if( filterValue( context ) & IECore::PathMatcher::ExactMatch )
+	if( !globalPlug()->getValue() && ( filterValue( context ) & IECore::PathMatcher::ExactMatch ) )
 	{
 		ConstCompoundObjectPtr inputAttributes = inPlug()->attributesPlug()->getValue();
-		return computeProcessedAttributes( path, context, inputAttributes.get() );
+		return computeProcessedAttributes( context, inputAttributes.get() );
 	}
 	else
 	{

--- a/src/GafferScene/AttributeTweaks.cpp
+++ b/src/GafferScene/AttributeTweaks.cpp
@@ -108,28 +108,29 @@ bool AttributeTweaks::affectsProcessedAttributes( const Gaffer::Plug *input) con
 	;
 }
 
-void AttributeTweaks::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void AttributeTweaks::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( tweaksPlug()->children().empty() )
 	{
-		h = inPlug()->attributesPlug()->hash();
+		return;
 	}
-	else
+
+	AttributeProcessor::hashProcessedAttributes( context, h );
+	localisePlug()->hash( h );
+
+	if( localisePlug()->getValue() )
 	{
-		AttributeProcessor::hashProcessedAttributes( path, context, h );
-		localisePlug()->hash( h );
-
-		if( localisePlug()->getValue() )
+		if( auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
 		{
-			h.append( inPlug()->fullAttributesHash( path, /* withGlobalAttributes = */ true ) );
+			h.append( inPlug()->fullAttributesHash( *path, /* withGlobalAttributes = */ true ) );
 		}
-
-		ignoreMissingPlug()->hash( h );
-		tweaksPlug()->hash( h );
 	}
+
+	ignoreMissingPlug()->hash( h );
+	tweaksPlug()->hash( h );
 }
 
-IECore::ConstCompoundObjectPtr AttributeTweaks::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr AttributeTweaks::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	const TweaksPlug *tweaksPlug = this->tweaksPlug();
 	if( tweaksPlug->children().empty() )
@@ -150,8 +151,11 @@ IECore::ConstCompoundObjectPtr AttributeTweaks::computeProcessedAttributes( cons
 	ConstCompoundObjectPtr fullAttributes;
 	if( localisePlug()->getValue() )
 	{
-		fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ true );
-		source = fullAttributes.get();
+		if( auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
+		{
+			fullAttributes = inPlug()->fullAttributes( *path, /* withGlobalAttributes = */ true );
+			source = fullAttributes.get();
+		}
 	}
 
 	tweaksPlug->applyTweaks(

--- a/src/GafferScene/AttributeVisualiser.cpp
+++ b/src/GafferScene/AttributeVisualiser.cpp
@@ -175,9 +175,9 @@ bool AttributeVisualiser::affectsProcessedAttributes( const Gaffer::Plug *input 
 	;
 }
 
-void AttributeVisualiser::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void AttributeVisualiser::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	AttributeProcessor::hashProcessedAttributes( path, context, h );
+	AttributeProcessor::hashProcessedAttributes( context, h );
 	attributeNamePlug()->hash( h );
 	modePlug()->hash( h );
 	minPlug()->hash( h );
@@ -188,7 +188,7 @@ void AttributeVisualiser::hashProcessedAttributes( const ScenePath &path, const 
 	shaderParameterPlug()->hash( h );
 }
 
-IECore::ConstCompoundObjectPtr AttributeVisualiser::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr AttributeVisualiser::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	const std::string attributeName = attributeNamePlug()->getValue();
 	if( !attributeName.size() )

--- a/src/GafferScene/Attributes.cpp
+++ b/src/GafferScene/Attributes.cpp
@@ -67,13 +67,7 @@ Attributes::Attributes( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new CompoundDataPlug( "attributes" ) );
-	addChild( new BoolPlug( "global", Plug::In, false ) );
 	addChild( new CompoundObjectPlug( "extraAttributes", Plug::In, new IECore::CompoundObject ) );
-
-	// Connect to signals we use to manage pass-throughs for globals
-	// and attributes based on the value of globalPlug().
-	plugSetSignal().connect( boost::bind( &Attributes::plugSet, this, ::_1 ) );
-	plugInputChangedSignal().connect( boost::bind( &Attributes::plugInputChanged, this, ::_1 ) );
 }
 
 
@@ -106,139 +100,41 @@ const Gaffer::CompoundDataPlug *Attributes::attributesPlug() const
 	return getChild<Gaffer::CompoundDataPlug>( g_firstPlugIndex );
 }
 
-Gaffer::BoolPlug *Attributes::globalPlug()
-{
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
-}
-
-const Gaffer::BoolPlug *Attributes::globalPlug() const
-{
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
-}
-
 Gaffer::CompoundObjectPlug *Attributes::extraAttributesPlug()
 {
-	return getChild<Gaffer::CompoundObjectPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::CompoundObjectPlug>( g_firstPlugIndex + 1 );
 }
 
 const Gaffer::CompoundObjectPlug *Attributes::extraAttributesPlug() const
 {
-	return getChild<Gaffer::CompoundObjectPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::CompoundObjectPlug>( g_firstPlugIndex + 1 );
 }
-
-void Attributes::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
-{
-	AttributeProcessor::affects( input, outputs );
-
-	if(
-		input == globalPlug() ||
-		input == inPlug()->globalsPlug() ||
-		attributesPlug()->isAncestorOf( input ) ||
-		input == extraAttributesPlug()
-	)
-	{
-		// We can only affect a particular output if we haven't
-		// connected it as a pass-through in updateInternalConnections().
-		if( !outPlug()->globalsPlug()->getInput() )
-		{
-			outputs.push_back( outPlug()->globalsPlug() );
-		}
-	}
-
-}
-
-void Attributes::hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
-{
-	if( globalPlug()->getValue() )
-	{
-		// We will modify the globals.
-		AttributeProcessor::hashGlobals( context, parent, h );
-		inPlug()->globalsPlug()->hash( h );
-		attributesPlug()->hash( h );
-		extraAttributesPlug()->hash( h );
-	}
-	else
-	{
-		// We won't modify the globals - pass through the hash.
-		h = inPlug()->globalsPlug()->hash();
-	}
-}
-
-IECore::ConstCompoundObjectPtr Attributes::computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const
-{
-	ConstCompoundObjectPtr inputGlobals = inPlug()->globalsPlug()->getValue();
-	if( !globalPlug()->getValue() )
-	{
-		return inputGlobals;
-	}
-
-	const CompoundDataPlug *p = attributesPlug();
-	IECore::CompoundObjectPtr result = new CompoundObject;
-	// Since we're not going to modify any existing members (only add new ones),
-	// and our result becomes const on returning it, we can directly reference
-	// the input members in our result without copying. Be careful not to modify
-	// them though!
-	result->members() = inputGlobals->members();
-
-	std::string name;
-	for( NameValuePlug::Iterator it( p ); !it.done(); ++it )
-	{
-		IECore::DataPtr d = p->memberDataAndName( it->get(), name );
-		if( d )
-		{
-			result->members()["attribute:" + name] = d;
-		}
-	}
-
-	IECore::ConstCompoundObjectPtr extraAttributes = extraAttributesPlug()->getValue();
-	for( const auto &e : extraAttributes->members() )
-	{
-		result->members()["attribute:" + e.first.string()] = e.second;
-	}
-
-	return result;
-}
-
 bool Attributes::affectsProcessedAttributes( const Gaffer::Plug *input ) const
 {
-	if( outPlug()->attributesPlug()->getInput() )
-	{
-		// We've made a pass-through connection
-		return false;
-	}
-
 	return
 		AttributeProcessor::affectsProcessedAttributes( input ) ||
 		attributesPlug()->isAncestorOf( input ) ||
-		input == globalPlug() ||
 		input == extraAttributesPlug()
 	;
 }
 
-void Attributes::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Attributes::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	if( ( attributesPlug()->children().empty() && extraAttributesPlug()->isSetToDefault() ) || globalPlug()->getValue() )
+	if( !attributesPlug()->children().size() && extraAttributesPlug()->isSetToDefault() )
 	{
-		h = inPlug()->attributesPlug()->hash();
+		return;
 	}
-	else
-	{
-		AttributeProcessor::hashProcessedAttributes( path, context, h );
-		attributesPlug()->hash( h );
-		extraAttributesPlug()->hash( h );
-	}
+
+	AttributeProcessor::hashProcessedAttributes( context, h );
+	attributesPlug()->hash( h );
+	extraAttributesPlug()->hash( h );
 }
 
-IECore::ConstCompoundObjectPtr Attributes::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr Attributes::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	const CompoundDataPlug *ap = attributesPlug();
 	IECore::ConstCompoundObjectPtr extraAttributes = extraAttributesPlug()->getValue();
 	if( !ap->children().size() && extraAttributes->members().empty() )
-	{
-		return inputAttributes;
-	}
-
-	if( globalPlug()->getValue() )
 	{
 		return inputAttributes;
 	}
@@ -257,43 +153,4 @@ IECore::ConstCompoundObjectPtr Attributes::computeProcessedAttributes( const Sce
 	}
 
 	return result;
-}
-
-void Attributes::plugSet( Gaffer::Plug *plug )
-{
-	if( plug == globalPlug() )
-	{
-		updateInternalConnections();
-	}
-}
-
-void Attributes::plugInputChanged( Gaffer::Plug *plug )
-{
-	if( plug == globalPlug() )
-	{
-		updateInternalConnections();
-	}
-}
-
-void Attributes::updateInternalConnections()
-{
-	// Manage internal pass-throughs based on the value of the globalPlug().
-	const Plug *p = globalPlug()->source<Gaffer::Plug>();
-	boost::tribool global;
-	if( p->direction() == Plug::Out && runTimeCast<const ComputeNode>( p->node() ) )
-	{
-		// Can vary from compute to compute.
-		global = boost::indeterminate;
-	}
-	else
-	{
-		global = globalPlug()->getValue();
-	}
-
-	outPlug()->globalsPlug()->setInput(
-		global || boost::indeterminate( global ) ? nullptr : inPlug()->globalsPlug()
-	);
-	outPlug()->attributesPlug()->setInput(
-		!global || boost::indeterminate( global ) ? nullptr : inPlug()->attributesPlug()
-	);
 }

--- a/src/GafferScene/CollectTransforms.cpp
+++ b/src/GafferScene/CollectTransforms.cpp
@@ -310,22 +310,19 @@ bool CollectTransforms::affectsProcessedAttributes( const Gaffer::Plug *input ) 
 	return AttributeProcessor::affectsProcessedAttributes( input ) || input == transformsPlug();
 }
 
-void CollectTransforms::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void CollectTransforms::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	IECore::MurmurHash transformsHash = transformsPlug()->hash();
 	if( transformsHash == g_emptyCompoundHash )
 	{
-		h = inPlug()->attributesPlug()->hash();
+		return;
 	}
-	else
-	{
-		AttributeProcessor::hashProcessedAttributes( path, context, h );
-		h.append( transformsHash );
-	}
+
+	AttributeProcessor::hashProcessedAttributes( context, h );
+	h.append( transformsHash );
 }
 
-
-IECore::ConstCompoundObjectPtr CollectTransforms::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr CollectTransforms::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	IECore::ConstCompoundObjectPtr collectedTransforms = transformsPlug()->getValue();
 	if( collectedTransforms->members().size() == 0 )

--- a/src/GafferScene/CollectTransforms.cpp
+++ b/src/GafferScene/CollectTransforms.cpp
@@ -72,6 +72,10 @@ CollectTransforms::CollectTransforms( const std::string &name )
 	addChild( new BoolPlug( "requireVariation", Plug::In, false ) );
 
 	addChild( new CompoundObjectPlug( "transforms", Plug::Out, new CompoundObject() ) );
+
+	// Hide `global` plug, since collecting transforms makes no sense unless
+	// `scene:path` is defined.
+	globalPlug()->setName( "__global" );
 }
 
 CollectTransforms::~CollectTransforms()

--- a/src/GafferScene/LocaliseAttributes.cpp
+++ b/src/GafferScene/LocaliseAttributes.cpp
@@ -87,15 +87,22 @@ bool LocaliseAttributes::affectsProcessedAttributes( const Gaffer::Plug *input )
 	;
 }
 
-void LocaliseAttributes::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void LocaliseAttributes::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	AttributeProcessor::hashProcessedAttributes( path, context, h );
-	h.append( inPlug()->fullAttributesHash( path, /* withGlobalAttributes = */ includeGlobalAttributesPlug()->getValue() ) );
+	auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	if( !path )
+	{
+		// Processing global attributes, where localisation is a no-op.
+		return;
+	}
+
+	AttributeProcessor::hashProcessedAttributes( context, h );
+	h.append( inPlug()->fullAttributesHash( *path, /* withGlobalAttributes = */ includeGlobalAttributesPlug()->getValue() ) );
 	includeGlobalAttributesPlug()->hash( h );
 	attributesPlug()->hash( h );
 }
 
-IECore::ConstCompoundObjectPtr LocaliseAttributes::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr LocaliseAttributes::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	const string attributes = attributesPlug()->getValue();
 	if( attributes.empty() )
@@ -106,6 +113,7 @@ IECore::ConstCompoundObjectPtr LocaliseAttributes::computeProcessedAttributes( c
 	CompoundObjectPtr result = new CompoundObject;
 	result->members() = inputAttributes->members();
 
+	const auto &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
 	ConstCompoundObjectPtr fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ includeGlobalAttributesPlug()->getValue() );
 	for( const auto &attribute : fullAttributes->members() )
 	{

--- a/src/GafferScene/LocaliseAttributes.cpp
+++ b/src/GafferScene/LocaliseAttributes.cpp
@@ -51,6 +51,8 @@ LocaliseAttributes::LocaliseAttributes( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "attributes", Plug::In, "*" ) );
 	addChild( new BoolPlug( "includeGlobalAttributes", Plug::In, false ) );
+	// Hide `global` plug, since localising global attributes is a no-op.
+	globalPlug()->setName( "__global" );
 }
 
 LocaliseAttributes::~LocaliseAttributes()
@@ -104,6 +106,13 @@ void LocaliseAttributes::hashProcessedAttributes( const Gaffer::Context *context
 
 IECore::ConstCompoundObjectPtr LocaliseAttributes::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
+	auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	if( !path )
+	{
+		// Processing global attributes.
+		return inputAttributes;
+	}
+
 	const string attributes = attributesPlug()->getValue();
 	if( attributes.empty() )
 	{
@@ -113,8 +122,7 @@ IECore::ConstCompoundObjectPtr LocaliseAttributes::computeProcessedAttributes( c
 	CompoundObjectPtr result = new CompoundObject;
 	result->members() = inputAttributes->members();
 
-	const auto &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
-	ConstCompoundObjectPtr fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ includeGlobalAttributesPlug()->getValue() );
+	ConstCompoundObjectPtr fullAttributes = inPlug()->fullAttributes( *path, /* withGlobalAttributes = */ includeGlobalAttributesPlug()->getValue() );
 	for( const auto &attribute : fullAttributes->members() )
 	{
 		if( StringAlgo::matchMultiple( attribute.first, attributes ) )

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -679,7 +679,7 @@ void addShuffleAttributesPredecessors( const ShuffleAttributes *shuffleAttribute
 	// has come from.
 
 	InternedString sourceAttributeName = destination->attributeName;
-	if( shuffleAttributes->filterPlug()->match( shuffleAttributes->inPlug() ) & PathMatcher::ExactMatch )
+	if( !shuffleAttributes->globalPlug()->getValue() && ( shuffleAttributes->filterPlug()->match( shuffleAttributes->inPlug() ) & PathMatcher::ExactMatch ) )
 	{
 		auto inputAttributes = shuffleAttributes->inPlug()->attributesPlug()->getValue();
 		map<InternedString, InternedString> shuffledNames;

--- a/src/GafferScene/SetVisualiser.cpp
+++ b/src/GafferScene/SetVisualiser.cpp
@@ -331,9 +331,16 @@ bool SetVisualiser::affectsProcessedAttributes( const Gaffer::Plug *input ) cons
 	;
 }
 
-void SetVisualiser::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, MurmurHash &h ) const
+void SetVisualiser::hashProcessedAttributes( const Gaffer::Context *context, MurmurHash &h ) const
 {
-	AttributeProcessor::hashProcessedAttributes( path, context, h );
+	auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	if( !path )
+	{
+		// Processing global attributes, where set visualisation makes no sense.
+		return;
+	}
+
+	AttributeProcessor::hashProcessedAttributes( context, h );
 
 	ConstCompoundDataPtr outSetsData = outSetsPlug()->getValue();
 
@@ -349,11 +356,12 @@ void SetVisualiser::hashProcessedAttributes( const ScenePath &path, const Gaffer
 		h.append( inPlug()->setHash( setName ) );
 	}
 
+	const auto &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
 	h.append( path.data(), path.size() );
 	stripeWidthPlug()->hash( h );
 }
 
-ConstCompoundObjectPtr SetVisualiser::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+ConstCompoundObjectPtr SetVisualiser::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	CompoundObjectPtr result = new CompoundObject;
 
@@ -380,6 +388,7 @@ ConstCompoundObjectPtr SetVisualiser::computeProcessedAttributes( const ScenePat
 	for( auto &setName : setNamesData->readable() )
 	{
 		const PathMatcherData *pathMatchData = targetSets->member<const PathMatcherData>( setName );
+		const auto &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
 		if( pathMatchData->readable().match( path ) & matchResult )
 		{
 			shaderColors.push_back( setColorsData->readable()[ index ] );

--- a/src/GafferScene/SetVisualiser.cpp
+++ b/src/GafferScene/SetVisualiser.cpp
@@ -181,6 +181,10 @@ SetVisualiser::SetVisualiser( const std::string &name )
 
 	addChild( new CompoundDataPlug( "colorOverrides", Plug::In ) );
 	addChild( new AtomicCompoundDataPlug( "__outSets", Plug::Out, new CompoundData() ) );
+
+	// Hide `global` plug, since visualising sets makes no sense
+	// unless `scene:path` is defined.
+	globalPlug()->setName( "__global" );
 }
 
 SetVisualiser::~SetVisualiser()
@@ -356,13 +360,19 @@ void SetVisualiser::hashProcessedAttributes( const Gaffer::Context *context, Mur
 		h.append( inPlug()->setHash( setName ) );
 	}
 
-	const auto &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
-	h.append( path.data(), path.size() );
+	h.append( path->data(), path->size() );
 	stripeWidthPlug()->hash( h );
 }
 
 ConstCompoundObjectPtr SetVisualiser::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
+	auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	if( !path )
+	{
+		// Processing global attributes, where set visualisation makes no sense.
+		return inputAttributes;
+	}
+
 	CompoundObjectPtr result = new CompoundObject;
 
 	// Since we're not going to modify any existing members (only add a new one),
@@ -388,8 +398,7 @@ ConstCompoundObjectPtr SetVisualiser::computeProcessedAttributes( const Gaffer::
 	for( auto &setName : setNamesData->readable() )
 	{
 		const PathMatcherData *pathMatchData = targetSets->member<const PathMatcherData>( setName );
-		const auto &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
-		if( pathMatchData->readable().match( path ) & matchResult )
+		if( pathMatchData->readable().match( *path ) & matchResult )
 		{
 			shaderColors.push_back( setColorsData->readable()[ index ] );
 		}

--- a/src/GafferScene/ShaderAssignment.cpp
+++ b/src/GafferScene/ShaderAssignment.cpp
@@ -1,3 +1,4 @@
+
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2012, John Haddon. All rights reserved.
@@ -97,14 +98,14 @@ bool ShaderAssignment::affectsProcessedAttributes( const Gaffer::Plug *input ) c
 	return AttributeProcessor::affectsProcessedAttributes( input ) || input == shaderPlug() || input == labelPlug();
 }
 
-void ShaderAssignment::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void ShaderAssignment::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	AttributeProcessor::hashProcessedAttributes( path, context, h );
+	AttributeProcessor::hashProcessedAttributes( context, h );
 	h.append( shaderPlug()->attributesHash() );
 	labelPlug()->hash( h );
 }
 
-IECore::ConstCompoundObjectPtr ShaderAssignment::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr ShaderAssignment::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	ConstCompoundObjectPtr attributes = shaderPlug()->attributes();
 

--- a/src/GafferScene/ShaderTweaks.cpp
+++ b/src/GafferScene/ShaderTweaks.cpp
@@ -467,37 +467,39 @@ bool ShaderTweaks::affectsProcessedAttributes( const Gaffer::Plug *input ) const
 	;
 }
 
-void ShaderTweaks::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void ShaderTweaks::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( tweaksPlug()->children().empty() )
 	{
-		h = inPlug()->attributesPlug()->hash();
+		return;
 	}
-	else
+
+	AttributeProcessor::hashProcessedAttributes( context, h );
+
+	shaderPlug()->hash( h );
+	tweaksPlug()->hash( h );
+	ignoreMissingPlug()->hash( h );
+	localisePlug()->hash( h );
+
+	for( auto &tweak : TweakPlug::Range( *tweaksPlug() ) )
 	{
-		AttributeProcessor::hashProcessedAttributes( path, context, h );
-		shaderPlug()->hash( h );
-		tweaksPlug()->hash( h );
-		ignoreMissingPlug()->hash( h );
-		localisePlug()->hash( h );
-
-		for( auto &tweak : TweakPlug::Range( *tweaksPlug() ) )
+		const auto shaderOutput = ::shaderOutput( tweak.get() );
+		if( shaderOutput.first )
 		{
-			const auto shaderOutput = ::shaderOutput( tweak.get() );
-			if( shaderOutput.first )
-			{
-				shaderOutput.first->attributesHash( shaderOutput.second, h );
-			}
+			shaderOutput.first->attributesHash( shaderOutput.second, h );
 		}
+	}
 
-		if( localisePlug()->getValue() )
+	if( localisePlug()->getValue() )
+	{
+		if( auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
 		{
-			h.append( inPlug()->fullAttributesHash( path, /* withGlobalAttributes = */ true ) );
+			h.append( inPlug()->fullAttributesHash( *path, /* withGlobalAttributes = */ true ) );
 		}
 	}
 }
 
-IECore::ConstCompoundObjectPtr ShaderTweaks::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr ShaderTweaks::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	const string shader = shaderPlug()->getValue();
 	if( shader.empty() )
@@ -526,8 +528,11 @@ IECore::ConstCompoundObjectPtr ShaderTweaks::computeProcessedAttributes( const S
 	ConstCompoundObjectPtr fullAttributes;
 	if( localisePlug()->getValue() )
 	{
-		fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ true );
-		source = &fullAttributes->members();
+		if( auto path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
+		{
+			fullAttributes = inPlug()->fullAttributes( *path, /* withGlobalAttributes = */ true );
+			source = &fullAttributes->members();
+		}
 	}
 
 	for( const auto &attribute : *source )

--- a/src/GafferScene/ShaderTweaks.cpp
+++ b/src/GafferScene/ShaderTweaks.cpp
@@ -52,6 +52,8 @@
 #include "IECore/TypeTraits.h"
 #include "IECore/DataAlgo.h"
 
+#include "boost/algorithm/string/predicate.hpp"
+
 #include "fmt/format.h"
 
 #include <regex>
@@ -395,6 +397,8 @@ IECore::InternedString regexSubMatchToInterned( const std::ssub_match &subMatch 
 	return IECore::InternedString( &( *subMatch.first ), subMatch.length() );
 }
 
+const std::string g_optionPrefix( "option:" );
+
 }  // namespace
 
 GAFFER_NODE_DEFINE_TYPE( ShaderTweaks );
@@ -553,6 +557,37 @@ IECore::ConstCompoundObjectPtr ShaderTweaks::computeProcessedAttributes( const G
 		{
 			out[attribute.first] = tweakedNetwork;
 		}
+	}
+
+	return result;
+}
+
+IECore::ConstCompoundObjectPtr ShaderTweaks::computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	// This will have tweaks to `attribute:*` globals applied already.
+	ConstCompoundObjectPtr inputGlobals = AttributeProcessor::computeGlobals( context, parent );
+
+	// Now we want to add tweaks to `option:*` globals as well.
+
+	IECore::CompoundObjectPtr result = new CompoundObject;
+	IECore::CompoundObjectPtr optionsToProcess = new CompoundObject;
+
+	for( const auto &[name, value] : inputGlobals->members() )
+	{
+		if( boost::starts_with( name.string(), g_optionPrefix ) )
+		{
+			optionsToProcess->members()[name.string().substr( g_optionPrefix.size())] = value;
+		}
+		else
+		{
+			result->members()[name] = value;
+		}
+	}
+
+	IECore::ConstCompoundObjectPtr processedOptions = computeProcessedAttributes( context, optionsToProcess.get() );
+	for( const auto &[name, value] : processedOptions->members() )
+	{
+		result->members()[g_optionPrefix+name.string()] = value;
 	}
 
 	return result;

--- a/src/GafferScene/ShuffleAttributes.cpp
+++ b/src/GafferScene/ShuffleAttributes.cpp
@@ -70,20 +70,18 @@ bool ShuffleAttributes::affectsProcessedAttributes( const Gaffer::Plug *input ) 
 	return AttributeProcessor::affectsProcessedAttributes( input ) || shufflesPlug()->isAncestorOf( input );
 }
 
-void ShuffleAttributes::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void ShuffleAttributes::hashProcessedAttributes( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( shufflesPlug()->children().empty() )
 	{
-		h = inPlug()->attributesPlug()->hash();
+		return;
 	}
-	else
-	{
-		AttributeProcessor::hashProcessedAttributes( path, context, h );
-		shufflesPlug()->hash( h );
-	}
+
+	AttributeProcessor::hashProcessedAttributes( context, h );
+	shufflesPlug()->hash( h );
 }
 
-IECore::ConstCompoundObjectPtr ShuffleAttributes::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+IECore::ConstCompoundObjectPtr ShuffleAttributes::computeProcessedAttributes( const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
 	if( shufflesPlug()->children().empty() || inputAttributes->members().empty() )
 	{

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -332,7 +332,7 @@ Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::H
 
 	else if( auto attributeTweaks = runTimeCast<AttributeTweaks>( sceneNode ) )
 	{
-		if( !( attributeTweaks->filterPlug()->match( attributeTweaks->inPlug() ) & PathMatcher::ExactMatch ) )
+		if( attributeTweaks->globalPlug()->getValue() || !( attributeTweaks->filterPlug()->match( attributeTweaks->inPlug() ) & PathMatcher::ExactMatch ) )
 		{
 			return nullptr;
 		}

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -190,7 +190,7 @@ Gaffer::ValuePlugPtr ParameterInspector::source( const GafferScene::SceneAlgo::H
 	}
 	else if( auto shaderAssignment = runTimeCast<ShaderAssignment>( sceneNode ) )
 	{
-		if( !(shaderAssignment->filterPlug()->match( shaderAssignment->inPlug() ) & PathMatcher::ExactMatch) )
+		if( shaderAssignment->globalPlug()->getValue() || !(shaderAssignment->filterPlug()->match( shaderAssignment->inPlug() ) & PathMatcher::ExactMatch) )
 		{
 			return nullptr;
 		}
@@ -210,7 +210,7 @@ Gaffer::ValuePlugPtr ParameterInspector::source( const GafferScene::SceneAlgo::H
 	}
 	else if( auto shaderTweaks = runTimeCast<ShaderTweaks>( sceneNode ) )
 	{
-		if( !(shaderTweaks->filterPlug()->match( shaderTweaks->inPlug() ) & PathMatcher::ExactMatch) )
+		if( shaderTweaks->globalPlug()->getValue() || !(shaderTweaks->filterPlug()->match( shaderTweaks->inPlug() ) & PathMatcher::ExactMatch) )
 		{
 			return nullptr;
 		}

--- a/startup/gui/shaderPresets.py
+++ b/startup/gui/shaderPresets.py
@@ -52,14 +52,16 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	__registerShaderPresets( [
 
-		( "Arnold Surface", "ai:surface" ),
-		( "Arnold Displacement", "ai:disp_map" ),
-		( "Arnold Volume", "ai:volume" ),
-		( "Arnold Light", "ai:light" ),
-		( "Arnold Gobo", "ai:lightFilter:gobo" ),
-		( "Arnold Decay", "ai:lightFilter:light_decay" ),
-		( "Arnold Barndoor", "ai:lightFilter:barndoor" ),
-		( "Arnold Blocker", "ai:lightFilter:filter" )
+		( "Arnold/Surface", "ai:surface" ),
+		( "Arnold/Displacement", "ai:disp_map" ),
+		( "Arnold/Volume", "ai:volume" ),
+		( "Arnold/Light", "ai:light" ),
+		( "Arnold/Gobo", "ai:lightFilter:gobo" ),
+		( "Arnold/Decay", "ai:lightFilter:light_decay" ),
+		( "Arnold/Barndoor", "ai:lightFilter:barndoor" ),
+		( "Arnold/Blocker", "ai:lightFilter:filter" ),
+		( "Arnold/Atmosphere", "ai:atmosphere" ),
+		( "Arnold/Background", "ai:background" )
 
 	] )
 
@@ -70,8 +72,9 @@ if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "
 		import GafferCycles
 
 		__registerShaderPresets( [
-			( "Cycles Surface", "cycles:surface" ),
-			( "Cycles Light", "cycles:light" ),
+			( "Cycles/Surface", "cycles:surface" ),
+			( "Cycles/Light", "cycles:light" ),
+			( "Cycles/Background", "cycles:background" ),
 		] )
 
 with IECore.IgnoredExceptions( ImportError ) :
@@ -80,8 +83,8 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	__registerShaderPresets( [
 
-		( "OSL Surface", "osl:surface" ),
-		( "OSL Light", "osl:light" ),
+		( "OSL/Surface", "osl:surface" ),
+		( "OSL/Light", "osl:light" ),
 
 	] )
 
@@ -93,16 +96,17 @@ if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
 
 		__registerShaderPresets( [
 
-			( "RenderMan Surface", "ri:surface" ),
-			( "RenderMan Light", "ri:light" ),
-			( "RenderMan Light Filter", "ri:lightFilter" ),
+			( "RenderMan/Surface", "ri:surface" ),
+			( "RenderMan/Light", "ri:light" ),
+			( "RenderMan/Light Filter", "ri:lightFilter" ),
+			( "RenderMan/Integrator", "ri:integrator" ),
 
 		] )
 
 __registerShaderPresets( [
 
-		( "OpenGL Surface", "gl:surface" ),
-		( "USD Surface", "surface" ),
-		( "USD Light", "light" ),
+		( "OpenGL/Surface", "gl:surface" ),
+		( "USD/Surface", "surface" ),
+		( "USD/Light", "light" ),
 
 	] )


### PR DESCRIPTION
This originated with a request to use ShaderTweaks to tweak RenderMan integrators. So I [added a `global` plug](https://github.com/GafferHQ/gaffer/commit/86100d4ecebc2a5c49c38a6793cdbf692bb07315) to the AttributeProcessor base class, convinced that would do the trick, and benefit several other nodes too. Then I realised that the integrator is actually an option (doh!) rather than an attribute, so I extended ShaderTweaks to [support those too](https://github.com/GafferHQ/gaffer/commit/a232794e722675e621a6b03205c4d7a5dc69cda8). A little messier than I'd hoped, but still pretty worthwhile I think.