### PR TITLE
Double matrix fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- RenderMan : Fixed failure to release unused geometry in interactive renders.
+- RenderMan :
+  - Fixed failure to release unused geometry in interactive renders.
+  - Fixed export of M44d values.
 - SceneInspector, PathListingWidget : Fixed formatting of V2d, V3d, M33d and M44d values.
 
 1.6.19.0 (relative to 1.6.18.0)

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - RenderMan : Fixed failure to release unused geometry in interactive renders.
+- SceneInspector, PathListingWidget : Fixed formatting of V2d, V3d, M33d and M44d values.
 
 1.6.19.0 (relative to 1.6.18.0)
 ========

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -551,6 +551,8 @@ class RendererTest( GafferTest.TestCase ) :
 					"user:testColor" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
 					"user:testV2i" : IECore.V2iData( imath.V2i( 1, 2 ) ),
 					"user:testV2f" : IECore.V2fData( imath.V2f( 1.5, 2.5 ) ),
+					"user:testM44f" : IECore.M44fData( imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) ),
+					"user:testM44d" : IECore.M44dData( imath.M44d().scale( imath.V3d( 1, 2, 3 ) ) ),
 					"user:testIntArray" : IECore.IntVectorData( [ 3, 2, 1 ] ),
 					"user:testFloatArray" : IECore.FloatVectorData( [ 3.5, 2.5, 1.5 ] ),
 					"user:testStringArray" : IECore.StringVectorData( [ "a", "b", "c" ] ),
@@ -571,6 +573,8 @@ class RendererTest( GafferTest.TestCase ) :
 		self.__assertParameterEqual( attributes, "user:testColor", [ 1.0, 2.0, 3.0 ] )
 		self.__assertParameterEqual( attributes, "user:testV2i", [ 1, 2 ] )
 		self.__assertParameterEqual( attributes, "user:testV2f", [ 1.5, 2.5 ] )
+		self.__assertParameterEqual( attributes, "user:testM44f", [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1 ] )
+		self.__assertParameterEqual( attributes, "user:testM44d", [ 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1 ] )
 		self.__assertParameterEqual( attributes, "user:testIntArray", [ 3, 2, 1 ] )
 		self.__assertParameterEqual( attributes, "user:testFloatArray", [ 3.5, 2.5, 1.5 ] )
 		self.__assertParameterEqual( attributes, "user:testStringArray", [ "a", "b", "c" ] )

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -452,6 +452,10 @@ QVariant dataToVariant( const IECore::Data *value, int role )
 			return toString( static_cast<const IECore::V2fData *>( value )->readable() );
 		case IECore::V3fDataTypeId :
 			return toString( static_cast<const IECore::V3fData *>( value )->readable() );
+		case IECore::V2dDataTypeId :
+			return toString( static_cast<const IECore::V2dData *>( value )->readable() );
+		case IECore::V3dDataTypeId :
+			return toString( static_cast<const IECore::V3dData *>( value )->readable() );
 		case IECore::Color3fDataTypeId :
 			return toString( static_cast<const IECore::Color3fData *>( value )->readable() );
 		case IECore::Color4fDataTypeId :
@@ -468,6 +472,10 @@ QVariant dataToVariant( const IECore::Data *value, int role )
 			return toString( static_cast<const IECore::M33fData *>( value )->readable() );
 		case IECore::M44fDataTypeId :
 			return toString( static_cast<const IECore::M44fData *>( value )->readable() );
+		case IECore::M33dDataTypeId :
+			return toString( static_cast<const IECore::M33dData *>( value )->readable() );
+		case IECore::M44dDataTypeId :
+			return toString( static_cast<const IECore::M44dData *>( value )->readable() );
 		case IECore::DateTimeDataTypeId :
 		{
 			const IECore::DateTimeData *d = static_cast<const IECore::DateTimeData *>( value );

--- a/src/IECoreRenderMan/ParamListAlgo.cpp
+++ b/src/IECoreRenderMan/ParamListAlgo.cpp
@@ -113,6 +113,12 @@ struct ParameterConverter
 		paramList.SetMatrix( name, reinterpret_cast<const pxrcore::Matrix4x4 &>( data->readable() ) );
 	}
 
+	void operator()( const M44dData *data, RtUString name, RtParamList &paramList ) const
+	{
+		const Imath::M44f m( data->readable() );
+		paramList.SetMatrix( name, pxrcore::Matrix4x4( m.x ) );
+	}
+
 	void operator()( const IntVectorData *data, RtUString name, RtParamList &paramList ) const
 	{
 		paramList.SetIntegerArray( name, data->readable().data(), data->readable().size() );


### PR DESCRIPTION
Couple of fixes for handling of M44d data in the SceneInspector and RenderMan backend. Needed for a custom shading workflow at Cinesite, so getting this reviewed is pretty high priority.