### PR TITLE
NodeBinding, PlugBinding : Remove `isInstanceOf()` hacks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
             testRunner: sudo -E -u testUser
             sconsCacheMegabytes: 400
             jobs: 4
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a10/cortex-10.7.0.0a10-linux-platform24.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a11/cortex-10.7.0.0a11-linux-platform24.tar.gz
             extraBuildArguments: CYCLES_ROOT=""
 
           - name: windows

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/11.0.0a8/gafferDependencies-11.0.0a8-{platform}-{vfxPlatform}.{extension}"
+defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a11/cortex-10.7.0.0a11-{platform}-{vfxPlatform}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,17 @@ API
 
 - Image : Added `updateImage()` method.
 
+Build
+-----
+
+- Cortex : Updated to version 10.7.0.0a11.
+
+Breaking Changes
+----------------
+
+- SceneReader : Removed `./` prefix from relative prototype paths loaded from USD files.
+- Instancer : Defaulted `GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS` to `1`, as required by SceneReader's updated handling of relative USD prototypes. The environment variable may be removed in future.
+
 1.7.0.0a2 (relative to 1.7.0.0a1)
 =========
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Features
 --------
 
-- FlamencoDispatcher : Added a new node for sending tasks to Blender's [Flamenco]((https://flamenco.blender.org) render farm manager.
+- FlamencoDispatcher : Added a new node for sending tasks to Blender's [Flamenco](https://flamenco.blender.org) render farm manager.
 - PrimitiveQuery : Added a new node for querying a primitive's type and variable sizes.
 
 Fixes

--- a/bin/__private/_gaffer.py
+++ b/bin/__private/_gaffer.py
@@ -105,12 +105,6 @@ if sys.platform in ( "linux", "darwin" ) :
 	# Stop Cortex from making all Python modules load with RTLD_GLOBAL.
 	os.environ["IECORE_RTLD_GLOBAL"] = "0"
 
-# Load USD PointInstancer prototypes as relative paths by default. This allows
-# the _PointInstancerAdaptor to function even when the instancers are reparented
-# in the Gaffer hierarchy.
-if "IECOREUSD_POINTINSTANCER_RELATIVE_PROTOTYPES" not in os.environ :
-	os.environ["IECOREUSD_POINTINSTANCER_RELATIVE_PROTOTYPES"] = "1"
-
 # Work around https://github.com/ImageEngine/cortex/issues/1338, which causes
 # bad serialisations in certain locales.
 os.environ["LC_NUMERIC"] = "C"

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -77,47 +77,6 @@ class NodeWrapper : public GraphComponentWrapper<T>
 		{
 		}
 
-		bool isInstanceOf( IECore::TypeId typeId ) const override
-		{
-			// Optimise for common queries for types we know about. The standard
-			// wrapper implementation of `isInstanceOf()` would have to enter
-			// Python just in case the type was implemented there. Entering
-			// Python is incredibly costly for such a simple operation, and we
-			// perform these operations often, so these optimisations are well
-			// worth it.
-
-			if(
-				// We're a Node, so we cannot be a plug.
-				typeId == (IECore::TypeId)Gaffer::PlugTypeId ||
-				typeId == (IECore::TypeId)Gaffer::ValuePlugTypeId
-			)
-			{
-				return false;
-			}
-
-			if(
-				// It's important to optimise for ContextProcessor and
-				// Switch specifically, because they are queried heavily during
-				// the `Dispatcher::dispatch()` process.
-				typeId == (IECore::TypeId)Gaffer::ContextProcessorTypeId ||
-				typeId == (IECore::TypeId)Gaffer::SwitchTypeId ||
-				// ScriptNode, DependencyNode, ComputeNode and EditScope also
-				// appear on performance critical code paths.
-				typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId ||
-				typeId == (IECore::TypeId)Gaffer::ComputeNodeTypeId ||
-				typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId ||
-				typeId == (IECore::TypeId)Gaffer::EditScopeTypeId
-			)
-			{
-				// The types above are implemented in C++, so there is no need
-				// to consider Python overrides for `isInstanceOf()`. The base
-				// class implementation is sufficient.
-				return WrappedType::isInstanceOf( typeId );
-			}
-
-			return GraphComponentWrapper<T>::isInstanceOf( typeId );
-		}
-
 		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override
 		{
 			if( this->isSubclassed() )

--- a/include/GafferBindings/PlugBinding.h
+++ b/include/GafferBindings/PlugBinding.h
@@ -69,27 +69,6 @@ class PlugWrapper : public GraphComponentWrapper<WrappedType>
 		{
 		}
 
-		bool isInstanceOf( IECore::TypeId typeId ) const override
-		{
-			// Optimise for common queries we know should fail.
-			// The standard wrapper implementation of isInstanceOf()
-			// would have to enter Python only to discover this inevitable
-			// failure as it doesn't have knowledge of the relationships
-			// among types. Entering Python is incredibly costly for such
-			// a simple operation, and we perform these operations often,
-			// so this optimisation is well worth it.
-			if(
-				typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId ||
-				typeId == (IECore::TypeId)Gaffer::NodeTypeId ||
-				typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId ||
-				typeId == (IECore::TypeId)Gaffer::ComputeNodeTypeId
-			)
-			{
-				return false;
-			}
-			return GraphComponentWrapper<WrappedType>::isInstanceOf( typeId );
-		}
-
 		bool acceptsInput( const Gaffer::Plug *input ) const override
 		{
 			if( this->isSubclassed() )

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3690,17 +3690,17 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		self.assertEqual( instancer["out"].object( "/groupB/object/instances/sphere/0" ), rootSphere["out"].object( "/sphere" ) )
 		self.assertEqual( instancer["out"].object( "/groupB/object/instances/sphere1/1" ), sphereB["out"].object( "/sphere" ) )
 
-		if os.environ.get( "GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS", "0" ) != "0":
+		if os.environ.get( "GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS", "1" ) != "0":
 			self.assertEqual( instancer["out"].object( "/groupA/object/instances/sphere2/2" ), sphereA["out"].object( "/sphere" ) )
 			self.assertEqual( instancer["out"].object( "/groupB/object/instances/sphere2/2" ), sphereB["out"].object( "/sphere" ) )
 		else:
 			self.assertEqual( instancer["out"].object( "/groupA/object/instances/sphere2/2" ), rootSphere["out"].object( "/sphere" ) )
 			self.assertEqual( instancer["out"].object( "/groupB/object/instances/sphere2/2" ), rootSphere["out"].object( "/sphere" ) )
 
-	def testRelativePrototypePathsWithExplicitAbsolute( self ):
+	def testRelativePrototypePathsWithoutExplicitAbsolute( self ):
 		try :
 			env = Gaffer.environment()
-			env["GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS"] = "1"
+			env["GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS"] = "0"
 			subprocess.check_output(
 				[ str( Gaffer.executablePath() ), "test", "GafferSceneTest.InstancerTest.testRelativePrototypePaths" ],
 				stderr = subprocess.STDOUT,

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -750,12 +750,16 @@ def _leafTypes( typeId ) :
 	derivedTypes = IECore.RunTimeTyped.derivedTypeIds( typeId )
 
 	# By "leaf" we really mean "derived enough to appear in the Selection Mask
-	# menu". So we must pretend that the private InstancerCapsule subclass of
-	# Capsule doesn't exist.
+	# menu". So we ignore a couple of derived types.
 	## \todo No doubt this could be expressed more naturally somehow, perhaps
-	# just with a set union of `derivedTypes` and `typesWeUseInTheMenu`.
-	instancerCapsuleTypeId = IECore.RunTimeTyped.typeIdFromTypeName( "InstancerCapsule" )
-	derivedTypes = [ t for t in derivedTypes if t != instancerCapsuleTypeId ]
+	# just with a set union of `derivedTypes` and `typesWeUseInTheMenu`. We
+	# might like to have separate masks for PointsPrimitives and PointInstancers
+	# too.
+	ignoredDerivedTypes = {
+		IECore.RunTimeTyped.typeIdFromTypeName( "InstancerCapsule" ),
+		IECoreScene.PointInstancer.staticTypeId()
+	}
+	derivedTypes = [ t for t in derivedTypes if t not in ignoredDerivedTypes ]
 
 	if derivedTypes :
 		return set().union( *[ _leafTypes( t ) for t in derivedTypes ] )

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -1067,7 +1067,7 @@ class Instancer::EngineData : public Data
 			m_prototypeIndexRemap.reserve( rootStrings->size() );
 
 
-			const static bool g_explicitAbsolutePaths = checkEnvFlag( "GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS", false );
+			const static bool g_explicitAbsolutePaths = checkEnvFlag( "GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS", true );
 
 			size_t i = 0;
 			ScenePlug::ScenePath path;


### PR DESCRIPTION
These optimisations are now provided universally by Cortex, in https://github.com/ImageEngine/cortex/pull/1535. We have test coverage verifying this is the case already in `BoxTest.testComputeNodeCastDoesntRequirePython`.

We'll need a dependencies update to include the Cortex change before CI will pass.