### PR TITLE
RenderMan : Delete unused prototypes during interactive renders

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,7 +282,7 @@ jobs:
     - name: Install RenderMan 26.4
       run: |
         rm -r "$RMANTREE" # Free up precious disk space from the previous installation
-        ./.github/workflows/main/installRenderMan.py --version 26.4 --dailyBuildDate 2026-04-24 --outputFormat "RMANTREE={rmanTree}" >> $GITHUB_ENV
+        ./.github/workflows/main/installRenderMan.py --version 26.4 --dailyBuildDate 2026-05-22 --outputFormat "RMANTREE={rmanTree}" >> $GITHUB_ENV
       shell: bash
       env:
         RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.19.0)
 =======
 
+Fixes
+-----
 
+- RenderMan : Fixed failure to release unused geometry in interactive renders.
 
 1.6.19.0 (relative to 1.6.18.0)
 ========

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -217,6 +217,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
 			acquireSession();
 			m_lightLinker->updateDirtyLinks();
+			m_geometryPrototypeCache->clearUnused();
 			m_materialCache->clearUnused();
 			m_globals->render();
 		}


### PR DESCRIPTION
We should have been doing this all along.