### PR TITLE
VersionCheck, WhitespaceCheck : Update to Node24 compatible actions

### DIFF
--- a/.github/workflows/versionCheck.yml
+++ b/.github/workflows/versionCheck.yml
@@ -16,11 +16,11 @@ jobs:
     # Checkout both the merge commit for the PR and the
     # source branch for the PR.
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         path: merge
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: source

--- a/.github/workflows/whitespaceCheck.yml
+++ b/.github/workflows/whitespaceCheck.yml
@@ -4,7 +4,7 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         # So that we get the branch for `base_ref`.
         fetch-depth: 0


### PR DESCRIPTION
GitHub is moving to running actions on Node24 as of June 16th, as Node20 is EOL. We've already updated the actions in main.yml, but need to update these as well.