### PR TITLE
CI : Skip double-archiving of build artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -367,11 +367,8 @@ jobs:
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{ env.GAFFER_BUILD_NAME }}
         path: ${{ env.GAFFER_BUILD_NAME }}.${{ env.PACKAGE_EXTENSION }}
-        # Using compression-level 0 avoids compressing our already compressed
-        # package and results in a significantly faster upload.
-        compression-level: 0
+        archive: false
       if: matrix.publish
 
     - name: Publish Release


### PR DESCRIPTION
[actions/upload-artifact](https://github.com/actions/upload-artifact#upload-an-individual-file-unzipped) 7.0.0 added the ability to directly upload a single file without compressing it into a zip archive by setting `archive: false`. We can now use this to directly upload our already compressed build packages and avoid having to deal with double-archived PR build artifacts. The name of the uploaded file is used as the artifact name, so we no longer specify `name:` when uploading as it is ignored in this case.