### PR TITLE
CI : Update to GafferHQ/dependencies 11.0.0a8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
             testRunner: sudo -E -u testUser
             sconsCacheMegabytes: 400
             jobs: 4
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a9/cortex-10.7.0.0a9-linux-platform24.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a10/cortex-10.7.0.0a10-linux-platform24.tar.gz
             extraBuildArguments: CYCLES_ROOT=""
 
           - name: windows

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/11.0.0a6/gafferDependencies-11.0.0a6-{platform}-{vfxPlatform}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/11.0.0a8/gafferDependencies-11.0.0a8-{platform}-{vfxPlatform}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -113,24 +113,28 @@ Build
 -----
 
 - Boost : Updated to version 1.85.0.
-- Cortex : Updated to version 10.7.0.0a9.
+- Cortex : Updated to version 10.7.0.0a10.
 - Cycles : Updated to version 5.1.0.
 - Embree : Updated to version 4.4.0.
 - Imath : Updated to version 3.1.12.
 - Jemalloc : Removed when building on macOS.
 - LLVM : Updated to version 17.0.6.
+- MaterialX : Updated to version 1.39.4.
+- Nanobind : Added version 2.12.0.
 - OpenColorIO :
   - Updated to version 2.4.2.
   - Added ACES 2.0 configs.
 - OpenEXR : Updated to version 3.3.6.
 - OpenShadingLanguage : Updated to version 1.14.8.0.
 - OpenSubdiv : Updated to version 3.6.1.
+- OpenVDB : Updated to version 12.1.1.
 - PySide : Updated to version 6.5.8.
 - Python : Updated to version 3.11.14.
 - Qt : Updated to version 6.5.8.
+- Robin-map : Added version 1.4.1.
 - SSE2NEON : Added version 1.9.1 when building on macOS.
 - TBB : Updated to version 2021.13.0.
-- USD : Updated to version 26.03.
+- USD : Updated to version 26.05.
 
 1.6.x.x (relative to 1.6.18.0)
 =======

--- a/python/GafferVDB/__init__.py
+++ b/python/GafferVDB/__init__.py
@@ -36,15 +36,6 @@
 
 __import__( "GafferScene" )
 
-import warnings
-
-# the first import of pyopenvdb results in a duplicate c++ -> python
-# boost python type conversions warnings.
-# we use the warnings module to suppress these during the import
-with warnings.catch_warnings():
-	warnings.simplefilter("ignore")
-	import pyopenvdb
-
 from ._GafferVDB import *
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferVDB" )


### PR DESCRIPTION
This updates `main` to USD 26.05, with MaterialX 1.39.4 and PyBind11 2.13.6. 