### PR TITLE
PlugLayout : Avoid updates when private plugs are dirtied

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.7.x.x (relative to 1.7.0.0a4)
 =======
 
+Fixes
+-----
 
+- NodeEditor : Fixed redundant updates when editing private plugs, such as when repositioning the currently viewed node in the Graph Editor.
 
 1.7.0.0a4 (relative to 1.7.0.0a3)
 =========

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -160,30 +160,38 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__setValueChanged( any( values ) )
 
+	## \todo This has a pretty high overhead for large plug hierarchies, such
+	# as those in Spreadsheets. It could probably benefit from being reimplemented
+	# in C++, which would mean reimplementing NodeAlgo's user-default mechanism
+	# in C++ too.
 	@staticmethod
 	def _hasUserValue( plug ) :
 
-		if plug.direction() == Gaffer.Plug.Direction.Out :
-			return False
+		def walk( plug, checkIsSetToDefault ) :
 
-		if plug.getInput() is not None :
-			return True
+			if plug.direction() == Gaffer.Plug.Direction.Out :
+				return False
 
-		if any(
-			p.getInput() is not None and p.direction() != Gaffer.Plug.Direction.Out
-			for p in Gaffer.Plug.RecursiveRange( plug )
-		) :
-			return True
+			if plug.getInput() is not None :
+				return True
 
-		if isinstance( plug, Gaffer.ValuePlug ) and Gaffer.NodeAlgo.hasUserDefault( plug ) :
-			return not Gaffer.NodeAlgo.isSetToUserDefault( plug )
+			if isinstance( plug, Gaffer.ValuePlug ) and Gaffer.NodeAlgo.hasUserDefault( plug ) :
+				if not Gaffer.NodeAlgo.isSetToUserDefault( plug ) :
+					return True
+				else :
+					# Plug is at the user-specified default value. We still
+					# need to check for connections to children, but don't
+					# want to check their values against the non-user default.
+					checkIsSetToDefault = False
 
-		if len( plug ) :
-			return any( LabelPlugValueWidget._hasUserValue( p ) for p in Gaffer.Plug.Range( plug ) )
-		elif isinstance( plug, Gaffer.ValuePlug ) :
-			return not plug.isSetToDefault()
-		else :
-			return False
+			if len( plug ) :
+				return any( walk( p, checkIsSetToDefault ) for p in Gaffer.Plug.Range( plug ) )
+			elif checkIsSetToDefault and isinstance( plug, Gaffer.ValuePlug ) :
+				return not plug.isSetToDefault()
+			else :
+				return False
+
+		return walk( plug, checkIsSetToDefault = True )
 
 	# Sets whether or not the label be rendered in a ValueChanged state.
 	def __setValueChanged( self, valueChanged ) :

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -580,8 +580,19 @@ class PlugLayout( GafferUI.Widget ) :
 		if plug.direction() != plug.Direction.In :
 			return
 
+		# Private plugs do not affect activations or summaries.
+		relativeName = plug.relativeName( self.__node() )
+		if relativeName.startswith( "__" ) or ".__" in relativeName :
+			return
+
+		# Activations can depend on any plug on this node.
 		self.__activationsDirty = True
-		self.__summariesDirty = True
+
+		# But summaries and `section.valuesChanged` can only depend
+		# on plugs we are actually displaying.
+		if self.__parent.isAncestorOf( plug ) :
+			self.__summariesDirty = True
+
 		self.__updateLazily()
 
 	def __contextChanged( self, contextTracker ) :

--- a/python/GafferUITest/LabelPlugValueWidgetTest.py
+++ b/python/GafferUITest/LabelPlugValueWidgetTest.py
@@ -39,6 +39,7 @@ import unittest
 import imath
 
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 
@@ -136,6 +137,17 @@ class LabelPlugValueWidgetTest( GafferUITest.TestCase ) :
 		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"] ) )
 		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"]["x"] ) )
 		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"]["y"] ) )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testHasUserValuePerformance( self ) :
+
+		spreadsheet = Gaffer.Spreadsheet()
+		for i in range( 10 ) :
+			spreadsheet["rows"].addColumn( Gaffer.V3fPlug() )
+		spreadsheet["rows"].addRows( 1000 )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferUI.LabelPlugValueWidget._hasUserValue( spreadsheet["rows" ] )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
We don't display private plugs in a PlugLayout, but were still triggering a lazy update of the PlugLayout when they were dirtied. This was reported on Discord as UI slowdown in the Graph Editor when repositioning large Spreadsheet nodes while they were visible in the Node Editor. Moving the node would update its `__uiPosition` plug and trigger a lazy update of the PlugLayout.