### PR TITLE
Cycles : Fix crash when rendering primitives with missing `P`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -45,6 +45,7 @@ Fixes
   - Reduced memory usage when rendering a single segment of deformation blur.
   - Fixed PointsPrimitive motion blur when rendering with even numbers of segments.
   - Fixed translation of Uniform `N` primitive variables, these are now resampled to FaceVarying.
+  - Fixed crashes when rendering primitives with missing `P` primitive variables (#6267).
 - USDShader : Fixed value of `type` plug after loading a USDLux light.
 - CyclesLight, ArnoldLight, LightFilter : Fixed potential hang when loading shaders (GIL management bug in `loadShader()` binding).
 - StandardNodeGadget : Fixed crash caused by the node emitting `errorSignal()` while the gadget is undergoing construction.

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -3104,5 +3104,43 @@ class RendererTest( GafferTest.TestCase ) :
 					del object
 					del renderer
 
+	def testPointlessPrimitives( self ) :
+
+		pointlessMesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		del pointlessMesh["P"]
+
+		for primitive in (
+			pointlessMesh,
+			IECoreScene.PointsPrimitive( 10 ),
+			IECoreScene.CurvesPrimitive( IECore.IntVectorData( [ 4 ] ) ),
+		) :
+			primitiveType = primitive.typeName()
+
+			for withSamples in ( False, True ) :
+
+				with self.subTest( primitiveType = primitiveType, withSamples = withSamples ) :
+
+					renderer = self.createRenderer( GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive )
+
+					with IECore.CapturingMessageHandler() as mh :
+
+						if withSamples :
+							objectInterface = renderer.object(
+								"/pointless", [ primitive, primitive ], [ 0, 1 ],
+								renderer.attributes( IECore.CompoundObject() )
+							)
+						else :
+							objectInterface = renderer.object(
+								"/pointless", primitive,
+								renderer.attributes( IECore.CompoundObject() )
+							)
+
+						self.assertEqual( len( mh.messages ), 1 )
+						self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
+						self.assertEqual( mh.messages[0].message, f'{primitiveType} does not have "P" primitive variable of interpolation type Vertex.' )
+
+					del objectInterface
+					del renderer
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
@@ -60,6 +60,14 @@ namespace
 ccl::Hair *convertPrimary( const IECoreScene::CurvesPrimitive *curve, ccl::Scene *scene )
 {
 	assert( curve->typeId() == IECoreScene::CurvesPrimitive::staticTypeId() );
+
+	const V3fVectorData *p = curve->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
+	if( !p )
+	{
+		msg( Msg::Warning, "IECoreCyles::CurvesAlgo", "CurvesPrimitive does not have \"P\" primitive variable of interpolation type Vertex." );
+		return nullptr;
+	}
+
 	ccl::Hair *hair = SceneAlgo::createNodeWithLock<ccl::Hair>( scene );
 	/// \todo Support per-object `curve_shape` configured via an attribute.
 	hair->curve_shape = scene->params.hair_shape;
@@ -75,7 +83,6 @@ ccl::Hair *convertPrimary( const IECoreScene::CurvesPrimitive *curve, ccl::Scene
 
 	hair->reserve_curves( numCurves, numKeys );
 
-	const V3fVectorData *p = curve->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
 	const vector<Imath::V3f> &points = p->readable();
 
 	if( const FloatVectorData *w = curve->variableData<FloatVectorData>( "width", PrimitiveVariable::Vertex ) )
@@ -145,9 +152,13 @@ ccl::Hair *convertPrimary( const IECoreScene::CurvesPrimitive *curve, ccl::Scene
 
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::CurvesPrimitive *> &curves, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::Hair *result = convertPrimary( curves[primarySampleIndex], scene );
-	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( curves ), primarySampleIndex, *result );
-	return result;
+	if( ccl::Hair *result = convertPrimary( curves[primarySampleIndex], scene ) )
+	{
+		GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( curves ), primarySampleIndex, *result );
+		return result;
+	}
+
+	return nullptr;
 }
 
 GeometryAlgo::ConverterDescription<CurvesPrimitive> g_description( convert );

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -62,21 +62,6 @@ using namespace IECoreScene;
 // Internal utilities
 //////////////////////////////////////////////////////////////////////////
 
-namespace std
-{
-
-/// \todo Move to IECore/TypeIds.h
-template<>
-struct hash<IECore::TypeId>
-{
-	size_t operator()( IECore::TypeId typeId ) const
-	{
-		return hash<size_t>()( typeId );
-	}
-};
-
-} // namespace std
-
 namespace
 {
 

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -96,6 +96,13 @@ ccl::Mesh *convertPrimary( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *s
 {
 	assert( mesh->typeId() == IECoreScene::MeshPrimitive::staticTypeId() );
 
+	const V3fVectorData *p = mesh->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
+	if( !p )
+	{
+		msg( Msg::Warning, "IECoreCyles::MeshAlgo", "MeshPrimitive does not have \"P\" primitive variable of interpolation type Vertex." );
+		return nullptr;
+	}
+
 	// Triangulate if necessary
 
 	ConstMeshPrimitivePtr triangulatedMesh;
@@ -109,7 +116,6 @@ ccl::Mesh *convertPrimary( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *s
 	// Convert topology and points
 
 	const size_t numFaces = mesh->numFaces();
-	const V3fVectorData *p = mesh->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
 	const vector<Imath::V3f> &points = p->readable();
 	const vector<int> &vertexIds = mesh->vertexIds()->readable();
 	const size_t numVerts = points.size();
@@ -233,9 +239,13 @@ ccl::Mesh *convertPrimary( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *s
 
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::MeshPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::Mesh *result = convertPrimary( samples[primarySampleIndex], scene );
-	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
-	return result;
+	if( ccl::Mesh *result = convertPrimary( samples[primarySampleIndex], scene ) )
+	{
+		GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
+		return result;
+	}
+
+	return nullptr;
 }
 
 GeometryAlgo::ConverterDescription<MeshPrimitive> g_description( convert );

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -108,23 +108,22 @@ ccl::Mesh *convertPrimary( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *s
 
 	// Convert topology and points
 
+	const size_t numFaces = mesh->numFaces();
+	const V3fVectorData *p = mesh->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
+	const vector<Imath::V3f> &points = p->readable();
+	const vector<int> &vertexIds = mesh->vertexIds()->readable();
+	const size_t numVerts = points.size();
+
 	ccl::Mesh *cmesh = SceneAlgo::createNodeWithLock<ccl::Mesh>( scene );
+	cmesh->reserve_mesh( numVerts, numFaces );
+	for( size_t i = 0; i < numVerts; i++ )
+	{
+		cmesh->add_vertex( ccl::make_float3( points[i].x, points[i].y, points[i].z ) );
+	}
 
 	if( mesh->interpolation() == "catmullClark" )
 	{
 		cmesh->set_subdivision_type( ccl::Mesh::SUBDIVISION_CATMULL_CLARK );
-
-		const size_t numFaces = mesh->numFaces();
-		const V3fVectorData *p = mesh->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
-		const vector<Imath::V3f> &points = p->readable();
-		const vector<int> &vertexIds = mesh->vertexIds()->readable();
-		const size_t numVerts = points.size();
-
-		cmesh->reserve_mesh( numVerts, numFaces );
-		for( size_t i = 0; i < numVerts; i++ )
-		{
-			cmesh->add_vertex( ccl::make_float3( points[i].x, points[i].y, points[i].z ) );
-		}
 
 		const std::vector<int> &vertsPerFace = mesh->verticesPerFace()->readable();
 		size_t ncorners = 0;
@@ -180,19 +179,6 @@ ccl::Mesh *convertPrimary( const IECoreScene::MeshPrimitive *mesh, ccl::Scene *s
 	}
 	else
 	{
-		const V3fVectorData *p = mesh->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
-		const vector<Imath::V3f> &points = p->readable();
-		const size_t numVerts = points.size();
-		const std::vector<int> &vertexIds = mesh->vertexIds()->readable();
-
-		const size_t numFaces = mesh->numFaces();
-		cmesh->reserve_mesh( numVerts, numFaces );
-
-		for( size_t i = 0; i < numVerts; i++ )
-		{
-			cmesh->add_vertex( ccl::make_float3( points[i].x, points[i].y, points[i].z ) );
-		}
-
 		const bool smooth = hasSmoothNormals( mesh );
 		for( size_t i = 0; i < vertexIds.size(); i+= 3 )
 		{

--- a/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
@@ -61,6 +61,14 @@ namespace
 ccl::PointCloud *convertPrimary( const IECoreScene::PointsPrimitive *points, ccl::Scene *scene )
 {
 	assert( points->typeId() == IECoreScene::PointsPrimitive::staticTypeId() );
+
+	const V3fVectorData *p = points->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
+	if( !p )
+	{
+		msg( Msg::Warning, "IECoreCyles::PointsAlgo", "PointsPrimitive does not have \"P\" primitive variable of interpolation type Vertex." );
+		return nullptr;
+	}
+
 	ccl::PointCloud *pointcloud = SceneAlgo::createNodeWithLock<ccl::PointCloud>( scene );
 
 	PrimitiveVariableMap variablesToConvert = points->variables;
@@ -68,7 +76,6 @@ ccl::PointCloud *convertPrimary( const IECoreScene::PointsPrimitive *points, ccl
 	size_t numPoints = points->getNumPoints();
 	pointcloud->reserve( numPoints );
 
-	const V3fVectorData *p = points->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
 	const vector<Imath::V3f> &pos = p->readable();
 
 	if( const FloatVectorData *w = points->variableData<FloatVectorData>( "width", PrimitiveVariable::Vertex ) )
@@ -139,9 +146,13 @@ ccl::PointCloud *convertPrimary( const IECoreScene::PointsPrimitive *points, ccl
 
 ccl::Geometry *convert( const IECoreScenePreview::Renderer::Samples<const IECoreScene::PointsPrimitive *> &samples, const IECoreScenePreview::Renderer::SampleTimes &times, size_t primarySampleIndex, ccl::Scene *scene )
 {
-	ccl::PointCloud *result = convertPrimary( samples[primarySampleIndex], scene );
-	GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
-	return result;
+	if( ccl::PointCloud *result = convertPrimary( samples[primarySampleIndex], scene ) )
+	{
+		GeometryAlgo::convertMotion( IECoreScenePreview::Renderer::staticSamplesCast<const IECoreScene::Primitive *>( samples ), primarySampleIndex, *result );
+		return result;
+	}
+
+	return nullptr;
 }
 
 GeometryAlgo::ConverterDescription<PointsPrimitive> g_description( convert );


### PR DESCRIPTION
Fixes #6267.