### PR TITLE
Dispatcher : Omit TaskLists without `preTasks`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Fixes
 - Box : Fixed hangs creating a Box. This was caused by a GIL management bug in the Python bindings.
 - Button, SelectionMenu, TabbedContainer : Fixed issues with stylesheet propagation in custom builds of Qt 6.
 - RenderMan : Fixed export of matrix primitive variables.
+- Dispatcher : Fixed handling of TaskLists without `preTasks`. These are now correctly omitted from the dispatch graph.
 
 1.6.18.0 (relative to 1.6.17.0)
 ========

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -3161,6 +3161,46 @@ class DispatcherTest( GafferTest.TestCase ) :
 			self.assertEqual( renderTask.plug(), script["render"]["task"] )
 			self.assertEqual( renderTask.frames(), [ i ] )
 
+	def testOmitEmptyLeafTaskLists( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["taskList"] = GafferDispatch.TaskList()
+
+		script["command"] = GafferDispatch.SystemCommand()
+		script["command"]["command"].setValue( "echo Hello World" )
+		script["command"]["preTasks"][0].setInput( script["taskList"]["task"] )
+
+		script["dispatcher"] = self.NullDispatcher()
+		script["dispatcher"]["tasks"][0].setInput( script["command"]["task"] )
+		script["dispatcher"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+
+		for omit in ( None, False, True ) :
+
+			with self.subTest( omit = omit ) :
+
+				if omit is None :
+					if "GAFFERDISPATCH_OMIT_EMPTY_TASKS" in os.environ :
+						del os.environ["GAFFERDISPATCH_OMIT_EMPTY_TASKS"]
+				else :
+					os.environ["GAFFERDISPATCH_OMIT_EMPTY_TASKS"] = str( int( omit ) )
+
+				script["dispatcher"]["task"].execute()
+				rootBatch = script["dispatcher"].lastDispatch
+				self.assertIsNone( rootBatch.plug() )
+
+				self.assertEqual( len( rootBatch.preTasks() ), 1 )
+				self.assertEqual( rootBatch.preTasks()[0].plug(), script["command"]["task"] )
+
+				if omit is not False :
+
+					self.assertEqual( rootBatch.preTasks()[0].preTasks(), [] )
+
+				else :
+
+					self.assertEqual( len( rootBatch.preTasks()[0].preTasks() ), 1 )
+					self.assertEqual( rootBatch.preTasks()[0].preTasks()[0].plug(), script["taskList"]["task"] )
+
 	def testBatchNames( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -833,7 +833,10 @@ void Dispatcher::TaskBatch::preprocess( bool omitEmpty, Namer &namer, bool immed
 			continue;
 		}
 
-		if( omitEmpty && preTask->frames().empty() && !preTask->node()->isInstanceOf( "GafferDispatch::TaskList" ) )
+		if(
+			omitEmpty && preTask->frames().empty() &&
+			(!preTask->node()->isInstanceOf( "GafferDispatch::TaskList" ) || preTask->preTasks().empty() )
+		)
 		{
 			for( const auto &prePreTask : preTask->preTasks() )
 			{


### PR DESCRIPTION
Our general rule is to omit any no-op nodes from the dispatch graph, to simplify what people see in Tractor, Deadline etc. But we made an exception for TaskLists, because their sole purpose is to introduce structure to the graph, and omitting them discards that structure. There is one case where we _do_ want to omit them though, and that is when they have no `preTasks` and are therefore structuring nothing. This commit allows us to omit in this case.
