### PR TITLE
bug: fix gaffer about page showing outdated copyright notice

### DIFF
--- a/python/Gaffer/About.py
+++ b/python/Gaffer/About.py
@@ -36,6 +36,7 @@
 
 import os
 import json
+import datetime
 
 class About :
 
@@ -84,8 +85,8 @@ class About :
 
 	@staticmethod
 	def copyright() :
-
-		return "Copyright (c) 2011-2019 John Haddon, Copyright (c) 2011-2019 Image Engine Design Inc."
+		current_year = datetime.datetime.now().year
+		return f"Copyright (c) 2011-{current_year} John Haddon, Copyright (c) 2011-{current_year} Image Engine Design Inc."
 
 	@staticmethod
 	def license() :


### PR DESCRIPTION
While opening gaffer today I noticed that the about page is out-of-date showing a copyright notice from 7 years ago. I figured we should rectify that. Now it will just auto-update the about page to the current year

### Related issues ###

N/A

### Dependencies ###

N/A

### Breaking changes ###

N/A

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
