### PR TITLE
CI : Update actions to Node24 compatible versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
@@ -170,7 +170,7 @@ jobs:
       if: runner.os == 'Windows'
 
     - name: Cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.GAFFER_CACHE_DIR }}
         key: ${{ runner.os }}-${{ matrix.containerImage }}-${{env.GAFFER_DEPENDENCIES_HASH}}-${{ matrix.buildType }}-${{ github.sha }}
@@ -259,7 +259,7 @@ jobs:
         echo "::remove-matcher owner=validateRelease::"
       if: matrix.publish
 
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.GAFFER_BUILD_NAME }}
         path: ${{ env.GAFFER_BUILD_NAME }}.${{ env.PACKAGE_EXTENSION }}


### PR DESCRIPTION
GitHub is moving to running actions on Node24 as of June 16th, as Node20 is EOL. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The msvc-dev-cmd action version hasn't been changed as we're already on the latest release, which targets Node20 but still runs in a Node24 environment. It appears that action is no longer maintained, so we'll need to eventually find an alternative...