### PR TITLE
PathFilterUI, SetFilterUI : Improve drag & drop registration

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -70,6 +70,7 @@ API
 - SetExpressionAlgo : Added new namespace with functions for evaluating and editing set expressions.
 - GraphComponentPath : Added `setFromComponent()`
 - BreadCrumbsWidget : Added widget for interacting with paths using a combination of button widgets and text entry.
+- NodeGadget : Added `instanceCreatedSignal()`. This allows extensions to customise gadgets after their creation.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -53,6 +53,7 @@ Fixes
 - StandardNodeGadget : Fixed crash caused by the node emitting `errorSignal()` while the gadget is undergoing construction.
 - Shader : Fixed hash for output plugs.
 - LightEditor : Fixed context used to compute the solo column header icon, this now uses the correct context with respect to the focus node.
+- NodeGadget : Fixed potential hang calling `create()` from Python.
 
 API
 ---

--- a/include/GafferUI/NodeGadget.h
+++ b/include/GafferUI/NodeGadget.h
@@ -64,6 +64,9 @@ class GAFFERUI_API NodeGadget : public Gadget
 		Gaffer::Node *node();
 		const Gaffer::Node *node() const;
 
+		/// Nodules and connections
+		/// =======================
+
 		/// Should be overridden by derived classes to return a nodule for
 		/// the plug if it has one, and 0 otherwise.
 		virtual Nodule *nodule( const Gaffer::Plug *plug );
@@ -83,12 +86,20 @@ class GAFFERUI_API NodeGadget : public Gadget
 		/// appropriate.
 		NoduleSignal &noduleRemovedSignal();
 
+		/// Registration and Creation
+		/// =========================
+
 		/// Creates a NodeGadget for the specified node. The type of
 		/// NodeGadget created can be controlled by registering a
 		/// "nodeGadget:type" metadata value for the node. Registering
 		/// "" suppresses creation of a NodeGadget, in which case
 		/// nullptr will be returned.
 		static NodeGadgetPtr create( Gaffer::NodePtr node );
+
+		using InstanceCreatedSignal = Gaffer::Signals::Signal<void ( NodeGadget * )>;
+		/// Signal emitted whenever a new NodeGadget is created. This provides
+		/// an opportunity for customisation.
+		static InstanceCreatedSignal &instanceCreatedSignal();
 
 		using NodeGadgetCreator = std::function<NodeGadgetPtr ( Gaffer::NodePtr )>;
 		/// Registers a named NodeGadget creator, optionally registering it as the default
@@ -133,5 +144,22 @@ class GAFFERUI_API NodeGadget : public Gadget
 };
 
 IE_CORE_DECLAREPTR( NodeGadget );
+
+/// Overload for the standard `intrusive_ptr_add_ref` defined in RefCounted.h.
+/// This allows us to emit `instanceCreatedSignal()` once the object is fully
+/// constructed and it is safe for slots (especially Python slots) to add
+/// additional references.
+///
+/// > Caution : This won't be called if you assign a new NodeGadget to
+/// > RefCountedPtr rather than NodeGadgetPtr. Don't do that!
+inline void intrusive_ptr_add_ref( NodeGadget *nodeGadget )
+{
+	const bool firstRef = nodeGadget->refCount() == 0;
+	nodeGadget->addRef();
+	if( firstRef )
+	{
+		NodeGadget::instanceCreatedSignal()( nodeGadget );
+	}
+}
 
 } // namespace GafferUI

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -81,20 +81,6 @@ Gaffer.Metadata.registerNode(
 )
 
 ##########################################################################
-# Gadgets
-##########################################################################
-
-def __nodeGadget( node ) :
-
-	nodeGadget = GafferUI.StandardNodeGadget( node )
-	GafferSceneUI.PathFilterUI.addObjectDropTarget( nodeGadget )
-	GafferSceneUI.SetFilterUI.addSetDropTarget( nodeGadget )
-
-	return nodeGadget
-
-GafferUI.NodeGadget.registerNodeGadget( GafferScene.FilteredSceneProcessor, __nodeGadget )
-
-##########################################################################
 # GraphEditor context menu
 ##########################################################################
 

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -255,7 +255,7 @@ def __pathsPlug( node ) :
 
 def __filterPlug( node ) :
 
-	filterPlugs = list( GafferScene.FilterPlug.Range( node ) )
+	filterPlugs = list( GafferScene.FilterPlug.InputRange( node ) )
 	if len( filterPlugs ) == 1 :
 		return filterPlugs[0]
 	return None
@@ -268,12 +268,10 @@ def __dropMode( nodeGadget, event ) :
 
 	pathsPlug = __pathsPlug( nodeGadget.node() )
 	if pathsPlug is None :
-		filter = None
-
 		filterPlug = __filterPlug( nodeGadget.node() )
 		if filterPlug is None :
 			return __DropMode.None_
-
+		filter = None
 		if filterPlug.getInput() is not None :
 			filter = filterPlug.source().node()
 		if filter is None :
@@ -413,13 +411,3 @@ def addObjectDropTarget( nodeGadget ) :
 	nodeGadget.dragLeaveSignal().connect( __dragLeave )
 	nodeGadget.dragMoveSignal().connect( __dragMove )
 	nodeGadget.dropSignal().connect( __drop )
-
-def __nodeGadget( pathFilter ) :
-
-	nodeGadget = GafferUI.StandardNodeGadget( pathFilter )
-	addObjectDropTarget( nodeGadget )
-
-	return nodeGadget
-
-GafferUI.NodeGadget.registerNodeGadget( GafferScene.PathFilter, __nodeGadget )
-GafferUI.NodeGadget.registerNodeGadget( Gaffer.SubGraph, __nodeGadget )

--- a/python/GafferSceneUI/SetFilterUI.py
+++ b/python/GafferSceneUI/SetFilterUI.py
@@ -123,6 +123,13 @@ def __setsPlug( node ) :
 
 	return None
 
+def __filterPlug( node ) :
+
+	filterPlugs = list( GafferScene.FilterPlug.InputRange( node ) )
+	if len( filterPlugs ) == 1 :
+		return filterPlugs[0]
+	return None
+
 def __editable( plug ) :
 	if Gaffer.MetadataAlgo.readOnly( plug ) or not plug.settable() :
 		return False
@@ -142,11 +149,15 @@ def __dropMode( nodeGadget, event ) :
 
 	setsPlug = __setsPlug( nodeGadget.node() )
 	if setsPlug is None :
+		filterPlug = __filterPlug( nodeGadget.node() )
+		if filterPlug is None :
+			return __DropMode.None_
+
 		filter = None
-		if nodeGadget.node()["filter"].getInput() is not None :
-			filter = nodeGadget.node()["filter"].source().node()
+		if filterPlug.getInput() is not None :
+			filter = filterPlug.source().node()
 		if filter is None :
-			return __DropMode.Replace if __editable( nodeGadget.node()["filter"] ) else __DropMode.NotEditable
+			return __DropMode.Replace if __editable( filterPlug ) else __DropMode.NotEditable
 		elif not isinstance( filter, GafferScene.SetFilter ) :
 			return __DropMode.None_
 		setsPlug = filter["setExpression"]
@@ -219,7 +230,7 @@ def __drop( nodeGadget, event ) :
 
 	setsPlug = __setsPlug( nodeGadget.node() )
 	if setsPlug is None :
-		setsPlug = __setsPlug( nodeGadget.node()["filter"].source().node() )
+		setsPlug = __setsPlug( __filterPlug( nodeGadget.node() ).source().node() )
 
 	dropSets = event.data
 
@@ -241,7 +252,7 @@ def __drop( nodeGadget, event ) :
 
 			setFilter = GafferScene.SetFilter()
 			nodeGadget.node().parent().addChild( setFilter )
-			nodeGadget.node()["filter"].setInput( setFilter["out"] )
+			__filterPlug( nodeGadget.node() ).setInput( setFilter["out"] )
 
 			setsPlug = setFilter["setExpression"]
 
@@ -258,12 +269,3 @@ def addSetDropTarget( nodeGadget ) :
 	nodeGadget.dragLeaveSignal().connect( __dragLeave )
 	nodeGadget.dragMoveSignal().connect( __dragMove )
 	nodeGadget.dropSignal().connect( __drop )
-
-def __nodeGadget( setFilter ) :
-
-	nodeGadget = GafferUI.StandardNodeGadget( setFilter )
-	addSetDropTarget( nodeGadget )
-
-	return nodeGadget
-
-GafferUI.NodeGadget.registerNodeGadget( GafferScene.SetFilter, __nodeGadget )

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -397,17 +397,3 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 			)
 
 GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu )
-
-##########################################################################
-# Gadgets
-##########################################################################
-
-def __nodeGadget( node ) :
-
-	nodeGadget = GafferUI.StandardNodeGadget( node )
-	GafferSceneUI.PathFilterUI.addObjectDropTarget( nodeGadget )
-	GafferSceneUI.SetFilterUI.addSetDropTarget( nodeGadget )
-
-	return nodeGadget
-
-GafferUI.NodeGadget.registerNodeGadget( GafferScene.Set, __nodeGadget )

--- a/python/GafferUITest/NodeGadgetTest.py
+++ b/python/GafferUITest/NodeGadgetTest.py
@@ -116,5 +116,15 @@ class NodeGadgetTest( GafferUITest.TestCase ) :
 		Gaffer.Metadata.registerValue( n, "nodeGadget:type", "GafferUI::StandardNodeGadget" )
 		self.assertTrue( isinstance( GafferUI.NodeGadget.create( n ), GafferUI.StandardNodeGadget ) )
 
+	def testInstanceCreatedSignal( self ) :
+
+		cs = GafferTest.CapturingSlot( GafferUI.NodeGadget.instanceCreatedSignal() )
+		node = Gaffer.Node()
+
+		gadget1 = GafferUI.StandardNodeGadget( node )
+		gadget2 = GafferUI.NodeGadget.create( node )
+
+		self.assertEqual( [ x[0] for x in cs ], [ gadget1, gadget2 ] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/NodeGadget.cpp
+++ b/src/GafferUI/NodeGadget.cpp
@@ -138,6 +138,12 @@ NodeGadgetPtr NodeGadget::create( Gaffer::NodePtr node )
 	return nullptr;
 }
 
+NodeGadget::InstanceCreatedSignal &NodeGadget::instanceCreatedSignal()
+{
+	static InstanceCreatedSignal g_signal;
+	return g_signal;
+}
+
 void NodeGadget::registerNodeGadget( const std::string &nodeGadgetType, NodeGadgetCreator creator, IECore::TypeId nodeType )
 {
 	typeCreators()[nodeGadgetType] = creator;

--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -79,6 +79,21 @@ struct NoduleSlotCaller
 	}
 };
 
+struct InstanceCreatedSlotCaller
+{
+	void operator()( boost::python::object slot, NodeGadget *nodeGadget )
+	{
+		try
+		{
+			slot( NodeGadgetPtr( nodeGadget ) );
+		}
+		catch( const error_already_set & )
+		{
+			ExceptionAlgo::translatePythonException();
+		}
+	}
+};
+
 struct NodeGadgetCreator
 {
 	NodeGadgetCreator( object fn )
@@ -177,6 +192,8 @@ void GafferUIModule::bindNodeGadget()
 		.def( "noduleAddedSignal", &NodeGadget::noduleAddedSignal, return_internal_reference<1>() )
 		.def( "noduleRemovedSignal", &NodeGadget::noduleRemovedSignal, return_internal_reference<1>() )
 		.def( "create", &NodeGadget::create ).staticmethod( "create" )
+		.def( "instanceCreatedSignal", &NodeGadget::instanceCreatedSignal, return_value_policy<reference_existing_object>() )
+		.staticmethod( "instanceCreatedSignal" )
 		.def( "registerNodeGadget", &registerNodeGadget1 )
 		.def( "registerNodeGadget", &registerNodeGadget2,
 			(
@@ -189,6 +206,7 @@ void GafferUIModule::bindNodeGadget()
 	;
 
 	SignalClass<NodeGadget::NoduleSignal, DefaultSignalCaller<NodeGadget::NoduleSignal>, NoduleSlotCaller >( "NoduleSignal" );
+	SignalClass<NodeGadget::InstanceCreatedSignal, DefaultSignalCaller<NodeGadget::InstanceCreatedSignal>, InstanceCreatedSlotCaller>( "InstanceCreatedSignal" );
 
 	{
 		scope s = NodeGadgetClass<StandardNodeGadget, StandardNodeGadgetWrapper>()

--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -94,6 +94,12 @@ struct InstanceCreatedSlotCaller
 	}
 };
 
+NodeGadgetPtr nodeGadgetCreateWrapper( Gaffer::Node &node )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return NodeGadget::create( &node );
+}
+
 struct NodeGadgetCreator
 {
 	NodeGadgetCreator( object fn )
@@ -191,7 +197,7 @@ void GafferUIModule::bindNodeGadget()
 		.def( "node", (Gaffer::Node *(NodeGadget::*)())&NodeGadget::node, return_value_policy<CastToIntrusivePtr>() )
 		.def( "noduleAddedSignal", &NodeGadget::noduleAddedSignal, return_internal_reference<1>() )
 		.def( "noduleRemovedSignal", &NodeGadget::noduleRemovedSignal, return_internal_reference<1>() )
-		.def( "create", &NodeGadget::create ).staticmethod( "create" )
+		.def( "create", &nodeGadgetCreateWrapper ).staticmethod( "create" )
 		.def( "instanceCreatedSignal", &NodeGadget::instanceCreatedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "instanceCreatedSignal" )
 		.def( "registerNodeGadget", &registerNodeGadget1 )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -324,3 +324,14 @@ def __graphEditorCreated( graphEditor ) :
 	graphEditor.graphGadget().dropSignal().connect( functools.partial( __locationDrop, graphEditor = weakref.ref( graphEditor ) ) )
 
 GafferUI.GraphEditor.instanceCreatedSignal().connect( __graphEditorCreated )
+
+##########################################################################
+# Filter drop handlers
+##########################################################################
+
+def __nodeGadgetCreated( nodeGadget ) :
+
+	GafferSceneUI.PathFilterUI.addObjectDropTarget( nodeGadget )
+	GafferSceneUI.SetFilterUI.addSetDropTarget( nodeGadget )
+
+GafferUI.NodeGadget.instanceCreatedSignal().connect( __nodeGadgetCreated )


### PR DESCRIPTION
We now register the signal handlers automatically via a new `NodeGadget.instanceCreatedSignal()`. This removes API surface area but also fixes a bug introduced by https://github.com/GafferHQ/gaffer/commit/01f1ca61b6a32efc12277065ae9b26356b201a08 - because extension nodes are no longer inherited from SubGraph, they weren't getting the handlers applied. This could be seen in a failure to accept drags on nodes like PromotePointInstances.