### PR TITLE
ShadingEngine : Add TextureOrigin parameter

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Fixes
 - NodeEditor : Fixed redundant updates when editing private plugs, such as when repositioning the currently viewed node in the Graph Editor.
 - RenderPassEditor : Fixed errors displaying presets while editing the `type` column [^1].
 
+API
+---
+
+- ShadingEngine : Added `TextureOrigin` enum, to allow emulation of renderers whose texture origin is at the top left rather than bottom left.
+
 Breaking Changes
 ----------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,8 @@ Breaking Changes
 ----------------
 
 - RenderPassTypeAdaptorUI : Removed `renderPassTypePresetNames()` and `renderPassTypePresetValues()`.
+- OpenImageIO : Removed source compatibility for versions prior to 3.
+- OpenShadingLanguage : Removed source compatibility for versions prior to 1.14.
 
 [^1]: Fix for bug introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
 

--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -54,10 +54,19 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 
 		IE_CORE_DECLAREMEMBERPTR( ShadingEngine )
 
-		explicit ShadingEngine( const IECoreScene::ShaderNetwork *shaderNetwork );
+		enum class TextureOrigin
+		{
+			// 0 at the bottom, 1 at the top. Gaffer's standard coordinate system.
+			Bottom,
+			// 0 at the top, 1 at the bottom. For emulating renderers with upside
+			// down textures.
+			Top
+		};
+
+		explicit ShadingEngine( const IECoreScene::ShaderNetwork *shaderNetwork, TextureOrigin textureOrigin = TextureOrigin::Bottom );
 
 		// Fast version that takes ownership of network instead of copying
-		ShadingEngine( IECoreScene::ShaderNetworkPtr &&shaderNetwork );
+		ShadingEngine( IECoreScene::ShaderNetworkPtr &&shaderNetwork, TextureOrigin textureOrigin = TextureOrigin::Bottom );
 
 		~ShadingEngine() override;
 
@@ -98,6 +107,7 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 
 		void queryShaderGroup();
 
+		const TextureOrigin m_textureOrigin;
 		const IECore::MurmurHash m_hash;
 
 		bool m_timeNeeded;

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -719,19 +719,25 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 
 	def testTextureOrientation( self ) :
 
-		s = self.compileShader( pathlib.Path( __file__ ).parent / "shaders" / "uvTextureMap.osl" )
-		e = GafferOSL.ShadingEngine( IECoreScene.ShaderNetwork(
+		shader = self.compileShader( pathlib.Path( __file__ ).parent / "shaders" / "uvTextureMap.osl" )
+		shaderNetwork = IECoreScene.ShaderNetwork(
 			shaders = {
-				"output" : IECoreScene.Shader( s, "osl:surface", { "fileName" : ( pathlib.Path( __file__ ).parent / "images" / "vRamp.tx" ).as_posix() } )
+				"output" : IECoreScene.Shader( shader, "osl:surface", { "fileName" : ( pathlib.Path( __file__ ).parent / "images" / "vRamp.tx" ).as_posix() } )
 			},
 			output = "output"
-		) )
+		)
 
-		p = self.rectanglePoints()
-		r = e.shade( p )
+		for origin in ( GafferOSL.ShadingEngine.TextureOrigin.values.values() ) :
 
-		for i, c in enumerate( r["Ci"] ) :
-			self.assertAlmostEqual( c[1], p["v"][i], delta = 0.02 )
+			engine = GafferOSL.ShadingEngine( shaderNetwork, origin )
+			points = self.rectanglePoints()
+			result = engine.shade( points )
+
+			for i, c in enumerate( result["Ci"] ) :
+				if origin == GafferOSL.ShadingEngine.TextureOrigin.Bottom :
+					self.assertAlmostEqual( c[1], points["v"][i], delta = 0.02 )
+				else :
+					self.assertAlmostEqual( c[1], 1.0 - points["v"][i], delta = 0.02 )
 
 	def testDerivatives( self ) :
 

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -54,7 +54,6 @@
 #include "IECore/FileSequenceFunctions.h"
 #include "IECore/MessageHandler.h"
 
-#include "OpenImageIO/imagecache.h"
 #include "OpenImageIO/deepdata.h"
 
 #include <boost/algorithm/string.hpp>

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -82,13 +82,9 @@ namespace
 {
 
 // When OSL uses a TypeDesc to say it is holding an `OIIO::TypeString`,
-// that is not actually true. Instead, it will either be referring to
-// a `ustringhash` or a `ustring`, depending on library version.
-#if OSL_LIBRARY_VERSION_CODE >= 11400
+// that is not actually true. Instead, it will be referring to
+// a `ustringhash`.
 using OSLStringType = ustringhash;
-#else
-using OSLStringType = ustring;
-#endif
 
 //////////////////////////////////////////////////////////////////////////
 // RenderState. OSL would think of this as representing the object

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -310,7 +310,7 @@ bool convertValueToOSL( void *dst, TypeDesc dstType, const void *src, TypeDesc s
 		{
 			return true;
 		}
-#if OSL_LIBRARY_VERSION_CODE >= 11400
+
 		if( g_shadingSystemBatchSize > 1 )
 		{
 			*(ustring *)dst = *(const char**)src;
@@ -319,9 +319,7 @@ bool convertValueToOSL( void *dst, TypeDesc dstType, const void *src, TypeDesc s
 		{
 			*(ustringhash *)dst = ustringhash( *(const char**)src );
 		}
-#else
-		*(ustring *)dst = *(const char**)src;
-#endif
+
 		return true;
 	}
 
@@ -415,13 +413,7 @@ struct PointCloud
 
 	}
 
-#if OSL_LIBRARY_VERSION_CODE >= 11400
-		using PointIndex = int;
-#else
-		using PointIndex = size_t;
-#endif
-
-	int search( const OSL::Vec3 &center, float radius, int maxPoints, PointIndex *outIndices, float *outDistances ) const
+	int search( const OSL::Vec3 &center, float radius, int maxPoints, int *outIndices, float *outDistances ) const
 	{
 		vector<IECore::V3fTree::Neighbour> neighbours;
 		neighbours.reserve( maxPoints );
@@ -466,14 +458,13 @@ struct PointCloud
 		return it != m_attributes.end() ? &it->second : nullptr;
 	}
 
-	int get( const Attribute &attribute, PointIndex index, TypeDesc outType, void *outData ) const
+	int get( const Attribute &attribute, int index, TypeDesc outType, void *outData ) const
 	{
-#if OSL_LIBRARY_VERSION_CODE >= 11400
 		if( index < 0 )
 		{
 			return 0;
 		}
-#endif
+
 		if( (size_t)index >= m_size )
 		{
 			return 0;
@@ -828,7 +819,7 @@ class GafferBatchedRendererServices : public OSL::BatchedRendererServices<WidthT
 				return;
 			}
 
-			vector<PointCloud::PointIndex> tmpIndices( maxPoints ); tmpIndices.resize( maxPoints );
+			vector<int> tmpIndices( maxPoints ); tmpIndices.resize( maxPoints );
 			vector<float> tmpDistances( maxPoints ); tmpDistances.resize( maxPoints );
 
 			auto wideIndices = results.windices();
@@ -1131,7 +1122,7 @@ class RendererServices : public OSL::RendererServices
 
 		int pointcloud_search(
 			ShaderGlobals *sg, ustringhash filename, const OSL::Vec3 &center, float radius, int maxPoints,
-			bool sort, PointCloud::PointIndex *outIndices, float *outDistances,
+			bool sort, int *outIndices, float *outDistances,
 			int derivsOffset
 		) override
 		{
@@ -1171,14 +1162,8 @@ class RendererServices : public OSL::RendererServices
 			return numPoints;
 		}
 
-#if OSL_LIBRARY_VERSION_CODE >= 11400
-		using ConstPointIndex = const PointCloud::PointIndex;
-#else
-		using ConstPointIndex = PointCloud::PointIndex;
-#endif
-
 		int pointcloud_get(
-			ShaderGlobals *sg, ustringhash filename, ConstPointIndex *indices, int count,
+			ShaderGlobals *sg, ustringhash filename, const int *indices, int count,
 			ustringhash attrName, TypeDesc attrType,
 			void *outData
 		) override
@@ -1255,8 +1240,6 @@ struct EmissionParameters
 struct StringParameter
 {
 
-#if OSL_LIBRARY_VERSION_CODE >= 11400
-
 	static_assert( sizeof( ustring ) == sizeof( ustringhash ) );
 	static_assert( is_trivially_copyable_v<ustring> );
 	static_assert( is_trivially_copyable_v<ustringhash> );
@@ -1282,14 +1265,6 @@ struct StringParameter
 	// We just use bytes for storage so we can deal with both cases.
 	std::byte storage[sizeof(ustring)];
 
-#else
-
-	ustring asUString() const { return string; }
-	ustring string;
-
-#endif
-
-
 };
 
 struct DebugParameters
@@ -1312,11 +1287,7 @@ ShadingSystemWriteMutex g_shadingSystemWriteMutex;
 OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 {
 	ShadingSystemWriteMutex::scoped_lock shadingSystemWriteLock( g_shadingSystemWriteMutex );
-#if OIIO_VERSION >= 30000
 	static std::shared_ptr<OSL::TextureSystem> g_textureSystem = nullptr;
-#else
-	static OSL::TextureSystem *g_textureSystem = nullptr;
-#endif
 	static OSL::ShadingSystem *g_shadingSystem = nullptr;
 
 	if( g_shadingSystem )
@@ -1335,13 +1306,8 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 	g_textureSystem->attribute( "flip_t", 1 );
 
 	g_shadingSystem = new ShadingSystem(
-#if OIIO_VERSION >= 30000
 		new RendererServices( g_textureSystem.get() ),
 		g_textureSystem.get()
-#else
-		new RendererServices( g_textureSystem ),
-		g_textureSystem
-#endif
 	);
 
 	ClosureParam emissionParams[] = {

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -64,6 +64,7 @@
 #include "OSL/wide.h"
 #endif
 
+#include "OpenImageIO/imagecache.h"
 #include "OpenImageIO/ustring.h"
 
 #include "boost/algorithm/string/classification.hpp"
@@ -1284,30 +1285,36 @@ struct DebugParameters
 using ShadingSystemWriteMutex = tbb::spin_mutex;
 ShadingSystemWriteMutex g_shadingSystemWriteMutex;
 
-OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
+OSL::ShadingSystem *acquireShadingSystem( ShadingEngine::TextureOrigin textureOrigin, int *batchSize = nullptr )
 {
 	ShadingSystemWriteMutex::scoped_lock shadingSystemWriteLock( g_shadingSystemWriteMutex );
-	static std::shared_ptr<OSL::TextureSystem> g_textureSystem = nullptr;
-	static OSL::ShadingSystem *g_shadingSystem = nullptr;
+	// One for each value of TextureOrigin.
+	static std::array<std::shared_ptr<OIIO::TextureSystem>, 2> g_textureSystems;
+	static std::array<OSL::ShadingSystem *, 2> g_shadingSystems = { nullptr, nullptr };
 
-	if( g_shadingSystem )
+	OSL::ShadingSystem *&shadingSystem = g_shadingSystems[(int)textureOrigin];
+
+	if( shadingSystem )
 	{
 		if( batchSize )
 		{
 			*batchSize = g_shadingSystemBatchSize;
 		}
-		return g_shadingSystem;
+		return shadingSystem;
 	}
 
-	g_textureSystem = OIIO::TextureSystem::create( /* shared = */ false );
-	// By default, OIIO considers the image origin to be at the
-	// top left. We consider it to be at the bottom left.
-	// Compensate.
-	g_textureSystem->attribute( "flip_t", 1 );
+	// One ImageCache, not shared with the outside world, but shared by both `TextureOrigin::Bottom`
+	// and `TextureOrigin::Top`.
+	static std::shared_ptr<OIIO::ImageCache> g_imageCache = OIIO::ImageCache::create( /* shared = */ false );
+	std::shared_ptr<OIIO::TextureSystem> &textureSystem = g_textureSystems[(int)textureOrigin];
 
-	g_shadingSystem = new ShadingSystem(
-		new RendererServices( g_textureSystem.get() ),
-		g_textureSystem.get()
+	textureSystem = OIIO::TextureSystem::create( /* shared = */ false, g_imageCache );
+	// By default, OIIO considers the image origin to be at the top left.
+	textureSystem->attribute( "flip_t", textureOrigin == ShadingEngine::TextureOrigin::Bottom ? 1 : 0 );
+
+	shadingSystem = new ShadingSystem(
+		new RendererServices( textureSystem.get() ),
+		textureSystem.get()
 	);
 
 	ClosureParam emissionParams[] = {
@@ -1324,7 +1331,7 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 		CLOSURE_FINISH_PARAM( DebugParameters )
 	};
 
-	g_shadingSystem->register_closure(
+	shadingSystem->register_closure(
 		/* name */ "emission",
 		/* id */ EmissionClosureId,
 		/* params */ emissionParams,
@@ -1332,7 +1339,7 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 		/* setup */ nullptr
 	);
 
-	g_shadingSystem->register_closure(
+	shadingSystem->register_closure(
 		/* name */ "debug",
 		/* id */ DebugClosureId,
 		/* params */ debugParams,
@@ -1340,7 +1347,7 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 		/* setup */ nullptr
 	);
 
-	g_shadingSystem->register_closure(
+	shadingSystem->register_closure(
 		/* name */ "deformation",
 		/* id */ DeformationClosureId,
 		/* params */ debugParams,
@@ -1350,21 +1357,21 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 
 	if( const char *searchPath = getenv( "OSL_SHADER_PATHS" ) )
 	{
-		g_shadingSystem->attribute( "searchpath:shader", searchPath );
+		shadingSystem->attribute( "searchpath:shader", searchPath );
 	}
 
 	if( const char *oslHome = getenv( "OSLHOME" ) )
 	{
-		g_shadingSystem->attribute( "searchpath:library", ( std::filesystem::path( oslHome ) / "lib" ).string() );
+		shadingSystem->attribute( "searchpath:library", ( std::filesystem::path( oslHome ) / "lib" ).string() );
 	}
 	else
 	{
 		msg( Msg::Warning, "ShadingEngine", "Please set OSLHOME env var to allow finding OSL libraries." );
 	}
 
-	g_shadingSystem->attribute( "lockgeom", 1 );
+	shadingSystem->attribute( "lockgeom", 1 );
 
-	g_shadingSystem->attribute( "commonspace", "object" );
+	shadingSystem->attribute( "commonspace", "object" );
 
 	g_shadingSystemBatchSize = 1;
 
@@ -1385,11 +1392,11 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 	// farm ... getting a subtle flicker because frames that hit out of date farm blades
 	// render ever-so-slightly darker is not much fun.
 
-	if( requestBatch && g_shadingSystem->configure_batch_execution_at( 16 ) )
+	if( requestBatch && shadingSystem->configure_batch_execution_at( 16 ) )
 	{
 		g_shadingSystemBatchSize = 16;
 	}
-	else if( requestBatch && g_shadingSystem->configure_batch_execution_at( 8 ) )
+	else if( requestBatch && shadingSystem->configure_batch_execution_at( 8 ) )
 	{
 		g_shadingSystemBatchSize = 8;
 	}
@@ -1405,9 +1412,9 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 	else
 	{
 		ustring llvm_jit_target;
-		g_shadingSystem->getattribute("llvm_jit_target", llvm_jit_target);
+		shadingSystem->getattribute("llvm_jit_target", llvm_jit_target);
 		int llvm_jit_fma;
-		g_shadingSystem->getattribute("llvm_jit_fma", llvm_jit_fma);
+		shadingSystem->getattribute("llvm_jit_fma", llvm_jit_fma);
 
 		msg( Msg::Info, "ShadingEngine", fmt::format( "Initialized shading system with support for {}-wide batched shading. Architecture: {}, Fused-Multiply-Add: {}", g_shadingSystemBatchSize, llvm_jit_target.string(), llvm_jit_fma ? "Enabled" : "Disabled" ) );
 	}
@@ -1417,7 +1424,7 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 	{
 		*batchSize = g_shadingSystemBatchSize;
 	}
-	return g_shadingSystem;
+	return shadingSystem;
 }
 
 } // namespace
@@ -1629,21 +1636,27 @@ class ShadingResults
 // and the OSL machinery that needs to be stored per "renderer-thread"
 struct ThreadInfo
 {
-	ThreadInfo() :
-		oslThreadInfo( ::shadingSystem()->create_thread_info() ),
-		shadingContext( ::shadingSystem()->get_context( oslThreadInfo ) )
+	ThreadInfo( OSL::ShadingSystem *shadingSystem ) :
+		oslThreadInfo( shadingSystem->create_thread_info() ),
+		shadingContext( shadingSystem->get_context( oslThreadInfo ) ),
+		m_shadingSystem( shadingSystem )
 	{
 	}
 
 	~ThreadInfo()
 	{
-		::shadingSystem()->release_context( shadingContext );
-		::shadingSystem()->destroy_thread_info( oslThreadInfo );
+		m_shadingSystem->release_context( shadingContext );
+		m_shadingSystem->destroy_thread_info( oslThreadInfo );
 	}
 
 	ShadingResults::DebugResultsMap debugResults;
 	OSL::PerThreadInfo *oslThreadInfo;
 	OSL::ShadingContext *shadingContext;
+
+	private :
+
+		OSL::ShadingSystem *m_shadingSystem;
+
 };
 
 
@@ -1729,16 +1742,17 @@ bool shaderExists( const IECoreScene::Shader *shader )
 
 } // namespace
 
-ShadingEngine::ShadingEngine( const IECoreScene::ShaderNetwork *shaderNetwork ) : ShadingEngine( shaderNetwork->copy() )
+ShadingEngine::ShadingEngine( const IECoreScene::ShaderNetwork *shaderNetwork, TextureOrigin textureOrigin )
+	:	ShadingEngine( shaderNetwork->copy(), textureOrigin )
 {
 }
 
-ShadingEngine::ShadingEngine( IECoreScene::ShaderNetworkPtr &&shaderNetwork )
-	:	m_hash( shaderNetwork->Object::hash() ), m_timeNeeded( false ), m_unknownAttributesNeeded( false ), m_hasDeformation( false )
+ShadingEngine::ShadingEngine( IECoreScene::ShaderNetworkPtr &&shaderNetwork, TextureOrigin textureOrigin )
+	:	m_textureOrigin( textureOrigin ), m_hash( shaderNetwork->Object::hash() ), m_timeNeeded( false ), m_unknownAttributesNeeded( false ), m_hasDeformation( false )
 {
 	IECoreScene::ShaderNetworkAlgo::convertToOSLConventions( shaderNetwork.get(), OSL_VERSION );
 
-	ShadingSystem *shadingSystem = ::shadingSystem();
+	ShadingSystem *shadingSystem = acquireShadingSystem( textureOrigin );
 
 	{
 		ShadingSystemWriteMutex::scoped_lock shadingSystemWriteLock( g_shadingSystemWriteMutex );
@@ -1793,7 +1807,7 @@ ShadingEngine::ShadingEngine( IECoreScene::ShaderNetworkPtr &&shaderNetwork )
 
 void ShadingEngine::queryShaderGroup()
 {
-	ShadingSystem *shadingSystem = ::shadingSystem();
+	ShadingSystem *shadingSystem = acquireShadingSystem( m_textureOrigin );
 	ShaderGroup &shaderGroup = **static_cast<ShaderGroupRef *>( m_shaderGroupRef );
 
 	// Globals
@@ -1896,6 +1910,11 @@ namespace
 
 struct ExecuteShadeParameters
 {
+	ExecuteShadeParameters( OSL::ShadingSystem *shadingSystem )
+		:	threadInfoCache( shadingSystem )
+	{
+	}
+
 	ShaderGlobals shaderGlobals;
 
 	const IECore::Canceller *canceller;
@@ -2098,9 +2117,9 @@ IECore::CompoundDataPtr ShadingEngine::shade( const IECore::CompoundData *points
 {
 	ShaderGroup &shaderGroup = **static_cast<ShaderGroupRef *>( m_shaderGroupRef );
 
-	ExecuteShadeParameters shadeParameters;
 	int batchSize;
-	ShadingSystem *shadingSystem = ::shadingSystem( &batchSize );
+	ShadingSystem *shadingSystem = ::acquireShadingSystem( m_textureOrigin, &batchSize );
+	ExecuteShadeParameters shadeParameters( shadingSystem );
 
 	const Gaffer::Context *context = Gaffer::Context::current();
 	shadeParameters.canceller = context->canceller();

--- a/src/GafferOSLModule/GafferOSLModule.cpp
+++ b/src/GafferOSLModule/GafferOSLModule.cpp
@@ -226,8 +226,24 @@ BOOST_PYTHON_MODULE( _GafferOSL )
 
 
 	{
-		scope s = IECorePython::RefCountedClass<ShadingEngine, IECore::RefCounted>( "ShadingEngine" )
-			.def( init<const IECoreScene::ShaderNetwork *>() )
+		IECorePython::RefCountedClass<ShadingEngine, IECore::RefCounted> shadingEngineClass( "ShadingEngine" );
+		scope s = shadingEngineClass;
+
+		enum_<ShadingEngine::TextureOrigin>( "TextureOrigin" )
+			.value( "Bottom", ShadingEngine::TextureOrigin::Bottom )
+			.value( "Top", ShadingEngine::TextureOrigin::Top )
+		;
+
+		class_<ShadingEngine::Transform>( "Transform" )
+			.def( init<const Imath::M44f &>() )
+			.def( init<const Imath::M44f &, const Imath::M44f&>() )
+			.def_readwrite( "fromObjectSpace", &ShadingEngine::Transform::fromObjectSpace )
+			.def_readwrite( "toObjectSpace", &ShadingEngine::Transform::toObjectSpace )
+			.def( "__repr__", &repr )
+		;
+
+		shadingEngineClass
+			.def( init<const IECoreScene::ShaderNetwork *, ShadingEngine::TextureOrigin>( ( arg( "shaderNetwork" ), arg( "textureOrigin" ) = ShadingEngine::TextureOrigin::Bottom ) ) )
 			.def( "hash", &ShadingEngine::hash )
 			.def( "shade", &shadeWrapper,
 				(
@@ -240,13 +256,7 @@ BOOST_PYTHON_MODULE( _GafferOSL )
 			.def( "hasDeformation", &ShadingEngine::hasDeformation )
 		;
 
-		class_<ShadingEngine::Transform>( "Transform" )
-			.def( init<const Imath::M44f &>() )
-			.def( init<const Imath::M44f &, const Imath::M44f&>() )
-			.def_readwrite( "fromObjectSpace", &ShadingEngine::Transform::fromObjectSpace )
-			.def_readwrite( "toObjectSpace", &ShadingEngine::Transform::toObjectSpace )
-			.def( "__repr__", &repr )
-		;
+
 	}
 
 	{


### PR DESCRIPTION
For our own OSLImage and OSLObject nodes, we chose a bottom-left origin, as we believe it is far more natural for users. And since these two nodes were the only clients of ShadingEngine, we just hardcoded the direction in there. But we now have a use case at Cinesite where ShadingEngine is being used to bake RenderMan OSL shaders to primvars, and we need to emulate the RenderMan top-left origin, so we're exposing the option to create an upside-down ShadingEngine. We are careful to make sure that both ShadingEngines share the same underlying ImageCache so hopefully are not adding much memory overhead even in the case that we do access the same texture with different orientations.

It's unfortunate that OSL itself didn't take the opportunity to make a stand on this, and prescribe the one true direction. That the same shader can render a trivial `texture()` call with completely different orientations depending on the host renderer is a bit vexing when otherwise OSL is so close to being portable.

One alternative approach I considered was to allow an arbitrary CompoundData of attributes to be passed, which would then be sent to `OIIO::TextureSystem::attribute()` and/or `OSL::ShadingSystem::attribute()`. This potentially gives a client more flexibility, but at the risk of letting them break something we needed to have control over. So for now I'm only exposing the minimal control necessary for the one use case we have.