### PR TITLE
CurvesTangents : Add new node for computing tangents on a curve

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Features
 - CurvesPrimitive : Added `Pinned` wrap mode in addition to the existing `Periodic` and `NonPeriodic` modes. This conveniently interpolates CatmullRom
 and BSpline curves to their endpoints automatically, without manual management of duplicate endpoints or "phantom vertices".
 - CurvesInterpolation : Added node for modifying CurvesPrimitive `basis` and `wrap`. This includes the ability to convert curves with `Pinned` wrap to `NonPeriodic`, adding the appropriate "phantom" points to maintain curve shape.
+- CurvesTangents : Added node for computing tangents on CurvesPrimitives (#6166).
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@ Features
 --------
 
 - Cycles : Updated to version 5.1.0.
+- CurvesPrimitive : Added `Pinned` wrap mode in addition to the existing `Periodic` and `NonPeriodic` modes. This conveniently interpolates CatmullRom
+and BSpline curves to their endpoints automatically, without manual management of duplicate endpoints or "phantom vertices".
 - CurvesInterpolation : Added node for modifying CurvesPrimitive `basis` and `wrap`. This includes the ability to convert curves with `Pinned` wrap to `NonPeriodic`, adding the appropriate "phantom" points to maintain curve shape.
 
 Improvements
@@ -23,8 +25,6 @@ Improvements
 - CyclesOptions : Added `cycles:integrator:volume_ray_marching` option.
 - LightEditor : Added column for `cycles:visibility:camera` attribute.
 - OpenColorIO : Added ACES Studio 2.0 config. The default config is still ACES 1.3, due to RenderMan not supporting ACES 2.0.
-- CurvesPrimitive : Added `Pinned` wrap mode in addition to the existing `Periodic` and `NonPeriodic` modes. This conveniently interpolates CatmullRom
-and BSpline curves to their endpoints automatically, without manual management of duplicate endpoints or "phantom vertices".
 - SceneReader, SceneWriter : Added support for pinned UsdGeomBasisCurves.
 - OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.
 - ArnoldMeshLight, RenderManMeshLight : Added support for deformation motion blur (#6869). In the case of RenderMan, this only affects the camera-visible mesh, since RenderMan doesn't yet support deformation for the light itself.

--- a/include/GafferScene/CurvesTangents.h
+++ b/include/GafferScene/CurvesTangents.h
@@ -1,0 +1,90 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/ObjectProcessor.h"
+
+#include "Gaffer/StringPlug.h"
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API CurvesTangents : public ObjectProcessor
+{
+
+	public :
+
+		explicit CurvesTangents( const std::string &name=defaultName<CurvesTangents>() );
+		~CurvesTangents() override;
+
+		enum class Mode
+		{
+			FirstDifference,
+			CentralDifference,
+			Derivative
+		};
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
+
+		Gaffer::BoolPlug *normalizePlug();
+		const Gaffer::BoolPlug *normalizePlug() const;
+
+		Gaffer::StringPlug *positionPlug();
+		const Gaffer::StringPlug *positionPlug() const;
+
+		Gaffer::StringPlug *tangentPlug();
+		const Gaffer::StringPlug *tangentPlug() const;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::CurvesTangents, CurvesTangentsTypeId, ObjectProcessor );
+
+	protected :
+
+		Gaffer::ValuePlug::CachePolicy processedObjectComputeCachePolicy() const override;
+		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( CurvesTangents )
+
+} // namespace GafferScene

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -198,6 +198,7 @@ enum TypeId
 	ReflectionConstraintTypeId = 120153,
 	CurvesInterpolationTypeId = 120154,
 	MeshLightTypeId = 120155,
+	CurvesTangentsTypeId = 120156,
 
 	LastTypeId = 120999
 };

--- a/python/GafferSceneTest/CurvesTangentsTest.py
+++ b/python/GafferSceneTest/CurvesTangentsTest.py
@@ -1,0 +1,309 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+import GafferTest
+
+class CurvesTangentsTest( GafferSceneTest.SceneTestCase ) :
+
+	def testFirstDifference( self ) :
+
+		Wrap = IECoreScene.CurvesPrimitive.Wrap
+		for wrap, expectedTangents in [
+			( Wrap.NonPeriodic, [ imath.V3f( 2, 0, 0 ), imath.V3f( -1, 1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( 0, 1, 0 ) ] ),
+			( Wrap.Periodic, [ imath.V3f( 2, 0, 0 ), imath.V3f( -1, 1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( -1, -2, 0 ) ] ),
+		] :
+
+			with self.subTest( wrap = wrap ) :
+
+				curves = IECoreScene.CurvesPrimitive(
+					IECore.IntVectorData( [ 4 ] ),
+					IECore.CubicBasisf.linear(), wrap,
+					IECore.V3fVectorData( [
+						imath.V3f( 0, 0, 0 ), imath.V3f( 2, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 1, 2, 0 ),
+					] )
+				)
+
+				objectToScene = GafferScene.ObjectToScene()
+				objectToScene["object"].setValue( curves )
+
+				objectFilter = GafferScene.PathFilter()
+				objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+				node = GafferScene.CurvesTangents()
+				node["in"].setInput( objectToScene["out"] )
+				node["filter"].setInput( objectFilter["out"] )
+				node["mode"].setValue( node.Mode.FirstDifference )
+
+				tangents = node["out"].object( "/object" )["tangent"]
+				self.assertEqual( tangents.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+				self.assertEqual( list( tangents.data ), expectedTangents )
+				self.assertEqual( tangents.data.getInterpretation(), IECore.GeometricData.Interpretation.Vector )
+
+				node["normalize"].setValue( True )
+				tangents = node["out"].object( "/object" )["tangent"]
+				self.assertEqual( list( tangents.data ), [ t.normalized() for t in expectedTangents ] )
+
+	def testCentralDifference( self ) :
+
+		Wrap = IECoreScene.CurvesPrimitive.Wrap
+		for wrap, expectedTangents in [
+			( Wrap.NonPeriodic, [ imath.V3f( 2, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( -1, 2, 0 ), imath.V3f( 0, 1, 0 ) ] ),
+			( Wrap.Periodic, [ imath.V3f( 1, -2, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( -1, 2, 0 ), imath.V3f( -1, -1, 0 ) ] ),
+		] :
+
+			with self.subTest( wrap = wrap ) :
+
+				curves = IECoreScene.CurvesPrimitive(
+					IECore.IntVectorData( [ 4 ] ),
+					IECore.CubicBasisf.linear(), wrap,
+					IECore.V3fVectorData( [
+						imath.V3f( 0, 0, 0 ), imath.V3f( 2, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 1, 2, 0 ),
+					] )
+				)
+
+				objectToScene = GafferScene.ObjectToScene()
+				objectToScene["object"].setValue( curves )
+
+				objectFilter = GafferScene.PathFilter()
+				objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+				node = GafferScene.CurvesTangents()
+				node["in"].setInput( objectToScene["out"] )
+				node["filter"].setInput( objectFilter["out"] )
+				node["mode"].setValue( node.Mode.CentralDifference )
+
+				tangents = node["out"].object( "/object" )["tangent"]
+				self.assertEqual( tangents.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+				self.assertEqual( list( tangents.data ), expectedTangents )
+				self.assertEqual( tangents.data.getInterpretation(), IECore.GeometricData.Interpretation.Vector )
+
+				node["normalize"].setValue( True )
+				tangents = node["out"].object( "/object" )["tangent"]
+				self.assertEqual( list( tangents.data ), [ t.normalized() for t in expectedTangents ] )
+
+	def testDerivative( self ) :
+
+		Wrap = IECoreScene.CurvesPrimitive.Wrap
+		for wrap, expectedTangents in [
+			( Wrap.Pinned, [ imath.V3f( 2, 0, 0 ), imath.V3f( 0.5, 0.5, 0 ), imath.V3f( -0.5, 1, 0 ), imath.V3f( 0, 1, 0 ) ] ),
+			( Wrap.NonPeriodic, [ imath.V3f( 0.5, 0.5, 0 ), imath.V3f( -0.5, 1, 0 ) ] ),
+			( Wrap.Periodic, [ imath.V3f( 0.5, -1, 0 ), imath.V3f( 0.5, 0.5, 0 ), imath.V3f( -0.5, 1, 0 ), imath.V3f( -0.5, -0.5, 0 ) ] ),
+		] :
+
+			with self.subTest( wrap = wrap ) :
+
+				curves = IECoreScene.CurvesPrimitive(
+					IECore.IntVectorData( [ 4 ] ),
+					IECore.CubicBasisf.catmullRom(), wrap,
+					IECore.V3fVectorData( [
+						imath.V3f( 0, 0, 0 ), imath.V3f( 2, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 1, 2, 0 ),
+					] )
+				)
+
+				objectToScene = GafferScene.ObjectToScene()
+				objectToScene["object"].setValue( curves )
+
+				objectFilter = GafferScene.PathFilter()
+				objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+				node = GafferScene.CurvesTangents()
+				node["in"].setInput( objectToScene["out"] )
+				node["filter"].setInput( objectFilter["out"] )
+				node["mode"].setValue( node.Mode.Derivative )
+
+				self.assertTrue( node["out"].object( "/object" ).arePrimitiveVariablesValid() )
+
+				tangents = node["out"].object( "/object" )["tangent"]
+				self.assertEqual( tangents.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+				self.assertEqual( list( tangents.data ), expectedTangents )
+				self.assertEqual( tangents.data.getInterpretation(), IECore.GeometricData.Interpretation.Vector )
+
+				node["normalize"].setValue( True )
+				tangents = node["out"].object( "/object" )["tangent"]
+				self.assertEqual( list( tangents.data ), [ t.normalized() for t in expectedTangents ] )
+
+	def testDerivativeOnLinearCurves( self ) :
+
+		curves = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 4 ] ),
+			IECore.CubicBasisf.linear(), IECoreScene.CurvesPrimitive.Wrap.NonPeriodic,
+			IECore.V3fVectorData( [
+				imath.V3f( 0, 0, 0 ), imath.V3f( 2, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 1, 2, 0 ),
+			] )
+		)
+
+		objectToScene = GafferScene.ObjectToScene()
+		objectToScene["object"].setValue( curves )
+
+		objectFilter = GafferScene.PathFilter()
+		objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+		node = GafferScene.CurvesTangents()
+		node["in"].setInput( objectToScene["out"] )
+		node["filter"].setInput( objectFilter["out"] )
+		node["mode"].setValue( node.Mode.Derivative )
+
+		self.assertTrue( node["out"].object( "/object" ).arePrimitiveVariablesValid() )
+
+		tangents = node["out"].object( "/object" )["tangent"]
+		self.assertEqual( tangents.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual(
+			tangents.data,
+			IECore.V3fVectorData(
+				[ imath.V3f( 2, 0, 0 ), imath.V3f( -1, 1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( 0, 1, 0 ) ],
+				IECore.GeometricData.Interpretation.Vector
+			)
+		)
+
+	def testTangentName( self ) :
+
+		grid = GafferScene.Grid()
+
+		allFilter = GafferScene.PathFilter()
+		allFilter["paths"].setValue( IECore.StringVectorData( [ "/..." ] ) )
+
+		node = GafferScene.CurvesTangents()
+		node["in"].setInput( grid["out"] )
+		node["filter"].setInput( allFilter["out"] )
+
+		curves = node["out"].object( "/grid/centerLines" )
+		self.assertIn( "tangent", curves )
+		self.assertNotIn( "myTangent", curves )
+
+		node["tangent"].setValue( "myTangent" )
+		curves = node["out"].object( "/grid/centerLines" )
+		self.assertNotIn( "tangent", curves )
+		self.assertIn( "myTangent", curves )
+
+	def testPositionName( self ) :
+
+		curves = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 4 ] ),
+			IECore.CubicBasisf.linear(), IECoreScene.CurvesPrimitive.Wrap.NonPeriodic,
+			IECore.V3fVectorData( [ imath.V3f( x, 0, 0 ) for x in range( 0, 4 ) ] ),
+		)
+		curves["Pref"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V3fVectorData( [ imath.V3f( 0, y, 0 ) for y in range( 0, 4 ) ] )
+		)
+
+		objectToScene = GafferScene.ObjectToScene()
+		objectToScene["object"].setValue( curves )
+
+		objectFilter = GafferScene.PathFilter()
+		objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+		node = GafferScene.CurvesTangents()
+		node["in"].setInput( objectToScene["out"] )
+		node["filter"].setInput( objectFilter["out"] )
+		node["position"].setValue( "Pref" )
+		node["mode"].setValue( node.Mode.FirstDifference )
+
+		processedCurves = node["out"].object( "/object" )
+		self.assertEqual( list( processedCurves["tangent"].data ), [ imath.V3f( 0, 1, 0 ) ] * 4 )
+
+	def testNonCurvesPassThrough( self ) :
+
+		cube = GafferScene.Cube()
+
+		cubeFilter = GafferScene.PathFilter()
+		cubeFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		node = GafferScene.CurvesTangents()
+		node["in"].setInput( cube["out"] )
+		node["filter"].setInput( cubeFilter["out"] )
+
+		self.assertEqual( node["out"].object( "/cube" ), node["in"].object( "/cube" ) )
+
+	def testMissingPositionThrows( self ) :
+
+		grid = GafferScene.Grid()
+
+		allFilter = GafferScene.PathFilter()
+		allFilter["paths"].setValue( IECore.StringVectorData( [ "/..." ] ) )
+
+		node = GafferScene.CurvesTangents()
+		node["in"].setInput( grid["out"] )
+		node["filter"].setInput( allFilter["out"] )
+		node["position"].setValue( "missing" )
+
+		with self.assertRaisesRegex( Gaffer.ProcessException, "No primvar named 'missing' found" ) :
+			node["out"].object( "/grid/centerLines" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testPerformance( self ) :
+
+		# 10,000 curves of 100 vertices each = 1M vertices total.
+		numCurves = 10000
+		numVertsPerCurve = 100
+
+		vertsPerCurve = IECore.IntVectorData( [numVertsPerCurve] * numCurves )
+		p = IECore.V3fVectorData(
+			[
+				imath.V3f( c, float(v) / float(numVertsPerCurve - 1), 0 )
+				for c in range( numCurves )
+				for v in range( numVertsPerCurve )
+			]
+		)
+		curves = IECoreScene.CurvesPrimitive( vertsPerCurve, IECore.CubicBasisf.linear(), False, p )
+
+		objectToScene = GafferScene.ObjectToScene()
+		objectToScene["object"].setValue( curves )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( ["/object"] ) )
+
+		node = GafferScene.CurvesTangents()
+		node["in"].setInput( objectToScene["out"] )
+		node["filter"].setInput( pathFilter["out"] )
+
+		# Precache input so it is not included in the measurement.
+		node["in"].object( "/object" )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			node["out"].object( "/object" )
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -197,6 +197,7 @@ from .CameraQueryTest import CameraQueryTest
 from .GlobalsSanitiserTest import GlobalsSanitiserTest
 from .ReflectionConstraintTest import ReflectionConstraintTest
 from .CurvesInterpolationTest import CurvesInterpolationTest
+from .CurvesTangentsTest import CurvesTangentsTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/CurvesTangentsUI.py
+++ b/python/GafferSceneUI/CurvesTangentsUI.py
@@ -1,0 +1,112 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.CurvesTangents,
+
+	"description",
+	"""
+	Adds a tangent primitive variable to curves, giving the direction of travel
+	along the curve at each vertex position.
+	""",
+
+	plugs = {
+
+		"mode" : {
+
+			"description" :
+			"""
+			The method used to compute the tangents. Each has its pros and cons.
+
+			- CentralDifference (Vertex) : The vector between the previous vertex and the next one.
+			  This is well defined for all values of curve basis and wrap, and is identical in
+			  direction to the true derivative for CatmullRom curves. Hence it is a good default.
+			- Derivative (Varying) : The true derivative of the curve, calculated at the end of each
+			  segment. While exact, this is not always useful, due to not being defined at each
+			  vertex position. Best used for pinned curves, where Varying and Vertex values are
+			  equivalent.
+			- FirstDifference (Vertex) : The vector from one vertex to the next. May be of use for
+			  linear curves.
+			""",
+
+			"plugValueWidget:type" : "GafferUI.PresetsPlugValueWidget",
+			"preset:Central Difference" : GafferScene.CurvesTangents.Mode.CentralDifference,
+			"preset:Derivative" : GafferScene.CurvesTangents.Mode.Derivative,
+			"preset:First Difference" : GafferScene.CurvesTangents.Mode.FirstDifference,
+
+		},
+
+		"normalize" : {
+
+			"description" :
+			"""
+			Normalizes the tangents, so they all have unit length.
+			""",
+
+		},
+
+		"position" : {
+
+			"description" :
+			"""
+			The name of the primitive variable containing the positions used to
+			compute tangents. Defaults to `P`, but can be set to an alternative
+			such as `Pref` to compute tangents from reference positions.
+			""",
+
+			"layout:section" : "Settings.Input",
+
+		},
+
+		"tangent" : {
+
+			"description" :
+			"""
+			The name of the output primitive variable that will contain the
+			computed tangent vectors.
+			""",
+
+			"layout:section" : "Settings.Output",
+
+		},
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -216,6 +216,7 @@ from . import ReflectionConstraintUI
 from . import CurvesInterpolationUI
 from . import MeshLightUI
 from . import AttributeProcessorUI
+from . import CurvesTangentsUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/CurvesTangents.cpp
+++ b/src/GafferScene/CurvesTangents.cpp
@@ -1,0 +1,351 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/CurvesTangents.h"
+
+#include "Gaffer/ThreadState.h"
+
+#include "IECoreScene/CurvesAlgo.h"
+#include "IECoreScene/CurvesPrimitive.h"
+
+#include "IECore/Canceller.h"
+#include "IECore/VectorTypedData.h"
+
+#include "tbb/blocked_range.h"
+#include "tbb/parallel_for.h"
+
+#include <array>
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+namespace
+{
+
+/// \todo Feels like it'd be useful to expose this somewhere in Cortex.
+array<V3f, 4> segmentPoints( PrimitiveVariable::IndexedView<V3f> &points, size_t segmentIndex, size_t numSegments, size_t numVertices, int step, CurvesPrimitive::Wrap wrap, size_t vertexOffset )
+{
+	array<V3f, 4> result;
+	if( wrap == CurvesPrimitive::Wrap::Pinned )
+	{
+		if( segmentIndex == 0 )
+		{
+			result[0] = points[vertexOffset] * 2 - points[vertexOffset+1];
+		}
+		else
+		{
+			vertexOffset += (segmentIndex - 1) * step;
+			result[0] = points[vertexOffset];
+			vertexOffset++;
+		}
+
+		result[1] = points[vertexOffset];
+		result[2] = points[vertexOffset+1];
+
+		if( segmentIndex == numSegments - 1 )
+		{
+			result[3] = points[vertexOffset+1] * 2 - points[vertexOffset];
+		}
+		else
+		{
+			result[3] = points[vertexOffset+2];
+		}
+	}
+	else if( wrap == CurvesPrimitive::Wrap::Periodic )
+	{
+		const int vertexIndex = segmentIndex * step - 1;
+		result[0] = points[vertexOffset + (vertexIndex % numVertices)];
+		result[1] = points[vertexOffset + ((vertexIndex + 1) % numVertices)];
+		result[2] = points[vertexOffset + ((vertexIndex + 2) % numVertices)];
+		result[3] = points[vertexOffset + ((vertexIndex + 3) % numVertices)];
+	}
+	else // wrap == NonPeriodic
+	{
+		vertexOffset += segmentIndex * step;
+		result[0] = points[vertexOffset];
+		result[1] = points[vertexOffset+1];
+		result[2] = points[vertexOffset+2];
+		result[3] = points[vertexOffset+3];
+	}
+
+	return result;
+}
+
+} // namespace
+
+GAFFER_NODE_DEFINE_TYPE( CurvesTangents );
+
+size_t CurvesTangents::g_firstPlugIndex = 0;
+
+CurvesTangents::CurvesTangents( const std::string &name )
+	:	ObjectProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new IntPlug( "mode", Plug::In, (int)Mode::CentralDifference, (int)Mode::FirstDifference, (int)Mode::Derivative ) );
+	addChild( new BoolPlug( "normalize" ) );
+	addChild( new StringPlug( "position", Plug::In, "P" ) );
+	addChild( new StringPlug( "tangent", Plug::In, "tangent" ) );
+}
+
+CurvesTangents::~CurvesTangents()
+{
+}
+
+Gaffer::IntPlug *CurvesTangents::modePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::IntPlug *CurvesTangents::modePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+Gaffer::BoolPlug *CurvesTangents::normalizePlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::BoolPlug *CurvesTangents::normalizePlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::StringPlug *CurvesTangents::positionPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *CurvesTangents::positionPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::StringPlug *CurvesTangents::tangentPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::StringPlug *CurvesTangents::tangentPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::ValuePlug::CachePolicy CurvesTangents::processedObjectComputeCachePolicy() const
+{
+	return ValuePlug::CachePolicy::TaskCollaboration;
+}
+
+bool CurvesTangents::affectsProcessedObject( const Gaffer::Plug *input ) const
+{
+	return
+		ObjectProcessor::affectsProcessedObject( input ) ||
+		input == modePlug() ||
+		input == normalizePlug() ||
+		input == positionPlug() ||
+		input == tangentPlug()
+	;
+}
+
+void CurvesTangents::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	ObjectProcessor::hashProcessedObject( path, context, h );
+	modePlug()->hash( h );
+	normalizePlug()->hash( h );
+	positionPlug()->hash( h );
+	tangentPlug()->hash( h );
+}
+
+IECore::ConstObjectPtr CurvesTangents::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
+{
+	const CurvesPrimitive *curves = runTimeCast<const CurvesPrimitive>( inputObject );
+	if( !curves )
+	{
+		return inputObject;
+	}
+
+	Mode mode = (Mode)modePlug()->getValue();
+	const auto interpolation = mode == Mode::Derivative ? PrimitiveVariable::Interpolation::Varying : PrimitiveVariable::Interpolation::Vertex;
+	if( mode == Mode::Derivative && curves->basis().standardBasis() == StandardCubicBasis::Linear )
+	{
+		// This is equivalent, and means that we only need to consider
+		// cubic curves in our derivative calculations.
+		mode = Mode::FirstDifference;
+	}
+	const bool normalize = normalizePlug()->getValue();
+	const std::string positionName = positionPlug()->getValue();
+	const std::string tangentName = tangentPlug()->getValue();
+
+	if( positionName.empty() || tangentName.empty() )
+	{
+		return inputObject;
+	}
+
+	auto positionView = curves->variableIndexedView<V3fVectorData>(
+		positionName, PrimitiveVariable::Interpolation::Vertex,
+		/* throwIfInvalid = */ true
+	);
+
+	// Compute per-curve offsets into the vertex data. This gives
+	// us the random access we need to do multithreaded execution below.
+
+	const size_t numCurves = curves->numCurves();
+	const vector<int> &verticesPerCurve = curves->verticesPerCurve()->readable();
+
+	std::vector<size_t> vertexOffsets;
+	vertexOffsets.reserve( numCurves );
+	size_t vertexOffset = 0;
+	for( size_t curveIndex = 0; curveIndex < numCurves; ++curveIndex )
+	{
+		vertexOffsets.push_back( vertexOffset );
+		vertexOffset += verticesPerCurve[curveIndex];
+	}
+
+	// Do the same for varying data if we need it.
+
+	std::array<float, 4> derivativeCoefficients0, derivativeCoefficients1;
+	curves->basis().derivativeCoefficients( 0.0f, derivativeCoefficients0.data() );
+	curves->basis().derivativeCoefficients( 1.0f, derivativeCoefficients1.data() );
+	std::vector<size_t> varyingOffsets;
+	if( mode == Mode::Derivative )
+	{
+		varyingOffsets.reserve( numCurves );
+		size_t varyingOffset = 0;
+		for( size_t curveIndex = 0; curveIndex < numCurves; ++curveIndex )
+		{
+			varyingOffsets.push_back( varyingOffset );
+			varyingOffset += curves->variableSize( PrimitiveVariable::Varying, curveIndex );
+		}
+	}
+
+	// Prepare container for tangents.
+
+	V3fVectorDataPtr tangentData = new V3fVectorData();
+	tangentData->setInterpretation( GeometricData::Interpretation::Vector );
+	auto &tangents = tangentData->writable();
+	tangents.resize( curves->variableSize( mode == Mode::Derivative ? PrimitiveVariable::Varying : PrimitiveVariable::Vertex ) );
+
+	// Compute tangents, parallelising across curves.
+
+	const ThreadState &threadState = ThreadState::current();
+	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+	using Wrap = CurvesPrimitive::Wrap;
+	Wrap wrap = curves->wrap();
+	if( wrap == Wrap::Pinned && !CurvesAlgo::isPinned( curves ) )
+	{
+		// Basis not compatible with pinning.
+		wrap = Wrap::NonPeriodic;
+	}
+
+	tbb::parallel_for(
+		tbb::blocked_range<size_t>( 0, numCurves ),
+		[&]( const tbb::blocked_range<size_t> &range )
+		{
+			ThreadState::Scope threadStateScope( threadState );
+
+			for( size_t curveIndex = range.begin(); curveIndex != range.end(); ++curveIndex )
+			{
+				IECore::Canceller::check(  context->canceller() );
+				size_t vertexOffset = vertexOffsets[curveIndex];
+				const int numVertices = verticesPerCurve[curveIndex];
+				if( mode == Mode::Derivative )
+				{
+					const size_t varyingOffset = varyingOffsets[curveIndex];
+					const int numSegments = curves->numSegments( curveIndex );
+					for( int segmentIndex = 0; segmentIndex < numSegments; ++segmentIndex )
+					{
+						// Add tangent for start of segment.
+						array<V3f, 4> p = segmentPoints( *positionView, segmentIndex, numSegments, numVertices, curves->basis().step, wrap, vertexOffset );
+						const auto &w = derivativeCoefficients0;
+						V3f tangent = p[0] * w[0] + p[1] * w[1] + p[2] * w[2] + p[3] * w[3];
+						if( normalize )
+						{
+							tangent.normalize();
+						}
+						tangents[varyingOffset + segmentIndex] = tangent;
+						// If this is the last segment, add tangent for end of segment.
+						if( segmentIndex == numSegments - 1 && wrap != CurvesPrimitive::Wrap::Periodic )
+						{
+							const auto &w = derivativeCoefficients1;
+							V3f tangent = p[0] * w[0] + p[1] * w[1] + p[2] * w[2] + p[3] * w[3];
+							if( normalize )
+							{
+								tangent.normalize();
+							}
+							tangents[varyingOffset + segmentIndex + 1] = tangent;
+						}
+					}
+				}
+				else // mode == FirstDifference || mode == CentralDifference
+				{
+					for( int vertexIndex = 0; vertexIndex < numVertices; ++vertexIndex )
+					{
+						int i0, i1;
+						if( mode == Mode::FirstDifference )
+						{
+							i0 = vertexIndex < numVertices - 1 ? vertexIndex : ( wrap == Wrap::Periodic ? vertexIndex : vertexIndex - 1 );
+							i1 = vertexIndex < numVertices - 1 ? vertexIndex + 1 : ( wrap == Wrap::Periodic ? 0 : vertexIndex );
+						}
+						else // mode == CentralDifference
+						{
+							i0 = vertexIndex > 0 ? vertexIndex -1 : ( wrap == Wrap::Periodic ? numVertices -1 : 0 );
+							i1 = vertexIndex < numVertices -1 ? vertexIndex + 1 : ( wrap == Wrap::Periodic ? 0 : numVertices -1 );
+						}
+
+						V3f tangent = (*positionView)[i1+vertexOffset] - (*positionView)[i0+vertexOffset];
+						if( normalize )
+						{
+							tangent.normalize();
+						}
+						tangents[vertexOffset + vertexIndex] = tangent;
+					}
+				}
+			}
+		},
+		taskGroupContext
+	);
+
+	// Copy input and add tangent primitive variable.
+
+	CurvesPrimitivePtr result = runTimeCast<CurvesPrimitive>( curves->copy() );
+	result->variables[tangentName] = PrimitiveVariable( interpolation, tangentData );
+
+	return result;
+}

--- a/src/GafferSceneModule/ObjectProcessorBinding.cpp
+++ b/src/GafferSceneModule/ObjectProcessorBinding.cpp
@@ -40,6 +40,7 @@
 
 #include "GafferScene/CopyPrimitiveVariables.h"
 #include "GafferScene/CurvesInterpolation.h"
+#include "GafferScene/CurvesTangents.h"
 #include "GafferScene/Deformer.h"
 #include "GafferScene/DeleteCurves.h"
 #include "GafferScene/DeleteFaces.h"
@@ -112,6 +113,16 @@ void GafferSceneModule::bindObjectProcessor()
 	GafferBindings::DependencyNodeClass<MergePoints>();
 	GafferBindings::DependencyNodeClass<MergeCurves>();
 	GafferBindings::DependencyNodeClass<CurvesInterpolation>();
+
+	{
+		scope s = GafferBindings::DependencyNodeClass<CurvesTangents>();
+
+		enum_<GafferScene::CurvesTangents::Mode>( "Mode" )
+			.value( "FirstDifference", GafferScene::CurvesTangents::Mode::FirstDifference )
+			.value( "CentralDifference", GafferScene::CurvesTangents::Mode::CentralDifference )
+			.value( "Derivative", GafferScene::CurvesTangents::Mode::Derivative )
+		;
+	}
 
 	{
 		scope s = GafferBindings::DependencyNodeClass<GafferScene::DeletePoints>();

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -306,6 +306,7 @@ nodeMenu.append( "/Scene/Object/Merge Curves", GafferScene.MergeCurves, searchTe
 nodeMenu.append( "/Scene/Object/Mesh Tessellate", GafferScene.MeshTessellate, searchText = "MeshTessellate" )
 nodeMenu.append( "/Scene/Object/Camera Tweaks", GafferScene.CameraTweaks, searchText = "CameraTweaks" )
 nodeMenu.append( "/Scene/Object/Curves Interpolation", GafferScene.CurvesInterpolation, searchText = "CurvesInterpolation" )
+nodeMenu.append( "/Scene/Object/Curves Tangents", GafferScene.CurvesTangents, searchText = "CurvesTangents" )
 nodeMenu.append( "/Scene/Object/Curve Sampler", GafferScene.CurveSampler, searchText = "CurveSampler" )
 nodeMenu.append( "/Scene/Object/Closest Point Sampler", GafferScene.ClosestPointSampler, searchText = "ClosestPointSampler" )
 nodeMenu.append( "/Scene/Object/UV Sampler", GafferScene.UVSampler, searchText = "UVSampler" )


### PR DESCRIPTION
I wanted there to be "one true way" of doing this, but ended up with a choice of modes because there didn't seem to be a method that was perfectly suited to all situations.

First off, I discovered that the method used by `IECoreScene::CurveTangentsOp` just doesn't work. In attempting to associate the derivatives of the curve with vertices that aren't necessarily on the curve, it generates results that just don't make sense. What _does_ make sense is to store true derivatives as `Varying` values, since these are associated with the endpoints of each segment, which do naturally lie on the curve. But `Varying` values are of little use to someone who wants to perform per-vertex curve processing, and we assume that is one of the main motivations for having CurveTangents in the first place. Where `Varying` tangents _are_ useful is on pinned curves, where `Varying` has the same storage as `Vertex`, and resampling is a no-op. Pinned curves really are the best curves, but they're pretty new, and we can't expect everything to be pinned just yet.

That leaves us needing a mode that can cope with non-pinned curves. Ideally a mode that works with any input, and is therefore well suited as a default. This is provided by central differences, which have several nice properties. They're easy to describe, they're independent of the basis, and for CatmullRom curves they align with the true derivative (albeit with different magnitude).

But central differences feel a little odd with linear curves, since they generate tangents which rarely align with the curve itself. So I added a first difference mode to cater to that case.

Another mode I considered was essentially the same as `Derivative`, but duplicating end values to convert the `Varying` values up to `Vertex`. This seemed to work pretty well for BSpline and CatmullRom curves, but would have been nonsensical for Bezier. Since it wasn't universal like CentralDifference, and added little over Derivative mode in the cases where it worked, I opted to omit this mode entirely.

Full disclosure : this was my first experiment with Claude. It wrote a first version in the vein of CurveTangentsOp, and then suggested CentralDifference mode when pushed for something better. In the end I did the final implementation myself, so the boilerplate is basically the only thing that remains from the Claude version.

Fixes https://github.com/GafferHQ/gaffer/issues/6166