### PR TITLE
Interface: Hide USDLights using GAFFERUSDLIGHTS_HIDE_UI

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.18.0)
 =======
 
+Improvements
+------------
+
+- Interface :  Added the ability to hide USDLight nodes from the Tab Menu by setting the `GAFFERUSD_HIDE_LIGHT_UI` environment variable to `1`. This will also hide the USD lights category in the LightEditor.
+
 Fixes
 -----
 

--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -42,42 +42,42 @@ import Gaffer
 import GafferSceneUI
 
 # UsdLux lights
+if os.environ.get( "GAFFERUSD_HIDE_LIGHT_UI", "" ) != "1" :
+	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:USD", "light" )
 
-Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:USD", "light" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "color" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "intensity" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "exposure" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "colorTemperature" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "enableColorTemperature" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "normalize" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "diffuse" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "specular" )
 
-GafferSceneUI.LightEditor.registerParameter( "light", "color" )
-GafferSceneUI.LightEditor.registerParameter( "light", "intensity" )
-GafferSceneUI.LightEditor.registerParameter( "light", "exposure" )
-GafferSceneUI.LightEditor.registerParameter( "light", "colorTemperature" )
-GafferSceneUI.LightEditor.registerParameter( "light", "enableColorTemperature" )
-GafferSceneUI.LightEditor.registerParameter( "light", "normalize" )
-GafferSceneUI.LightEditor.registerParameter( "light", "diffuse" )
-GafferSceneUI.LightEditor.registerParameter( "light", "specular" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "width", "Geometry" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "height", "Geometry" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "radius", "Geometry" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "treatAsPoint", "Geometry" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "length", "Geometry" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "treatAsLine", "Geometry" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "angle", "Geometry" )
 
-GafferSceneUI.LightEditor.registerParameter( "light", "width", "Geometry" )
-GafferSceneUI.LightEditor.registerParameter( "light", "height", "Geometry" )
-GafferSceneUI.LightEditor.registerParameter( "light", "radius", "Geometry" )
-GafferSceneUI.LightEditor.registerParameter( "light", "treatAsPoint", "Geometry" )
-GafferSceneUI.LightEditor.registerParameter( "light", "length", "Geometry" )
-GafferSceneUI.LightEditor.registerParameter( "light", "treatAsLine", "Geometry" )
-GafferSceneUI.LightEditor.registerParameter( "light", "angle", "Geometry" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "texture:file", "Texture" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "texture:format", "Texture" )
 
-GafferSceneUI.LightEditor.registerParameter( "light", "texture:file", "Texture" )
-GafferSceneUI.LightEditor.registerParameter( "light", "texture:format", "Texture" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shaping:cone:angle", "Shaping" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shaping:cone:softness", "Shaping" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shaping:focus", "Shaping" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shaping:focusTint", "Shaping" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shaping:ies:file", "Shaping" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shaping:ies:angleScale", "Shaping" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shaping:ies:normalize", "Shaping" )
 
-GafferSceneUI.LightEditor.registerParameter( "light", "shaping:cone:angle", "Shaping" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shaping:cone:softness", "Shaping" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shaping:focus", "Shaping" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shaping:focusTint", "Shaping" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shaping:ies:file", "Shaping" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shaping:ies:angleScale", "Shaping" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shaping:ies:normalize", "Shaping" )
-
-GafferSceneUI.LightEditor.registerParameter( "light", "shadow:enable", "Shadow" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shadow:color", "Shadow" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shadow:distance", "Shadow" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shadow:falloff", "Shadow" )
-GafferSceneUI.LightEditor.registerParameter( "light", "shadow:falloffGamma", "Shadow" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shadow:enable", "Shadow" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shadow:color", "Shadow" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shadow:distance", "Shadow" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shadow:falloff", "Shadow" )
+	GafferSceneUI.LightEditor.registerParameter( "light", "shadow:falloffGamma", "Shadow" )
 
 if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "" ) != "1" :
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -538,10 +538,11 @@ def __usdLightCreator( lightType ) :
 
 	return light
 
-for lightType in [
-	"DistantLight", "DiskLight", "RectLight", "SphereLight", "CylinderLight", "DomeLight", "SpotLight"
-] :
-	nodeMenu.append( "/USD/Light/{}".format( IECore.CamelCase.toSpaced( lightType ) ), functools.partial( __usdLightCreator, lightType ), searchText = lightType )
+if os.environ.get( "GAFFERUSD_HIDE_LIGHT_UI", "" ) != "1" :
+	for lightType in [
+		"DistantLight", "DiskLight", "RectLight", "SphereLight", "CylinderLight", "DomeLight", "SpotLight"
+	] :
+		nodeMenu.append( "/USD/Light/{}".format( IECore.CamelCase.toSpaced( lightType ) ), functools.partial( __usdLightCreator, lightType ), searchText = lightType )
 
 nodeMenu.append( "/USD/Attributes", GafferUSD.USDAttributes, searchText = "USDAttributes" )
 nodeMenu.append( "/USD/Layer Writer", GafferUSD.USDLayerWriter, searchText = "USDLayerWriter" )


### PR DESCRIPTION
To prevent accidentally mixing USDLights and other renderers lights I'd like to be able to hide them from the UI.

Generally describe what this PR will do, and why it is needed

- added check for GAFFERUSDLIGHTS_HIDE_UI to hide the USD Lights from the Tab Menu and hide the USD lights category in the light editor

### Checklist ###

- [x ] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x ] My code follows the Gaffer project's prevailing coding style and conventions.
