### PR TITLE
Cycles Renderer : Fix auto-tiled renders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -49,6 +49,7 @@ Fixes
   - Fixed PointsPrimitive motion blur when rendering with even numbers of segments.
   - Fixed translation of Uniform `N` primitive variables, these are now resampled to FaceVarying.
   - Fixed crashes when rendering primitives with missing `P` primitive variables (#6267).
+  - Fixed bug preventing auto-tiled renders from producing images (#5233, #6767).
 - USDShader : Fixed value of `type` plug after loading a USDLux light.
 - CyclesLight, ArnoldLight, LightFilter : Fixed potential hang when loading shaders (GIL management bug in `loadShader()` binding).
 - StandardNodeGadget : Fixed crash caused by the node emitting `errorSignal()` while the gadget is undergoing construction.

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -3142,5 +3142,89 @@ class RendererTest( GafferTest.TestCase ) :
 					del objectInterface
 					del renderer
 
+	def testAutoTile( self ) :
+
+		plane = IECoreScene.MeshPrimitive.createPlane(
+			imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) ),
+			imath.V2i( 2 )
+		)
+
+		plane["uniformColor"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Uniform,
+			IECore.Color3fVectorData( [
+				imath.Color3f( i, i, i )
+				for i in range( 1, 5 )
+			] )
+		)
+
+		shader = IECoreScene.ShaderNetwork(
+			shaders = {
+				"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 } ),
+				"attribute" : IECoreScene.Shader( "attribute", "cycles:shader", { "attribute" : "uniformColor" } ),
+			},
+			connections = [
+				( ( "attribute", "color" ), ( "output", "emission_color" ) ),
+			],
+			output = "output",
+		)
+
+		untiledImage = None
+
+		for cropWindow in ( False, True ) :
+
+			camera = IECoreScene.Camera(
+				parameters = { "cropWindow" : imath.Box2f( imath.V2f( 0.1 ), imath.V2f( 0.85 ) ) } if cropWindow else {}
+			)
+
+			for tileSize in ( None, 160, 1024 ) :
+
+				with self.subTest( cropWindow = cropWindow, tileSize = tileSize ) :
+
+					renderer = self.createRenderer()
+
+					if tileSize :
+						renderer.option( "cycles:session:tile_size", IECore.IntData( tileSize ) )
+
+					renderer.camera( "testCamera", camera )
+					renderer.option( "camera", IECore.StringData( "testCamera" ) )
+
+					fileName = self.temporaryDirectory() / "test_{}_{}.exr".format( cropWindow, tileSize )
+					renderer.output(
+						"testOutput",
+						IECoreScene.Output(
+							str( fileName ),
+							"exr",
+							"rgba",
+							{}
+						)
+					)
+
+					planeHandle = renderer.object( "/plane", plane, renderer.attributes( IECore.CompoundObject ( { "cycles:surface" : shader } ) ) )
+					planeHandle.transform( imath.M44f().translate( imath.V3f( 0, 0, -1 ) ) )
+
+					renderer.render()
+
+					del planeHandle
+					del renderer
+
+					image = OpenImageIO.ImageBuf( str( fileName ) )
+					self.assertEqual( image.spec().full_width, 640 )
+					self.assertEqual( image.spec().full_height, 480 )
+
+					def assertColorAtUV( image, uv, color ) :
+
+						pixel = image.getpixel( int( uv.x * (image.spec().full_width - 1) ), int( uv.y * (image.spec().full_height - 1) ) )
+						self.assertEqual( imath.Color4f( *pixel ), color )
+
+					assertColorAtUV( image, imath.V2f( 0.33, 0.66 ), imath.Color4f( 1, 1, 1, 1 ) )
+					assertColorAtUV( image, imath.V2f( 0.66, 0.66 ), imath.Color4f( 2, 2, 2, 1 ) )
+					assertColorAtUV( image, imath.V2f( 0.33, 0.33 ), imath.Color4f( 3, 3, 3, 1 ) )
+					assertColorAtUV( image, imath.V2f( 0.66, 0.33 ), imath.Color4f( 4, 4, 4, 1 ) )
+
+					if not cropWindow and tileSize is None and untiledImage is None :
+						untiledImage = image
+					else :
+						self.assertFalse( OpenImageIO.ImageBufAlgo.compare( image, untiledImage, failthresh = 0, warnthresh = 0 ).error )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -70,6 +70,7 @@
 
 #include "fmt/format.h"
 
+#include <filesystem>
 #include <tuple>
 #include <unordered_map>
 
@@ -2337,6 +2338,7 @@ ccl::SessionParams defaultSessionParams( IECoreScenePreview::Renderer::RenderTyp
 	{
 		params.headless = true;
 		params.background = true;
+		params.temp_dir = std::filesystem::temp_directory_path().string();
 	}
 
 	return params;
@@ -2992,6 +2994,8 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			updatedBufferParams.full_y = (int)(camera->get_border_bottom() * (float)height);
 			updatedBufferParams.width =  (int)(camera->get_border_right() * (float)width) - updatedBufferParams.full_x;
 			updatedBufferParams.height = (int)(camera->get_border_top() * (float)height) - updatedBufferParams.full_y;
+			updatedBufferParams.window_width = updatedBufferParams.width;
+			updatedBufferParams.window_height = updatedBufferParams.height;
 
 			if( m_bufferParams.modified( updatedBufferParams ) )
 			{
@@ -3214,6 +3218,16 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			else
 			{
 				m_session->set_output_driver( ccl::make_unique<OIIOOutputDriver>( displayWindow, dataWindow, layersData->readable() ) );
+				// In auto-tiled renders Cycles writes tiles to a temporary EXR in
+				// `SessionParams.temp_dir` and invokes this callback once all
+				// tiles are complete. The host is then responsible for telling the
+				// session to process the buffer and send the completed frame to
+				// the output driver via `Session::process_full_buffer_from_disk()`.
+				m_session->full_buffer_written_cb = [session = m_session.get()]( ccl::string_view fileName ) {
+					session->process_full_buffer_from_disk( fileName );
+					// Clean up the temporary EXR as it is not removed by Cycles after processing.
+					std::filesystem::remove( std::filesystem::path( fileName.str() ) );
+				};
 			}
 
 			m_outputsChanged = false;


### PR DESCRIPTION
This fixes issues reported by users attempting Cycles renders with auto-tiling enabled, and also ensures Cycles' tile buffer images are written to a temp directory rather than `$GAFFER_ROOT/bin` and are cleaned up after use.

Early [investigations](https://github.com/GafferHQ/gaffer/issues/5233#issuecomment-1492721502) went down the path of accumulating and combining the tiles in our output driver, but this falls short when it comes to denoising as the individual tiles sent to the output driver aren't denoised. The alternative used here is to connect to the Cycles session's `full_buffer_written_cb` callback, which provides the filename of the tile buffer image once all tiles have finished writing to the buffer. It appears the host is required to use this callback to then tell the session to post-process the buffer file (including performing full-frame denoising), after post-processing the session sends the output driver the whole frame as a single tile.

Setting `ccl::BufferParams.window_width` and `window_height` is also necessary as these values are written into the metadata of the tile buffer EXR and used to determine the size of the final tile sent to the output driver, if these are left unset then the tile size defaults to (0, 0).

Fixes #5233.
Fixes #6767.
