### PR TITLE
RenderMan volume fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,7 +8,9 @@ Fixes
 - Scene Editors : Fixed an issue where an EditScope with downstream edits could sometimes be incorrectly flagged as non-editable.
 - Box : Fixed hangs creating a Box. This was caused by a GIL management bug in the Python bindings.
 - Button, SelectionMenu, TabbedContainer : Fixed issues with stylesheet propagation in custom builds of Qt 6.
-- RenderMan : Fixed export of matrix primitive variables.
+- RenderMan :
+  - Fixed rendering of `ri:volume` shader assignments loaded from USD files.
+  - Fixed export of matrix primitive variables.
 - RenderManShader : Fixed loading of `PxrVolume` shaders, which are now assigned correctly as `ri:volume` attributes rather than `ri:surface`. They still rendered correctly before, but now export correctly to USD as well.
 - Dispatcher : Fixed handling of TaskLists without `preTasks`. These are now correctly omitted from the dispatch graph.
 

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Fixes
 - Box : Fixed hangs creating a Box. This was caused by a GIL management bug in the Python bindings.
 - Button, SelectionMenu, TabbedContainer : Fixed issues with stylesheet propagation in custom builds of Qt 6.
 - RenderMan : Fixed export of matrix primitive variables.
+- RenderManShader : Fixed loading of `PxrVolume` shaders, which are now assigned correctly as `ri:volume` attributes rather than `ri:surface`. They still rendered correctly before, but now export correctly to USD as well.
 - Dispatcher : Fixed handling of TaskLists without `preTasks`. These are now correctly omitted from the dispatch graph.
 
 1.6.18.0 (relative to 1.6.17.0)

--- a/python/GafferRenderMan/ArgsFileAlgo.py
+++ b/python/GafferRenderMan/ArgsFileAlgo.py
@@ -80,7 +80,10 @@ def registerMetadata( argsFile, parametersToIgnore = set() ) :
 			if target is None :
 				return None
 
-			target = target.format( name = argsFile.stem )
+			if argsFile.stem == "PxrVolume" :
+				target = "ri:volume:PxrVolume"
+			else :
+				target = target.format( name = argsFile.stem )
 
 		elif element.tag == "page" :
 

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -185,6 +185,12 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 		shader.loadShader( "PxrBakePointCloud" )
 		self.assertEqual( shader["type"].getValue(), "ri:shader" )
 
+	def testVolumeShaderType( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrVolume" )
+		self.assertEqual( shader["type"].getValue(), "ri:volume" )
+
 	def testUtilityPatternArray( self ) :
 
 		shader = GafferRenderMan.RenderManShader()

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -2530,6 +2530,79 @@ class RendererTest( GafferTest.TestCase ) :
 		self.__assertShadingNetworkParameterEqual( displacements[0]["displacement"], "texture.filename", [ "dispDirA/displacement.exr" ] )
 		self.__assertShadingNetworkParameterEqual( displacements[1]["displacement"], "texture.filename", [ "dispDirB/displacement.exr" ] )
 
+	def testMaterialAssignment( self ) :
+
+		surfaceShader1 = IECoreScene.ShaderNetwork(
+			shaders = { "output" : IECoreScene.Shader( "PxrSurface", parameters = { "diffuseColor" : imath.Color3f( 1 ) } ) },
+			output = "output"
+		)
+
+		surfaceShader2 = IECoreScene.ShaderNetwork(
+			shaders = { "output" : IECoreScene.Shader( "PxrSurface", parameters = { "diffuseColor" : imath.Color3f( 2 ) } ) },
+			output = "output"
+		)
+
+		volumeShader1 = IECoreScene.ShaderNetwork(
+			shaders = { "output" : IECoreScene.Shader( "PxrVolume", parameters = { "diffuseColor" : imath.Color3f( 3 ) } ) },
+			output = "output"
+		)
+
+		volumeShader2 = IECoreScene.ShaderNetwork(
+			shaders = { "output" : IECoreScene.Shader( "PxrVolume", parameters = { "diffuseColor" : imath.Color3f( 4 ) } ) },
+			output = "output"
+		)
+
+		for riVolume, volume, riSurface, surface, expectedColor in [
+			( None, None, None, None, None ),
+			( volumeShader1, None, None, None, [ 3, 3, 3 ] ),
+			( volumeShader1, volumeShader2, None, None, [ 3, 3, 3 ] ),
+			( None, volumeShader2, None, None, [ 4, 4, 4 ] ),
+			( volumeShader1, None, surfaceShader1, None, [ 3, 3, 3 ] ),
+			( None, None, surfaceShader1, None, [ 1, 1, 1 ] ),
+			( None, None, surfaceShader1, surfaceShader2, [ 1, 1, 1 ] ),
+			( None, None, None, surfaceShader2, [ 2, 2, 2 ] ),
+		] :
+
+			with self.subTest( riVolume = bool( riVolume ), volume = bool( volume ), riSurface = bool( riSurface ), surface = bool( surface ) ) :
+
+				with IECoreRenderManTest.RileyCapture() as capture :
+
+					renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+						self.renderer,
+						GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+					)
+
+					mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+
+					attributes = {}
+					if riVolume is not None :
+						attributes["ri:volume"] = riVolume
+
+					if volume is not None :
+						attributes["volume"] = volume
+
+					if riSurface is not None :
+						attributes["ri:surface"] = riSurface
+
+					if surface is not None :
+						attributes["surface"] = surface
+
+					attributes = renderer.attributes( IECore.CompoundObject( attributes ) )
+
+					renderer.object( "mesh", mesh, attributes )
+
+					del attributes
+					del renderer
+
+				materials = [ x for x in capture.json if x["method"] == "CreateMaterial" ]
+				self.assertEqual( len( materials ), 1 )
+
+				if expectedColor is None :
+					node = materials[0]["material"]["nodes"][-1]
+					self.__assertNotInParameters( node["params"]["params"], "diffuseColor" )
+				else :
+					self.__assertShadingNetworkParameterEqual( materials[0]["material"], "output.diffuseColor", expectedColor )
+
 	def testCamera( self ) :
 
 		for ( proj, nearClip, farClip, focalLength, aperture, translate, dof, fStop, flWorldScale, focusDist ) in [

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -771,18 +771,26 @@ void RenderManShader::loadShader( const std::string &shaderName, bool keepExisti
 
 	namePlug()->source<StringPlug>()->setValue( shaderName );
 
-	string shaderType = tree.get<string>( "args.shaderType.tag.<xmlattr>.value" );
-	if( shaderType == "bxdf" )
+	string shaderType;
+	if( shaderName == "PxrVolume" )
 	{
-		shaderType = "surface";
+		shaderType = "volume";
 	}
-	else if( shaderType == "pattern" )
+	else
 	{
-		shaderType = "shader";
-	}
-	else if( shaderType == "lightfilter" )
-	{
-		shaderType = "lightFilter";
+		shaderType = tree.get<string>( "args.shaderType.tag.<xmlattr>.value" );
+		if( shaderType == "bxdf" )
+		{
+			shaderType = "surface";
+		}
+		else if( shaderType == "pattern" )
+		{
+			shaderType = "shader";
+		}
+		else if( shaderType == "lightfilter" )
+		{
+			shaderType = "lightFilter";
+		}
 	}
 
 	typePlug()->source<StringPlug>()->setValue( "ri:" + shaderType );

--- a/src/IECoreRenderMan/Attributes.cpp
+++ b/src/IECoreRenderMan/Attributes.cpp
@@ -118,6 +118,7 @@ const RtUString g_userMaterialId( "user:__materialid" );
 const vector<InternedString> g_displacementAttributeNames = { "ri:displacement", "osl:displacement", "displacement" };
 const vector<InternedString> g_lightAttributeNames = { "ri:light", "light" };
 const vector<InternedString> g_surfaceAttributeNames = { "ri:surface", "surface" };
+const vector<InternedString> g_volumeAttributeNames = { "ri:volume", "volume" };
 
 template<typename T>
 T *attributeCast( const IECore::RunTimeTyped *v, const IECore::InternedString &name )
@@ -227,7 +228,25 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 	// Convert shaders.
 
 	const auto [surfaceName, surface] = shaderNetworkAttribute( attributes->members(), g_surfaceAttributeNames );
-	m_surfaceMaterial = materialCache->getMaterial( surface ? surface : g_facingRatio.get(), surface ? surfaceName : InternedString(), attributes );
+	const auto [volumeName, volume] = shaderNetworkAttribute( attributes->members(), g_volumeAttributeNames );
+
+	if( volume )
+	{
+		// We can only choose a single material - either a volume or a surface.
+		// RenderMan supports rendering closed geometry (as well as VDBs) with a
+		// volume shader, so if a volume shader is assigned then we use it for all
+		// geometry types.
+		m_material = materialCache->getMaterial( volume, volumeName, attributes );
+	}
+	else
+	{
+		// No volume shader available, so use surface shader, falling back to a simple
+		// facing ratio.
+		// > Note : This is no good for VDBs, but we don't fall back to a default
+		// > volume as we don't know the right value for the `densityFloatPrimVar`
+		// > parameter.
+		m_material = materialCache->getMaterial( surface ? surface : g_facingRatio.get(), surface ? surfaceName : InternedString(), attributes );
+	}
 
 	const auto [displacementName, displacement] = shaderNetworkAttribute( attributes->members(), g_displacementAttributeNames );
 	if( displacement )
@@ -241,6 +260,7 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 		// Mesh lights default to having a black material so they don't appear
 		// in indirect rays, but the user can override with a surface assignment
 		// if they want further control. Other lights don't have materials.
+		// We assume that a volume shader makes no sense here.
 		m_lightMaterial = materialCache->getMaterial( surface ? surface : g_black.get(), surface ? surfaceName : InternedString(), attributes );
 	}
 
@@ -338,9 +358,9 @@ const RtParamList &Attributes::instanceAttributes() const
 	return m_instanceAttributes;
 }
 
-const Material *Attributes::surfaceMaterial() const
+const Material *Attributes::material() const
 {
-	return m_surfaceMaterial.get();
+	return m_material.get();
 }
 
 const Material *Attributes::lightMaterial() const

--- a/src/IECoreRenderMan/Attributes.h
+++ b/src/IECoreRenderMan/Attributes.h
@@ -64,7 +64,7 @@ class Attributes : public IECoreScenePreview::Renderer::AttributesInterface
 		/// Attributes to be applied to GeometryInstances.
 		const RtParamList &instanceAttributes() const;
 
-		const Material *surfaceMaterial() const;
+		const Material *material() const;
 		const Displacement *displacement() const { return m_displacement.get(); }
 
 		const IECoreScene::ShaderNetwork *lightShader() const;
@@ -80,7 +80,7 @@ class Attributes : public IECoreScenePreview::Renderer::AttributesInterface
 		std::optional<IECore::MurmurHash> m_prototypeHash;
 		RtParamList m_prototypeAttributes;
 		RtParamList m_instanceAttributes;
-		ConstMaterialPtr m_surfaceMaterial;
+		ConstMaterialPtr m_material;
 		ConstDisplacementPtr m_displacement;
 		IECoreScene::ConstShaderNetworkPtr m_lightShader;
 		ConstMaterialPtr m_lightMaterial;

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -94,7 +94,7 @@ Object::Object( const std::string &name, const ConstGeometryPrototypePtr &geomet
 		riley::UserId(),
 		/* group = */ riley::GeometryPrototypeId::InvalidId(),
 		m_geometryPrototype->id(),
-		m_attributes->surfaceMaterial()->id(),
+		m_attributes->material()->id(),
 		g_emptyCoordinateSystems,
 		IdentityTransform(),
 		mergedAttributes( m_attributes->instanceAttributes(), m_extraAttributes )
@@ -169,7 +169,7 @@ bool Object::attributes( const IECoreScenePreview::Renderer::AttributesInterface
 	const riley::GeometryInstanceResult result = m_session->riley->ModifyGeometryInstance(
 		/* group = */ riley::GeometryPrototypeId::InvalidId(),
 		m_geometryInstance,
-		&typedAttributes->surfaceMaterial()->id(),
+		&typedAttributes->material()->id(),
 		/* coordsys = */ nullptr,
 		/* xform = */ nullptr,
 		&allAttributes

--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -419,7 +419,7 @@ shaderMetadata = {
 
 	},
 
-	"ri:surface:PxrVolume" : {
+	"ri:volume:PxrVolume" : {
 
 		"noduleLayout:defaultVisibility" : False,
 


### PR DESCRIPTION
This updates RenderManShader so that PxrVolume is assigned as `ri:volume`, matching what we load from USD. And updates the renderer backend to respect this.

This is one of those tricky "is it a bugfix or a change of behaviour?" questions. For Arnold we [recently chose](https://github.com/GafferHQ/gaffer/pull/6586) to take the conservative option and hold a similar change for 1.7. But at this point in GafferRenderMan's development (and the development of shows using it) I think the balance is with getting the fix out quickly, as a patch to 1.6.