### PR TITLE
ScriptNode : No string substitution in `execute()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- Dispatcher : Fixed `Context has no variable named...` error when dispatching an isolated task with a `StringPlug` script variable containing a frame substitution.
+- Dispatcher :
+  - Fixed `Context has no variable named...` error when dispatching an isolated task with a `StringPlug` script variable containing a frame substitution.
+  - Fixed unnecessary baking of values for ScriptNode variables plugs without input connections.
 - RenderMan : Fixed handling of multiple intervals in `ri:checkpoint:interval` option. Intervals may be separated by spaces or commas.
 
 1.6.19.1 (relative to 1.6.19.0)

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Dispatcher : Fixed `Context has no variable named...` error when dispatching an isolated task with a `StringPlug` script variable containing a frame substitution.
 - RenderMan : Fixed handling of multiple intervals in `ri:checkpoint:interval` option. Intervals may be separated by spaces or commas.
 
 1.6.19.1 (relative to 1.6.19.0)

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -2405,7 +2405,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		testPlugs = [ p for p in newScript["variables"].children() if p["name"].getValue() == "test" ]
 		self.assertEqual( len( testPlugs ), 1 )
-		self.assertEqual( testPlugs[0]["value"].getValue(), "value 1" )
+		self.assertEqual( testPlugs[0]["value"].getValue(), "value #" )
 
 	def testIsolated( self ) :
 
@@ -2766,6 +2766,11 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["framesPerSecond"].setValue( 1.0 )
+		s["variables"].addChild( Gaffer.NameValuePlug( "a", IECore.StringData( "####" ), name = "a", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		s["variables"].addChild( Gaffer.NameValuePlug( "b", Gaffer.StringPlug( "value" ), name = "b", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		s["variablesBExpression"] = Gaffer.Expression()
+		s["variablesBExpression"].setExpression( 'parent["variables"]["b"]["value"] = {1: "a", 2: "b", 3: "c", 4: "d", 5: "e"}[context.getFrame()]' )
 
 		s["n"] = GafferDispatchTest.TextWriter()
 		s["n"]["dispatcher"]["isolated"].setValue( True )
@@ -2821,8 +2826,10 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( set( [ type( n ) for n in Gaffer.Node.RecursiveRange( newScript ) ] ), set( [ GafferDispatchTest.TextWriter, Gaffer.Spreadsheet ] ) )
 
 		self.assertEqual( len( newScript["isolatedAnimation"]["rows"] ), 6 )  # default + frame count
-		self.assertEqual( len( newScript["isolatedAnimation"]["rows"].defaultRow()["cells"] ), 3 )
+		self.assertEqual( len( newScript["isolatedAnimation"]["rows"].defaultRow()["cells"] ), 4 )
 
+		self.assertIsNone( newScript["variables"]["a"]["value"].getInput() )
+		self.assertEqual( newScript["variables"]["b"]["value"].getInput(), newScript["isolatedAnimation"]["out"]["variables_b_value"] )
 		self.assertIsNone( newScript["n"]["fileName"].getInput() )
 		self.assertIsNone( newScript["n"]["text"].getInput() )
 		self.assertIsNone( newScript["n"]["mode"].getInput() )
@@ -2834,6 +2841,8 @@ class DispatcherTest( GafferTest.TestCase ) :
 			for f in range( 1, 6 ) :
 				with self.subTest( f = f ) :
 					c.setFrame( f )
+					self.assertEqual( newScript["variables"]["a"]["value"].getValue(), "####" )
+					self.assertEqual( newScript["variables"]["b"]["value"].getValue(), [ "a", "b", "c", "d", "e" ][f-1] )
 					self.assertEqual( newScript["n"]["fileName"].getValue(), "${script:name}" )
 					self.assertEqual( newScript["n"]["text"].getValue(), "####" )
 					self.assertEqual( newScript["n"]["mode"].getValue(), "x" )
@@ -2885,6 +2894,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		self.assertEqual( set( [ type( n ) for n in Gaffer.Node.RecursiveRange( newScript["b"] ) ] ), set( [ GafferDispatchTest.TextWriter, Gaffer.Spreadsheet ] ) )
 
+		self.assertEqual( newScript["b"]["n"]["user"]["promotedFloatPlug"].getInput(), newScript["b"]["isolatedAnimation"]["out"]["user_promotedFloatPlug"] )
 		self.assertEqual( newScript["b"]["n"]["user"]["unpromotedFloatPlug"].getInput(), newScript["b"]["isolatedAnimation"]["out"]["user_unpromotedFloatPlug"] )
 
 		with s.context() as c :

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -2851,10 +2851,16 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s["b"]["n"] = GafferDispatchTest.TextWriter()
 		s["b"]["n"]["dispatcher"]["isolated"].setValue( True )
 		s["b"]["n"]["dispatcher"]["batchSize"].setValue( 2 )
-		p = Gaffer.FloatPlug( "floatPlug", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		a = Gaffer.FloatPlug( "unpromotedFloatPlug", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"].addChild( a )
+		p = Gaffer.FloatPlug( "promotedFloatPlug", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"]["n"]["user"].addChild( p )
 		promotedPlug = Gaffer.PlugAlgo.promote( p )
 		promotedTask = Gaffer.PlugAlgo.promote( s["b"]["n"]["task"] )
+
+		curveA = Gaffer.Animation.acquire( a )
+		curveA.addKey( Gaffer.Animation.Key( time = 1, value = 10 ) )
+		curveA.addKey( Gaffer.Animation.Key( time = 2, value = 20 ) )
 
 		curve = Gaffer.Animation.acquire( promotedPlug )
 		curve.addKey( Gaffer.Animation.Key( time = 1, value = 1 ) )
@@ -2879,12 +2885,13 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		self.assertEqual( set( [ type( n ) for n in Gaffer.Node.RecursiveRange( newScript["b"] ) ] ), set( [ GafferDispatchTest.TextWriter, Gaffer.Spreadsheet ] ) )
 
-		self.assertEqual( newScript["b"]["n"]["user"]["floatPlug"].getInput(), newScript["b"]["isolatedAnimation"]["out"]["user_floatPlug"] )
+		self.assertEqual( newScript["b"]["n"]["user"]["unpromotedFloatPlug"].getInput(), newScript["b"]["isolatedAnimation"]["out"]["user_unpromotedFloatPlug"] )
 
 		with s.context() as c :
 			for f in range( 1, 3 ) :
 				c.setFrame( f )
-				self.assertEqual( newScript["b"]["n"]["user"]["floatPlug"].getValue(), [ 1, 2 ][f - 1] )
+				self.assertEqual( newScript["b"]["n"]["user"]["promotedFloatPlug"].getValue(), [ 1, 2 ][f - 1] )
+				self.assertEqual( newScript["b"]["n"]["user"]["unpromotedFloatPlug"].getValue(), [ 10, 20 ][f - 1] )
 
 	def testIsolatedObjectPlugs( self ) :
 

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -2373,7 +2373,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s["frameRange"]["start"].setValue( 8 )
 		s["frameRange"]["end"].setValue( 22 )
 		s["frame"].setValue( 11 )
-		s["variables"].addMember( "test", IECore.StringData( "value" ), "test" )
+		s["variables"].addMember( "test", IECore.StringData( "value #" ), "test" )
 
 		s["n"] = GafferDispatchTest.TextWriter()
 		s["n"]["dispatcher"]["isolated"].setValue( True )
@@ -2384,7 +2384,13 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
 		s["d"]["tasks"][0].setInput( s["n"]["task"] )
 
-		s["d"]["task"].execute()
+		with IECore.CapturingMessageHandler() as mh :
+			s["d"]["task"].execute()
+
+		# The "test" variable has a frame substitution in it, but `TaskBatch` contexts
+		# omit frame variables. This test ensures the serialisation of `variables` done
+		# in `isolate()` does not error due to the missing frame variable.
+		self.assertEqual( len( mh.messages ), 0 )
 
 		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
 
@@ -2399,7 +2405,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		testPlugs = [ p for p in newScript["variables"].children() if p["name"].getValue() == "test" ]
 		self.assertEqual( len( testPlugs ), 1 )
-		self.assertEqual( testPlugs[0]["value"].getValue(), "value" )
+		self.assertEqual( testPlugs[0]["value"].getValue(), "value 1" )
 
 	def testIsolated( self ) :
 

--- a/python/GafferDispatchTest/PythonCommandTest.py
+++ b/python/GafferDispatchTest/PythonCommandTest.py
@@ -529,5 +529,29 @@ class PythonCommandTest( GafferTest.TestCase ) :
 		with open( self.temporaryDirectory() / "pythonCommand.txt" ) as inFile :
 			self.assertEqual( inFile.readlines()[0].strip(), "4" )
 
+	def testScriptNodeExecute( self ) :
+
+		# PythonCommand that calls `ScriptNode.execute()` to add a plug to the script's
+		# `variables` plug. This in turn triggers `ScriptNode::plugSet()` to transfer
+		# the plug's value into the script's context. We _don't_ want any substitutions
+		# to be applied to the value at this point, which means `ScriptNode::execute()`
+		# must scope a ThreadState without the current PythonCommand's `Process`.
+
+		pythonCommand = GafferDispatch.PythonCommand()
+		pythonCommand["command"].setValue( inspect.cleandoc(
+			"""
+			import Gaffer
+			toExecute = '''
+			import Gaffer
+			parent["variables"].addChild( Gaffer.NameValuePlug( "test", "testing #", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+			'''
+			script = Gaffer.ScriptNode()
+			script.execute( toExecute )
+			assert( script.context()["test"] == "testing #" )
+			"""
+		) )
+
+		pythonCommand["task"].execute()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -45,6 +45,7 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/Monitor.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/TypedPlug.h"
@@ -921,6 +922,16 @@ bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent
 	DirtyPropagationScope dirtyScope;
 	bool result = false;
 	bool wasExecuting = m_executing;
+
+	// As with `ScriptNodeBinding::serialise()`, we don't want to perform string
+	// substitutions. Removing the current Process from ThreadState ensures
+	// `StringPlug::getValue()` will not perform substitutions.
+	const Context *contextVariables = Context::current();
+	const Monitor::MonitorSet &monitors = Monitor::current();
+	const ThreadState defaultThreadState;
+	ThreadState::Scope defaultThreadStateScope( defaultThreadState );
+	Context::Scope contextScope( contextVariables );
+	Monitor::Scope monitorScope( monitors );
 
 	m_executing = true;
 	try

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -214,8 +214,9 @@ void bakePlugValue( ValuePlug *destinationPlug, const ValuePlug *sourcePlug, con
 		return;
 	}
 
-	ScriptNode *destinationScript = destinationPlug->node()->scriptNode();
-	Spreadsheet *animationSpreadsheet = destinationScript->getChild<Spreadsheet>( g_isolatedAnimationNodeName );
+	Node *destinationNode = destinationPlug->node();
+	Node *animationNodeParent = destinationNode->isInstanceOf( (IECore::TypeId)ScriptNodeTypeId ) ? destinationNode : destinationNode->parent<Node>();
+	Spreadsheet *animationSpreadsheet = animationNodeParent->getChild<Spreadsheet>( g_isolatedAnimationNodeName );
 
 	Context::EditableScope frameContext( Context::current() );
 	frameContext.setFrame( frames.front() );
@@ -239,15 +240,14 @@ void bakePlugValue( ValuePlug *destinationPlug, const ValuePlug *sourcePlug, con
 			animating = true;
 			if( !animationSpreadsheet )
 			{
-				Node *parentNode = destinationPlug->node()->parent<Node>();
-				parentNode->addChild( new Spreadsheet( g_isolatedAnimationNodeName ) );
-				animationSpreadsheet = parentNode->getChild<Spreadsheet>( parentNode->children().size() - 1 );
+				animationNodeParent->addChild( new Spreadsheet( g_isolatedAnimationNodeName ) );
+				animationSpreadsheet = animationNodeParent->getChild<Spreadsheet>( animationNodeParent->children().size() - 1 );
 				animationSpreadsheet->selectorPlug()->setValue( "${frame}" );
 			}
 
 			if( columnName.string().empty() )
 			{
-				columnName = boost::replace_all_copy( destinationPlug->relativeName( destinationPlug->node() ), ".", "_" );
+				columnName = boost::replace_all_copy( destinationPlug->relativeName( destinationNode ), ".", "_" );
 				animationSpreadsheet->rowsPlug()->addColumn( destinationPlug, columnName );
 
 				destinationPlug->setInput( animationSpreadsheet->outPlug()->getChild<Plug>( columnName ) );

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -43,6 +43,7 @@
 #include "Gaffer/PlugAlgo.h"
 #include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
+#include "Gaffer/Signals.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/SubGraph.h"
@@ -292,7 +293,10 @@ void isolateScriptPlugs( ScriptNode *destinationScript, const ScriptNode *source
 		auto destinationPlug = destinationScript->descendant<ValuePlug>( sourcePlug->relativeName( sourceScript ) );
 		assert( destinationPlug );
 
-		bakePlugValue( destinationPlug, sourcePlug.get(), frames );
+		if( sourcePlug->getInput() )
+		{
+			bakePlugValue( destinationPlug, sourcePlug.get(), frames );
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes a bug that could cause errors with isolated task dispatches.

If there is a string plug in the script `variables` plug that uses frame substitution, dispatching in isolated mode would error with `Context has no variable named "frame"`. This is a result of our use of serialisation followed by execution to copy / paste the script variables from the source script to the isolation script. `execute()` will compute values of the `variables` plugs, but the `TaskBatch` context that is active during dispatch purposefully omits the `frame` variable, resulting in an error.

One way to not perform string substitution is to get the value of a string plug outside of a compute Process. This is used by the `ScriptNodeBinding::serialise()` method and I'm using the same here.

Would it be more appropriate to put the test in `ScriptNodeTest`? I looked into that but I'm not sure how to get a `ScriptNode.execute()` call within a compute process so I couldn't get a test failure without the fix.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
