### PR TITLE
NodeGadgetBinding : Fix `instanceCreatedSignal()` emission for Python subclasses

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 
 - SceneInspector : Fixed Interpolation field for primitive variables that don't exist. Previously it said "Invalid", and now it shows nothing.
 - Renderer API : Added missing `Renderer.inl` header file.
+- NodeGadget : Fixed usage of `instanceCreatedSignal()` with NodeGadgets implemented in Python [^1].
 
 API
 ---
@@ -28,6 +29,8 @@ Breaking Changes
 
 - SceneReader : Removed `./` prefix from relative prototype paths loaded from USD files.
 - Instancer : Defaulted `GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS` to `1`, as required by SceneReader's updated handling of relative USD prototypes. The environment variable may be removed in future.
+
+[^1]: Fix for bug introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
 
 1.7.0.0a2 (relative to 1.7.0.0a1)
 =========

--- a/include/GafferUIBindings/NodeGadgetBinding.inl
+++ b/include/GafferUIBindings/NodeGadgetBinding.inl
@@ -54,7 +54,19 @@ Imath::V3f connectionTangent( T &p, const GafferUI::ConnectionCreator *creator )
 	return p.T::connectionTangent( creator );
 }
 
+PyTypeObject *nodeGadgetMetaclass();
+
 } // namespace Detail
+
+// Override to prevent the default implementation emitting
+// `instanceCreatedSignal()` for wrapped instances. This allows
+// us to emit the signal ourselves from our custom metaclass, only
+// after the Python subclass is fully constructed.
+template<typename T>
+inline void intrusive_ptr_add_ref( NodeGadgetWrapper<T> *nodeGadget )
+{
+	nodeGadget->addRef();
+}
 
 template<typename T, typename TWrapper>
 NodeGadgetClass<T, TWrapper>::NodeGadgetClass( const char *docString )
@@ -62,6 +74,8 @@ NodeGadgetClass<T, TWrapper>::NodeGadgetClass( const char *docString )
 {
 	this->def( "nodule", &Detail::nodule<T> );
 	this->def( "connectionTangent", &Detail::connectionTangent<T> );
+	// Install our custom metaclass.
+	Py_SET_TYPE( this->ptr(), Detail::nodeGadgetMetaclass() );
 }
 
 } // namespace GafferUIBindings

--- a/python/GafferUITest/NodeGadgetTest.py
+++ b/python/GafferUITest/NodeGadgetTest.py
@@ -126,5 +126,38 @@ class NodeGadgetTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( [ x[0] for x in cs ], [ gadget1, gadget2 ] )
 
+	def testInstanceCreatedSignalForPythonSubclasses( self ) :
+
+		class MyNodeGadget( GafferUI.StandardNodeGadget ) :
+
+			def __init__( self, node ) :
+
+				GafferUI.StandardNodeGadget.__init__( self, node )
+
+				self.initialised = True
+
+		numSlotCalls = 0
+
+		def instanceCreated( gadget ) :
+
+			self.assertIsInstance( gadget, MyNodeGadget )
+			self.assertTrue( gadget.initialised )
+
+			# At one point in time, `instanceCreatedSignal()` was emitted
+			# before the Python object was fully initialised, and these
+			# methods among others would throw exceptions.
+			gadget.dragEnterSignal()
+			repr( gadget )
+
+			nonlocal numSlotCalls
+			numSlotCalls += 1
+
+		connection = GafferUI.NodeGadget.instanceCreatedSignal().connect( instanceCreated, scoped = True )
+
+		node = Gaffer.Node()
+		gadget = MyNodeGadget( node )
+
+		self.assertEqual( numSlotCalls, 1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PathColumnTest.py
+++ b/python/GafferUITest/PathColumnTest.py
@@ -174,6 +174,8 @@ class PathColumnTest( GafferUITest.TestCase ) :
 			# fully constructed state should do all their initialisation before
 			# calling the base class `__init__()`. Hopefully this is not too
 			# onerous.
+			## \todo This could be fixed using a custom metaclass for PathColum -
+			# see NodeGadget binding.
 			self.assertEqual( column.member, "preInitValue" )
 
 		connection = GafferUI.PathColumn.instanceCreatedSignal().connect( instanceCreated, scoped = True )

--- a/src/GafferBindings/DependencyNodeBinding.cpp
+++ b/src/GafferBindings/DependencyNodeBinding.cpp
@@ -65,6 +65,9 @@ PyObject *dependencyNodeMetaclassCall( PyObject *self, PyObject *args, PyObject 
 
 } // namespace GafferBindings
 
+/// \todo We're doing something similar for the NodeGadget binding. Consider
+/// consolidating everything into the binding for RefCounted, perhaps by calling
+/// a new `RefCounted::postConstructor()` virtual method.
 PyTypeObject *GafferBindings::Detail::dependencyNodeMetaclass()
 {
 	static PyTypeObject g_dependencyNodeMetaclass;

--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -187,7 +187,51 @@ list framed( BackdropNodeGadget &b )
 	return result;
 }
 
+// This is the `__call__` operator for the metaclass we use for NodeGadgets.
+// It is responsible for creating and initialising NodeGadget instances in
+// Python, which allows us to emit `instanceCreatedSignal()` only when the Python
+// `__init__` call has completed fully.
+PyObject *nodeGadgetMetaclassCall( PyObject *self, PyObject *args, PyObject *kw )
+{
+	// Delegate the actual work to the default `type.__call__` method.
+	// This will call `__new__` and `__init__` and return a new NodeGadget
+	// instance.
+	PyObject *result = PyType_Type.tp_call( self, args, kw );
+	if( result )
+	{
+		// Emit the `instanceCreatedSignal()`, now that the Python instance
+		// has fully constructed.
+		auto n = boost::python::extract<GafferUI::NodeGadget *>( result )();
+		GafferUI::NodeGadget::instanceCreatedSignal()( n );
+	}
+	return result;
+}
+
 } // namespace
+
+/// \todo We're doing something similar for the DependencyNode binding. Consider
+/// consolidating everything into the binding for RefCounted, perhaps by calling
+/// a new `RefCounted::postConstructor()` virtual method.
+PyTypeObject *GafferUIBindings::Detail::nodeGadgetMetaclass()
+{
+	static PyTypeObject g_nodeGadgetMetaclass;
+	if( !g_nodeGadgetMetaclass.tp_name )
+	{
+		// Initialise. We derive from the standard Boost Python metaclass
+		// because it has functionality critical to making the Boost bindings
+		// work. The only thing we're doing is adding `nodeGadgetMetaclassCall`
+		// as the implementation of the `__call__` method.
+		Py_SET_TYPE( &g_nodeGadgetMetaclass, &PyType_Type );
+		g_nodeGadgetMetaclass.tp_name = "GafferUI.NodeGadgetMetaclass";
+		g_nodeGadgetMetaclass.tp_basicsize = PyType_Type.tp_basicsize,
+		g_nodeGadgetMetaclass.tp_base = boost::python::objects::class_metatype().get();
+		g_nodeGadgetMetaclass.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+		g_nodeGadgetMetaclass.tp_call = nodeGadgetMetaclassCall;
+		PyType_Ready( &g_nodeGadgetMetaclass );
+	}
+
+	return &g_nodeGadgetMetaclass;
+}
 
 void GafferUIModule::bindNodeGadget()
 {


### PR DESCRIPTION
We were emitting the signal immediately after the C++ instance was created, but before the Python subclass finished initialising. This was causing errors in `PathFilterUI.addObjectDropTarget()` when a node with a custom NodeGadget implemented in Python was added to the GraphEditor. We don't have any such gadgets in Gaffer itself (ours are all C++), but Python subclasses do exist in the wild.

The fix uses the same Python metaclass approach used for DependencyNode in 0be2404e996052c777b97f270748a1f7bb756a54. As noted in that commit, there is potential for consolidating all this into the RefCounted binding to make this sort of thing easier in the future. For now though, I've been content to just get the bug fixed so we can get the alpha into testing at Cinesite.
