### PR TITLE
Inspector : Fix inspector sometimes incorrectly returning non-editable

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - SceneInspector : Fixed crash caused by a particular configuration of ShuffleAttributes or ShufflePrimitiveVariables nodes (#6923).
+- All Inspectors : Fixed an issue where an EditScope with downstream edits could sometimes be incorrectly flagged as non-editable.
 - Box : Fixed hangs creating a Box. This was caused by a GIL management bug in the Python bindings.
 
 1.6.18.0 (relative to 1.6.17.0)

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -258,6 +258,10 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 		# If there's an edit downstream of the EditScope we're asked to use,
 		# then we're allowed to be editable still
 
+		# This is true even if the downstream edit is enabled and read-only
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], True )
+		lightEditScope2Edit["enabled"].setValue( True )
+
 		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", s["editScope1"] )
 		self.assertTrue( inspection.editable() )
 		self.assertEqual( inspection.nonEditableReason(), "" )
@@ -269,7 +273,29 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 				s["editScope1"], "/group/light", "gl:visualiser:scale", createIfNecessary = False
 			)
 		)
-		self.assertEqual( inspection.editWarning(), "" )
+		self.assertEqual( inspection.editWarning(), "Attribute has edits downstream in editScope2." )
+
+
+		# Having now created the edit, we should be able to acquire it again ( this uses a slightly
+		# different code path since now it will be found as a source ).
+
+		lightEditScope1Edit["enabled"].setValue( True )
+
+		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", s["editScope1"] )
+		self.assertTrue( inspection.editable() )
+		self.assertEqual( inspection.nonEditableReason(), "" )
+		lightEditScope1Edit = inspection.acquireEdit()
+		self.assertIsNotNone( lightEditScope1Edit )
+		self.assertEqual(
+			lightEditScope1Edit,
+			GafferScene.EditScopeAlgo.acquireAttributeEdit(
+				s["editScope1"], "/group/light", "gl:visualiser:scale", createIfNecessary = False
+			)
+		)
+		self.assertEqual( inspection.editWarning(), "Attribute has edits downstream in editScope2." )
+
+		# Unlock the edit scope again for the rest of the tests
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], False )
 
 		# If there is a source node inside an edit scope, make sure we use that
 

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -462,7 +462,7 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 		// Initialise editors from source if we can.
 		if( source && source->ancestor<EditScope>() == result->m_editScope )
 		{
-			const std::string nonEditableReason = ::nonEditableReason( result->m_source.get() );
+			const std::string nonEditableReason = ::nonEditableReason( source.get() );
 			if( nonEditableReason.empty() )
 			{
 				result->m_editors = {


### PR DESCRIPTION
As discussed previously, it seems like this may have been a typo.

The fix is very simple, testing is slightly more complicated. I think it's reasonable that I've modified the existing test to have the downstream edit enabled, and check for the message about "Attribute has edits downstream", but someone who knows the existing code better should probably double check that.

In terms of overall testing: I've added an explicit test to AttributeInspectorTest, run all existing GafferSceneUITest's ( just to make sure it didn't cause regressions ), and checked that it fixed the situation where I originally noticed this with the prototype PaintTool.