### PR TITLE
PrimitiveVariableInspector : Conform interpolation to other properties

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Features
 - FlamencoDispatcher : Added a new node for sending tasks to Blender's [Flamenco]((https://flamenco.blender.org) render farm manager.
 - PrimitiveQuery : Added a new node for querying a primitive's type and variable sizes.
 
+Fixes
+-----
+
+- SceneInspector : Fixed Interpolation field for primitive variables that don't exist. Previously it said "Invalid", and now it shows nothing.
+
 API
 ---
 

--- a/python/GafferSceneUITest/PrimitiveVariableInspectorTest.py
+++ b/python/GafferSceneUITest/PrimitiveVariableInspectorTest.py
@@ -310,11 +310,9 @@ class PrimitiveVariableInspectorTest( GafferUITest.TestCase ) :
 
 		self.__setupBasicConstant( s )
 
-		# TODO - this is inconsistent
-
 		self.assertEqual(
-			self.__inspect( s["primitiveVariables"]["out"], "/plane", "badPrimVar", Property.Interpolation ).value(),
-			IECore.StringData( "Invalid" )
+			self.__inspect( s["primitiveVariables"]["out"], "/plane", "badPrimVar", Property.Interpolation ),
+			None
 		)
 
 		self.assertEqual(

--- a/src/GafferSceneUI/PrimitiveVariableInspector.cpp
+++ b/src/GafferSceneUI/PrimitiveVariableInspector.cpp
@@ -243,6 +243,10 @@ IECore::ConstObjectPtr PrimitiveVariableInspector::value( const GafferScene::Sce
 
 	if( m_property == Property::Interpolation )
 	{
+		if( !primitiveVariableHistory->primitiveVariableValue.data )
+		{
+			return nullptr;
+		}
 		auto it = g_primitiveVariableInterpolations.find( primitiveVariableHistory->primitiveVariableValue.interpolation );
 		return it != g_primitiveVariableInterpolations.end() ? it->second : nullptr;
 	}


### PR DESCRIPTION
When the primitive variable doesn't exist at all, we just want to show an empty cell in the SceneInspector, not the "Invalid" text we were showing previously.

<img width="703" height="553" alt="image" src="https://github.com/user-attachments/assets/0ce10649-949e-4e55-912a-f7b0be5cf1c9" />
