### PR TITLE
ParameterInspector : Support `defaultValue` metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Improvements
 - LightEditor :
   - Added column for `cycles:visibility:camera` attribute.
   - USD lights now display default values for parameters that haven't been authored on the light. These are presented as dimmed "fallback" values.
+  - Changed default tweak mode to `Create` for newly created parameter tweaks.
 - OpenColorIO : Added ACES Studio 2.0 config. The default config is still ACES 1.3, due to RenderMan not supporting ACES 2.0.
 - SceneReader, SceneWriter : Added support for pinned UsdGeomBasisCurves.
 - OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.
@@ -76,6 +77,7 @@ API
 - GraphComponentPath : Added `setFromComponent()`
 - BreadCrumbsWidget : Added widget for interacting with paths using a combination of button widgets and text entry.
 - NodeGadget : Added `instanceCreatedSignal()`. This allows extensions to customise gadgets after their creation.
+- EditScopeAlgo : `acquireParameterEdit()` now creates new TweakPlugs in `Create` mode rather than `Replace`. This matches the behaviour of `acquireOptionEdit()` and `acquireAttributeEdit()`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -24,7 +24,9 @@ Improvements
 - ShaderTweaks : Added support for tweaking ramp parameters.
 - CyclesAttributes : Added `cycles:adaptive_space` attribute.
 - CyclesOptions : Added `cycles:integrator:volume_ray_marching` option.
-- LightEditor : Added column for `cycles:visibility:camera` attribute.
+- LightEditor :
+  - Added column for `cycles:visibility:camera` attribute.
+  - USD lights now display default values for parameters that haven't been authored on the light. These are presented as dimmed "fallback" values.
 - OpenColorIO : Added ACES Studio 2.0 config. The default config is still ACES 1.3, due to RenderMan not supporting ACES 2.0.
 - SceneReader, SceneWriter : Added support for pinned UsdGeomBasisCurves.
 - OSLCode : The OSL shader is now compiled on demand, rather than every time the node is edited. This avoids many redundant attempts at recompilation when loading nodes with many parameters.

--- a/python/GafferSceneTest/EditScopeAlgoTest.py
+++ b/python/GafferSceneTest/EditScopeAlgoTest.py
@@ -317,7 +317,7 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		edit = GafferScene.EditScopeAlgo.acquireParameterEdit( editScope, "/light", "light", ( "", "intensity" ) )
 		self.assertIsInstance( edit, Gaffer.TweakPlug )
 		self.assertIsInstance( edit["value"], Gaffer.Color3fPlug )
-		self.assertEqual( edit["mode"].getValue(), Gaffer.TweakPlug.Mode.Replace )
+		self.assertEqual( edit["mode"].getValue(), Gaffer.TweakPlug.Mode.Create )
 		self.assertEqual( edit["value"].getValue(), imath.Color3f( 0 ) )
 		self.assertEqual( edit["enabled"].getValue(), False )
 		self.assertEqual( editScope["LightEdits"]["ShaderTweaks"]["enabled"].getInput(), editScope["LightEdits"]["enabled"] )

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -331,7 +331,7 @@ class _InspectorWidget( GafferUI.Widget ) :
 			for path in selectedPaths :
 				context.set( "scene:path", IECore.InternedStringVectorData( path[1:].split( "/" ) ) )
 				inspectorResult = self.__inspector.inspect()
-				if inspectorResult is not None :
+				if inspectorResult is not None and not inspectorResult.fallbackDescription() :
 					inspectorResults.append( inspectorResult )
 
 		return inspectorResults

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -275,7 +275,7 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( c[2].property( "history:node" ), s["editScope"]["LightEdits"] )
 		self.assertEqual( c[2].property( "history:value" ), 3.0 )
 		self.assertEqual( c[2].property( "history:fallbackValue" ), None )
-		self.assertEqual( c[2].property( "history:operation" ), Gaffer.TweakPlug.Mode.Replace )
+		self.assertEqual( c[2].property( "history:operation" ), Gaffer.TweakPlug.Mode.Create )
 		self.assertEqual( c[2].property( "history:source" ), edit )
 		self.assertEqual( c[2].property( "history:editWarning" ), "" )
 

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -1646,5 +1646,97 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		inspection = self.__inspect( script["globalAssignment"]["out"], "/cube", "c", attribute="test:surface" )
 		self.assertEqual( inspection.source(), script["localShader"]["parameters"]["c"] )
 
+	def testDefaultValueMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["light"] = GafferSceneTest.TestLight()
+		s["light"].loadShader( "simpleLight" )
+
+		s["shaderTweak"] = GafferScene.ShaderTweaks()
+		s["shaderTweak"]["in"].setInput( s["light"]["out"] )
+
+		s["shaderTweakFilter"] = GafferScene.PathFilter()
+		s["shaderTweakFilter"]["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+		s["shaderTweak"]["filter"].setInput( s["shaderTweakFilter"]["out"] )
+
+		s["editScope"] = Gaffer.EditScope()
+		s["editScope"].setup( s["shaderTweak"]["out"] )
+		s["editScope"]["in"].setInput( s["shaderTweak"]["out"] )
+
+		# Inspecting the "testParameter" shader parameter with or without an active EditScope
+		# returns `None` as we have no upstream nodes capable of editing it, and we don't know
+		# how to create an edit within the EditScope.
+
+		self.assertIsNone( self.__inspect( s["editScope"]["out"], "/light", "testParameter" ) )
+		self.assertIsNone( self.__inspect( s["editScope"]["out"], "/light", "testParameter", s["editScope"] ) )
+
+		# Registering "defaultValue" metadata for the parameter allows it to be
+		# returned as the inspected value when the parameter does not exist.
+
+		Gaffer.Metadata.registerValue( "light:simpleLight:testParameter", "defaultValue", IECore.FloatData( 2.0 ) )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "light:simpleLight:testParameter", "defaultValue" )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/light", "testParameter", s["editScope"] )
+		self.assertEqual( inspection.value(), IECore.FloatData( 2.0 ) )
+		self.assertIsNone( inspection.value( useFallbacks = False ) )
+		self.assertEqual( inspection.sourceType(), GafferSceneUI.Private.Inspector.Result.SourceType.Other )
+		self.assertEqual( inspection.fallbackDescription(), "Default value" )
+
+		# Once a parameter is created on the inspected shader, it is
+		# returned instead of the defaultValue fallback.
+
+		s["shaderTweak"]["shader"].setValue( "light" )
+		lightTweakPlug = Gaffer.TweakPlug( "testParameter", IECore.FloatData( 4.0 ), Gaffer.TweakPlug.Mode.Create )
+		s["shaderTweak"]["tweaks"].addChild( lightTweakPlug )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/light", "testParameter" )
+		self.assertEqual( inspection.value(), IECore.FloatData( 4.0 ) )
+		self.assertEqual( inspection.sourceType(), GafferSceneUI.Private.Inspector.Result.SourceType.Other )
+		self.assertEqual( inspection.source(), lightTweakPlug )
+		self.assertEqual( inspection.fallbackDescription(), "" )
+
+		# Disabling the parameter should revert to the fallback.
+
+		lightTweakPlug["enabled"].setValue( False )
+		inspection = self.__inspect( s["editScope"]["out"], "/light", "testParameter" )
+		self.assertEqual( inspection.value(), IECore.FloatData( 2.0 ) )
+		self.assertEqual( inspection.sourceType(), GafferSceneUI.Private.Inspector.Result.SourceType.Other )
+		self.assertEqual( inspection.fallbackDescription(), "Default value" )
+
+		# Updates to "defaultValue" are reflected in new inspections.
+
+		Gaffer.Metadata.registerValue( "light:simpleLight:testParameter", "defaultValue", IECore.FloatData( 8.0 ) )
+		self.assertEqual( self.__inspect( s["editScope"]["out"], "/light", "testParameter" ).value(), IECore.FloatData( 8.0 ) )
+
+		# The fallback value should allow us to create an edit in the edit scope.
+
+		inspection = self.__inspect( s["editScope"]["out"], "/light", "testParameter", s["editScope"] )
+		edit = inspection.acquireEdit()
+		self.assertEqual(
+			edit,
+			GafferScene.EditScopeAlgo.acquireParameterEdit(
+				s["editScope"], "/light", "light", ( "", "testParameter" ), createIfNecessary = False
+			)
+		)
+
+		edit["enabled"].setValue( True )
+		edit["value"].setValue( 16.0 )
+
+		# With the tweak in place in `editScope`, ensure a new inspection returns the
+		# correct value and source.
+
+		inspection = self.__inspect( s["editScope"]["out"], "/light", "testParameter", s["editScope"] )
+		self.assertEqual( inspection.value(), IECore.FloatData( 16.0 ) )
+
+		self.__assertExpectedResult(
+			inspection,
+			source = edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.EditScope,
+			editable = True,
+			edit = edit,
+			fallbackDescription = ""
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -617,7 +617,7 @@ TweakPlug *GafferScene::EditScopeAlgo::acquireParameterEdit( Gaffer::EditScope *
 	/// every cell will have a `setValue()` for the name, and we expect to have fewer enabled cells than disabled ones.
 	/// Change the TweakPlug constructor (or provide an overload) so we can get the defaults we want. Consider the
 	/// relationship to NameValuePlug and ShufflePlug constructors at the same time.
-	TweakPlugPtr tweakPlug = new TweakPlug( tweakName, valuePlug, TweakPlug::Replace, false );
+	TweakPlugPtr tweakPlug = new TweakPlug( tweakName, valuePlug, TweakPlug::Create, false );
 
 	auto *shaderTweaks = processor->getChild<ShaderTweaks>( "ShaderTweaks" );
 	shaderTweaks->tweaksPlug()->addChild( tweakPlug );

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -525,6 +525,11 @@ ConstDataPtr parameterValue( const ScenePlug *scene, const ScenePlug::ScenePath 
 	}
 	else
 	{
+		if( const auto defaultValue = Gaffer::Metadata::value( fmt::format( "{}:{}:{}", shader->getType(), shader->getName(), parameter.name.string() ), "defaultValue" ) )
+		{
+			return defaultValue;
+		}
+
 		throw IECore::Exception( fmt::format( "Parameter \"{}\" does not exist", parameter.name.string() ) );
 	}
 }

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -924,7 +924,8 @@ class LightToolHandle : public Handle
 
 			for( const auto &i : m_inspectors )
 			{
-				if( !i.second->inspect() )
+				auto inspection = i.second->inspect();
+				if( !inspection || !inspection->fallbackDescription().empty() )
 				{
 					return false;
 				}

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -44,6 +44,7 @@
 #include "GafferScene/ShaderAssignment.h"
 #include "GafferScene/ShaderTweaks.h"
 
+#include "Gaffer/Metadata.h"
 #include "Gaffer/OptionalValuePlug.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Switch.h"
@@ -62,6 +63,7 @@ using namespace GafferSceneUI::Private;
 namespace
 {
 
+const InternedString g_defaultValue( "defaultValue" );
 const InternedString g_shaderConnectionShader( "shaderConnection:shader" );
 const InternedString g_shaderConnectionParameter( "shaderConnection:parameter" );
 
@@ -153,6 +155,24 @@ IECore::ConstObjectPtr ParameterInspector::fallbackValue( const GafferScene::Sce
 		return parameterData( fallbackAttribute.get(), m_parameter );
 	}
 
+	auto shaderNetwork = runTimeCast<const ShaderNetwork>( AttributeInspector::value( history ) );
+	if( !shaderNetwork )
+	{
+		return nullptr;
+	}
+
+	const IECoreScene::Shader *shader = m_parameter.shader.string().empty() ? shaderNetwork->outputShader() : shaderNetwork->getShader( m_parameter.shader );
+	if( !shader )
+	{
+		return nullptr;
+	}
+
+	if( const auto defaultValue = Gaffer::Metadata::value( fmt::format( "{}:{}:{}", shader->getType(), shader->getName(), m_parameter.name.string() ), g_defaultValue ) )
+	{
+		description = "Default value";
+		return defaultValue;
+	}
+
 	return nullptr;
 }
 
@@ -238,6 +258,12 @@ Inspector::AcquireEditFunctionOrFailure ParameterInspector::acquireEditFunction(
 	auto attributeHistory = static_cast<const SceneAlgo::AttributeHistory *>( history );
 
 	ConstObjectPtr v = value( history );
+	if( !v )
+	{
+		std::string description;
+		v = fallbackValue( history, description );
+	}
+
 	if( !v )
 	{
 		return fmt::format( "Parameter \"{}\" does not exist.", m_parameter.name.string() );

--- a/startup/GafferScene/usdLights.py
+++ b/startup/GafferScene/usdLights.py
@@ -37,7 +37,47 @@
 import math
 import imath
 
+from pxr import Gf
+from pxr import Sdf
+from pxr import Usd
+
 import Gaffer
+
+def __defaultValue( target ) :
+
+	light, _, parameter = target[6:].partition( ":" )
+
+	if parameter.startswith( "shaping:" ) :
+		primDefinition = Usd.SchemaRegistry().FindAppliedAPIPrimDefinition( "ShapingAPI" )
+	elif parameter.startswith( "shadow:" ) :
+		primDefinition = Usd.SchemaRegistry().FindAppliedAPIPrimDefinition( "ShadowAPI" )
+	else :
+		primDefinition = Usd.SchemaRegistry().FindConcretePrimDefinition( light )
+
+	if primDefinition is None :
+		return None
+
+	attribute = primDefinition.GetAttributeDefinition( f"inputs:{parameter}" )
+	if not attribute.IsAttribute() :
+		return None
+
+	value = attribute.GetFallbackValue()
+
+	## \todo Should Cortex bind `IECoreUSD::DataAlgo::fromUSD()` to Python
+	# so we can use it here?
+	if isinstance( value, Gf.Vec3f ) :
+		if attribute.GetTypeName() == "color3f" :
+			value = imath.Color3f( *value )
+		else :
+			value = imath.V3f( *value )
+	elif isinstance( value, Gf.Vec4f ) :
+		value = imath.Color4f( *value )
+	elif isinstance( value, Sdf.AssetPath ) :
+		value = value.path
+	elif attribute.GetTypeName() == "asset" and value is None :
+		value = ""
+
+	return value
 
 Gaffer.Metadata.registerValue( "light:RectLight", "type", "quad" )
 Gaffer.Metadata.registerValue( "light:SphereLight", "type", "point" )
@@ -55,6 +95,10 @@ for light in [ "RectLight", "SphereLight", "DiskLight", "CylinderLight", "Distan
 	Gaffer.Metadata.registerValue( metadataTarget, "exposureParameter", "exposure" )
 	Gaffer.Metadata.registerValue( metadataTarget, "coneAngleParameter", "shaping:cone:angle" )
 	Gaffer.Metadata.registerValue( metadataTarget, "coneAngleType", "half" )
+
+	## \todo Broaden these metadata registrations and migrate USDShader and USDShaderUI
+	# to use them as the source of truth in place of their USD SchemaRegistry queries.
+	Gaffer.Metadata.registerValue( f"{metadataTarget}:*", "defaultValue", __defaultValue )
 
 for light in [ "SphereLight", "DiskLight", "CylinderLight", "DistantLight" ] :
 	metadataTarget = "light:{}".format( light )


### PR DESCRIPTION
This updates ParameterInspector to support `defaultValue` metadata registrations and adds registrations for USD lights. The primarly motivating factor here is to improve support for editing USD lights in the Light Editor, where we currently require the parameter to exist on the light before it can be edited downstream.

One behavioural change worth flagging is the default tweak mode of newly created parameter tweaks has changed from `Replace` to `Create` as `Replace` mode is not so intuitive now that it's possible to create new parameters with nothing upstream to replace.