### PR TITLE
PrimitiveQuery : Add new node for querying type and variable sizes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - FlamencoDispatcher : Added a new node for sending tasks to Blender's [Flamenco]((https://flamenco.blender.org) render farm manager.
+- PrimitiveQuery : Added a new node for querying a primitive's type and variable sizes.
 
 API
 ---

--- a/include/GafferScene/PrimitiveQuery.h
+++ b/include/GafferScene/PrimitiveQuery.h
@@ -1,0 +1,99 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/Export.h"
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/TypeIds.h"
+
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API PrimitiveQuery : public Gaffer::ComputeNode
+{
+
+	public :
+
+		explicit PrimitiveQuery( const std::string &name = defaultName<PrimitiveQuery>() );
+		~PrimitiveQuery() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::PrimitiveQuery, PrimitiveQueryTypeId, Gaffer::ComputeNode );
+
+		Gaffer::BoolPlug *enabledPlug() override;
+		const Gaffer::BoolPlug *enabledPlug() const override;
+
+		ScenePlug *scenePlug();
+		const ScenePlug *scenePlug() const;
+
+		Gaffer::StringPlug *locationPlug();
+		const Gaffer::StringPlug *locationPlug() const;
+
+		Gaffer::StringPlug *typePlug();
+		const Gaffer::StringPlug *typePlug() const;
+
+		Gaffer::IntPlug *uniformPlug();
+		const Gaffer::IntPlug *uniformPlug() const;
+
+		Gaffer::IntPlug *vertexPlug();
+		const Gaffer::IntPlug *vertexPlug() const;
+
+		Gaffer::IntPlug *varyingPlug();
+		const Gaffer::IntPlug *varyingPlug() const;
+
+		Gaffer::IntPlug *faceVaryingPlug();
+		const Gaffer::IntPlug *faceVaryingPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( PrimitiveQuery )
+
+} // GafferScene

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -199,6 +199,7 @@ enum TypeId
 	CurvesInterpolationTypeId = 120154,
 	MeshLightTypeId = 120155,
 	CurvesTangentsTypeId = 120156,
+	PrimitiveQueryTypeId = 120157,
 
 	LastTypeId = 120999
 };

--- a/python/GafferSceneTest/PrimitiveQueryTest.py
+++ b/python/GafferSceneTest/PrimitiveQueryTest.py
@@ -1,0 +1,96 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECoreScene
+
+import GafferScene
+import GafferSceneTest
+
+class PrimitiveQueryTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		cube = GafferScene.Cube()
+		mesh = cube["out"].object( "/cube" )
+
+		query = GafferScene.PrimitiveQuery()
+		query["scene"].setInput( cube["out"] )
+		query["location"].setValue( "/cube" )
+
+		self.assertEqual( query["type"].getValue(), mesh.typeName() )
+		self.assertEqual( query["uniform"].getValue(), mesh.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Uniform ) )
+		self.assertEqual( query["vertex"].getValue(), mesh.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Vertex ) )
+		self.assertEqual( query["varying"].getValue(), mesh.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Varying ) )
+		self.assertEqual( query["faceVarying"].getValue(), mesh.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ) )
+
+		query["enabled"].setValue( False )
+		self.assertEqual( query["type"].getValue(), "" )
+		self.assertEqual( query["uniform"].getValue(), 0 )
+		self.assertEqual( query["vertex"].getValue(), 0 )
+		self.assertEqual( query["varying"].getValue(), 0 )
+		self.assertEqual( query["faceVarying"].getValue(), 0 )
+
+	def testDefaultOutputs( self ) :
+
+		query = GafferScene.PrimitiveQuery()
+
+		def assertDefaults() :
+			self.assertEqual( query["type"].getValue(), "" )
+			self.assertEqual( query["uniform"].getValue(), 0 )
+			self.assertEqual( query["vertex"].getValue(), 0 )
+			self.assertEqual( query["varying"].getValue(), 0 )
+			self.assertEqual( query["faceVarying"].getValue(), 0 )
+
+		# No scene connected, no location
+		assertDefaults()
+
+		cube = GafferScene.Cube()
+		query["scene"].setInput( cube["out"] )
+
+		# Location doesn't exist
+		query["location"].setValue( "/missing" )
+		assertDefaults()
+
+		# Location exists but holds no primitive (a camera)
+		camera = GafferScene.Camera()
+		query["scene"].setInput( camera["out"] )
+		query["location"].setValue( "/camera" )
+		assertDefaults()
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -198,6 +198,7 @@ from .GlobalsSanitiserTest import GlobalsSanitiserTest
 from .ReflectionConstraintTest import ReflectionConstraintTest
 from .CurvesInterpolationTest import CurvesInterpolationTest
 from .CurvesTangentsTest import CurvesTangentsTest
+from .PrimitiveQueryTest import PrimitiveQueryTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/PrimitiveQueryUI.py
+++ b/python/GafferSceneUI/PrimitiveQueryUI.py
@@ -1,0 +1,148 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.PrimitiveQuery,
+
+	"description",
+	"""
+	Queries the geometric primitive at a scene location, outputting its type and the
+	sizes for each type of primitive variable interpolation (`Uniform`, `Vertex` etc).
+	""",
+
+	"noduleLayout:section:bottom:spacing", 0.4,
+
+	plugs = {
+
+		"scene" : {
+
+			"description" :
+			"""
+			The scene to query.
+			"""
+
+		},
+
+		"location" : {
+
+			"description" :
+			"""
+			The location within the scene to query.
+			> Note : If the location does not exist, or contains no primitive,
+			> all outputs will be set to their default values.
+			""",
+
+			"plugValueWidget:type" : "GafferSceneUI.ScenePathPlugValueWidget",
+			"scenePathPlugValueWidget:scene" : "scene",
+			"nodule:type" : ""
+
+		},
+
+		"type" : {
+
+			"description" :
+			"""
+			The type of primitive at the queried location, for example
+			`MeshPrimitive` or `PointsPrimitive`. Empty if there is no
+			primitive at the location.
+			""",
+
+			"layout:section" : "Settings.Outputs"
+
+		},
+
+		"uniform" : {
+
+			"description" :
+			"""
+			The number of values needed for `Uniform` primitive variables
+			at the queried location. Zero if there is no primitive at the
+			location.
+
+			> Info : For mesh primitives, this is the number of faces. For
+			> curve primitives it is the number of individual curves.
+			""",
+
+			"layout:section" : "Settings.Outputs"
+
+		},
+
+		"vertex" : {
+
+			"description" :
+			"""
+			The number of values needed for `Vertex` primitive variables
+			at the queried location. Zero if there is no primitive at
+			the location.
+			""",
+
+			"layout:section" : "Settings.Outputs"
+
+		},
+
+		"varying" : {
+
+			"description" :
+			"""
+			The number of values needed for `Varying` primitive variables
+			at the queried location. Zero if there is no primitive at the
+			location.
+			""",
+
+			"layout:section" : "Settings.Outputs"
+
+		},
+
+		"faceVarying" : {
+
+			"description" :
+			"""
+			The number of values needed for `FaceVarying` primitive variables
+			at the queried location. Zero if there is no primitive at the
+			location.
+			""",
+
+			"layout:section" : "Settings.Outputs"
+
+		},
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -183,6 +183,7 @@ from . import AttributeTweaksUI
 from . import OptionTweaksUI
 from . import OptionQueryUI
 from . import RenameUI
+from . import PrimitiveQueryUI
 from . import PrimitiveVariableQueryUI
 from . import SetQueryUI
 from . import MeshSegmentsUI

--- a/src/GafferScene/PrimitiveQuery.cpp
+++ b/src/GafferScene/PrimitiveQuery.cpp
@@ -1,0 +1,246 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/PrimitiveQuery.h"
+
+#include "IECoreScene/Primitive.h"
+
+using namespace Gaffer;
+using namespace GafferScene;
+
+size_t PrimitiveQuery::g_firstPlugIndex = 0;
+
+GAFFER_NODE_DEFINE_TYPE( PrimitiveQuery );
+
+PrimitiveQuery::PrimitiveQuery( const std::string &name )
+:	Gaffer::ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new BoolPlug( "enabled", Plug::In, true ) );
+	addChild( new ScenePlug( "scene" ) );
+	addChild( new Gaffer::StringPlug( "location" ) );
+	addChild( new Gaffer::StringPlug( "type", Gaffer::Plug::Out ) );
+	addChild( new Gaffer::IntPlug( "uniform", Gaffer::Plug::Out ) );
+	addChild( new Gaffer::IntPlug( "vertex", Gaffer::Plug::Out ) );
+	addChild( new Gaffer::IntPlug( "varying", Gaffer::Plug::Out ) );
+	addChild( new Gaffer::IntPlug( "faceVarying", Gaffer::Plug::Out ) );
+}
+
+PrimitiveQuery::~PrimitiveQuery()
+{
+}
+
+Gaffer::BoolPlug *PrimitiveQuery::enabledPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::BoolPlug *PrimitiveQuery::enabledPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex );
+}
+
+ScenePlug *PrimitiveQuery::scenePlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 1 );
+}
+
+const ScenePlug *PrimitiveQuery::scenePlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::StringPlug *PrimitiveQuery::locationPlug()
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *PrimitiveQuery::locationPlug() const
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::StringPlug *PrimitiveQuery::typePlug()
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::StringPlug *PrimitiveQuery::typePlug() const
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::IntPlug *PrimitiveQuery::uniformPlug()
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::IntPlug *PrimitiveQuery::uniformPlug() const
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 4 );
+}
+
+Gaffer::IntPlug *PrimitiveQuery::vertexPlug()
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::IntPlug *PrimitiveQuery::vertexPlug() const
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 5 );
+}
+
+Gaffer::IntPlug *PrimitiveQuery::varyingPlug()
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 6 );
+}
+
+const Gaffer::IntPlug *PrimitiveQuery::varyingPlug() const
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 6 );
+}
+
+Gaffer::IntPlug *PrimitiveQuery::faceVaryingPlug()
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 7 );
+}
+
+const Gaffer::IntPlug *PrimitiveQuery::faceVaryingPlug() const
+{
+	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 7 );
+}
+
+void PrimitiveQuery::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	if(
+		input == enabledPlug() ||
+		input == locationPlug() ||
+		input == scenePlug()->existsPlug() ||
+		input == scenePlug()->objectPlug()
+	)
+	{
+		outputs.push_back( typePlug() );
+		outputs.push_back( uniformPlug() );
+		outputs.push_back( vertexPlug() );
+		outputs.push_back( varyingPlug() );
+		outputs.push_back( faceVaryingPlug() );
+	}
+}
+
+void PrimitiveQuery::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	if(
+		output == typePlug() ||
+		output == uniformPlug() ||
+		output == vertexPlug() ||
+		output == varyingPlug() ||
+		output == faceVaryingPlug()
+	)
+	{
+		ComputeNode::hash( output, context, h );
+		if( enabledPlug()->getValue() )
+		{
+			const std::string location = locationPlug()->getValue();
+			if( !location.empty() )
+			{
+				const ScenePlug::ScenePath path = ScenePlug::stringToPath( location );
+				const ScenePlug::PathScope scope( context, &path );
+				if( scenePlug()->existsPlug()->getValue() )
+				{
+					scenePlug()->objectPlug()->hash( h );
+				}
+			}
+		}
+	}
+	else
+	{
+		ComputeNode::hash( output, context, h );
+	}
+}
+
+void PrimitiveQuery::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if(
+		output == typePlug() ||
+		output == uniformPlug() ||
+		output == vertexPlug() ||
+		output == varyingPlug() ||
+		output == faceVaryingPlug()
+	)
+	{
+		IECoreScene::ConstPrimitivePtr primitive;
+		if( enabledPlug()->getValue() )
+		{
+			const std::string location = locationPlug()->getValue();
+			if( !location.empty() )
+			{
+				const ScenePlug::ScenePath path = ScenePlug::stringToPath( location );
+				const ScenePlug::PathScope scope( context, &path );
+				if( scenePlug()->existsPlug()->getValue() )
+				{
+					primitive = IECore::runTimeCast<const IECoreScene::Primitive>( scenePlug()->objectPlug()->getValue() );
+				}
+			}
+		}
+
+		if( output == typePlug() )
+		{
+			static_cast<Gaffer::StringPlug *>( output )->setValue( primitive ? primitive->typeName() : "" );
+		}
+		else if( output == uniformPlug() )
+		{
+			static_cast<Gaffer::IntPlug *>( output )->setValue( primitive ? (int)primitive->variableSize( IECoreScene::PrimitiveVariable::Uniform ) : 0 );
+		}
+		else if( output == vertexPlug() )
+		{
+			static_cast<Gaffer::IntPlug *>( output )->setValue( primitive ? (int)primitive->variableSize( IECoreScene::PrimitiveVariable::Vertex ) : 0 );
+		}
+		else if( output == varyingPlug() )
+		{
+			static_cast<Gaffer::IntPlug *>( output )->setValue( primitive ? (int)primitive->variableSize( IECoreScene::PrimitiveVariable::Varying ) : 0 );
+		}
+		else if( output == faceVaryingPlug() )
+		{
+			static_cast<Gaffer::IntPlug *>( output )->setValue( primitive ? (int)primitive->variableSize( IECoreScene::PrimitiveVariable::FaceVarying ) : 0 );
+		}
+	}
+	else
+	{
+		ComputeNode::compute( output, context );
+	}
+}

--- a/src/GafferSceneModule/QueryBinding.cpp
+++ b/src/GafferSceneModule/QueryBinding.cpp
@@ -47,6 +47,7 @@
 #include "GafferScene/ExistenceQuery.h"
 #include "GafferScene/FilterQuery.h"
 #include "GafferScene/OptionQuery.h"
+#include "GafferScene/PrimitiveQuery.h"
 #include "GafferScene/PrimitiveVariableQuery.h"
 #include "GafferScene/SetQuery.h"
 #include "GafferScene/ShaderQuery.h"
@@ -268,6 +269,7 @@ void GafferSceneModule::bindQueries()
 		;
 	}
 
+	GafferBindings::DependencyNodeClass< GafferScene::PrimitiveQuery >();
 	GafferBindings::DependencyNodeClass< GafferScene::ExistenceQuery >();
 	GafferBindings::DependencyNodeClass< GafferScene::FilterQuery >();
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -363,6 +363,7 @@ nodeMenu.append( "/Scene/Utility/Attribute Query", GafferScene.AttributeQuery, s
 nodeMenu.append( "/Scene/Utility/Set Query", GafferScene.SetQuery, searchText = "SetQuery" )
 nodeMenu.append( "/Scene/Utility/Shader Query", GafferScene.ShaderQuery, searchText = "ShaderQuery" )
 nodeMenu.append( "/Scene/Utility/Option Query", GafferScene.OptionQuery, searchText = "OptionQuery" )
+nodeMenu.append( "/Scene/Utility/Primitive Query", GafferScene.PrimitiveQuery, searchText = "PrimitiveQuery" )
 nodeMenu.append( "/Scene/Utility/Primitive Variable Query", GafferScene.PrimitiveVariableQuery, searchText = "PrimitiveVariableQuery" )
 nodeMenu.append( "/Scene/Utility/Camera Query", GafferScene.CameraQuery, searchText = "CameraQuery" )
 nodeMenu.append( "/Scene/Passes/Render Passes", GafferScene.RenderPasses, searchText = "RenderPasses" )


### PR DESCRIPTION
This is the first PR from a little side project of mine. It adds a very simple PrimitiveQuery node for querying the type of primitives and the sizes of each type of primitive variable. To follow will be a node to compute aggregate statistics (sum, min, max, average) for arbitrary input plugs, queried across a range of scene locations. This will then be used to add a Statistics tab to the SceneInspector, showing the number of meshes/curves/verts etc that are in the scene, optionally limited to the current selection.