### PR TITLE
RenderMan : Hide/Remove unused inputs on Stylized shading nodes

### DIFF
--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -511,6 +511,71 @@ shaderMetadata = {
 
 	},
 
+	"osl:shader:PxrStylizedControl" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "inputRGB", "Artistic_Light_Rotation_Vector", "lineAlbedo", "distortU", "distortV", "inputTextureCoords", "resultRGB", "resultAOV" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrStylizedHatchControl" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "Hatching_Signal_Input", "Input_RGB", "NPRalbedo2", "NPRalbedo3", "Input_Texture_Coords", "resultRGB", "resultAOV" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrStylizedLightControl" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "Input_RGB", "Artistic_Light_Rotation_Vector", "Result_RGB", "Result_Float", "Result_Shadow_Float", "Result_Lighting_Float", "resultAOV" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrStylizedLinesControl" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "Line_Color_RGB", "Normal_Map", "resultRGB", "resultAOV" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrStylizedToonControl" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "Input_RGB", "Signal_Input_Float", "Shadow_Input_Float", "resultRGB", "resultAOV" ]
+
+		},
+
+	},
+
 }
 
 for shader, metadata in shaderMetadata.items() :


### PR DESCRIPTION
This PR is to reduce the display of RenderMan Stylized Looks Shading nodes, as these nodes are used heavily currently they expose every parameter as an input node. I've made changes to the visible ports by default based on usage. 
- PxrStylizedControl: Reduced the default ports that are displayed to minimize the size of the node.
- PxrStylizedHatchControl: Reduced the default ports that are displayed to minimize the size of the node.
- PxrStylizedLineControl: Reduced the default ports that are displayed to minimize the size of the node.
- PxrStylizedToonControl: Reduced the default ports that are displayed to minimize the size of the node.

### Related issues ###

- PxrStylizedControl: Node display is much more manageable and correctly reflects actual use for required ports.
- PxrStylizedHatchControl: Node display is much more manageable and correctly reflects actual use for required ports.
- PxrStylizedLineControl: Node display is much more manageable and correctly reflects actual use for required ports.
- PxrStylizedToonControl: Node display is much more manageable and correctly reflects actual use for required ports.

### Dependencies ###

- None

### Breaking changes ###

- There are no breaking changes

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.