### PR TITLE
Gaffer17build fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1039,6 +1039,7 @@ cyclesDefines = [
 ###############################################################################################
 
 usdPythonLib = basePythonEnv.subst( "boost_python$BOOST_PYTHON_LIB_SUFFIX" )
+usdLibs = []
 if env["GAFFERUSD"] :
 
 	pxrVersionHeader = baseLibEnv.FindFile(

--- a/bin/__private/__gaffer.py
+++ b/bin/__private/__gaffer.py
@@ -56,10 +56,12 @@ warnings.simplefilter( "default", DeprecationWarning )
 restorePrefix = "__GAFFER_RESTORE_"
 for name, value in list( os.environ.items() ) :
 	if name.startswith( restorePrefix ) :
+		originalName = name[len(restorePrefix):]
 		if value != "__NONE__" :
-			os.environ[name[len(restorePrefix):]] = value
+			os.environ[originalName] = value
 		else :
-			del os.environ[name[len(restorePrefix):]]
+			if originalName in os.environ:
+				del os.environ[originalName]
 		del os.environ[name]
 
 import Gaffer


### PR DESCRIPTION
- Initialized usdLibs in the SConstruct before usage. This was causing the build to fail when GAFFERUSD was set to false, which we do sometimes at IE.
- Checked for existence of an env var before deleting it in __gaffer.py. This was causing builds at IE to fail because we don't set any value for LD_PRELOAD in our builds.  

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
