### PR TITLE
IECoreScene::PointInstancer rendering, round 1

### DIFF
--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -111,6 +111,8 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				const ObjectSamples &capturedSamples() const;
 				const SampleTimes &capturedSampleTimes() const;
 
+				const std::vector<Prototype> &capturedPointInstancerPrototypes() const;
+
 				const TransformSamples &capturedTransforms() const;
 				const SampleTimes &capturedTransformTimes() const;
 
@@ -143,6 +145,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				const std::string m_name;
 				ObjectSamples m_capturedSamples;
 				SampleTimes m_capturedSampleTimes;
+				std::vector<Prototype> m_capturedPointInstancerPrototypes;
 				TransformSamples m_capturedTransforms;
 				SampleTimes m_capturedTransformTimes;
 				ConstCapturedAttributesPtr m_capturedAttributes;
@@ -169,6 +172,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;
 

--- a/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CompoundRenderer.h
@@ -63,6 +63,7 @@ class GAFFERSCENE_API CompoundRenderer final : public IECoreScenePreview::Render
 		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const IECoreScenePreview::Renderer::ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes ) override;
 		void render() override;
 		void pause() override;
 		IECore::DataPtr command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters ) override;

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -40,6 +40,7 @@
 
 #include "IECoreScene/Camera.h"
 #include "IECoreScene/Output.h"
+#include "IECoreScene/PointInstancer.h"
 
 #include "IECore/CompoundObject.h"
 #include "IECore/MessageHandler.h"
@@ -168,6 +169,7 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		using TransformSamples = Samples<Imath::M44f>;
 		using CameraSamples = Samples<IECoreScene::ConstCameraPtr>;
 		using ObjectSamples = Samples<IECore::ConstObjectPtr>;
+		using PointInstancerSamples = Samples<IECoreScene::ConstPointInstancerPtr>;
 		using SampleTimes = Samples<float>;
 
 		/// Convenience function for casting between sample types. Typically
@@ -311,6 +313,20 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		virtual ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) = 0;
 		/// Convenience overload for when there is only a single object sample.
 		ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes );
+
+		/// Prototype geometry for use in the `pointInstancer()` method.
+		struct Prototype
+		{
+			ObjectSamples samples;
+			SampleTimes times;
+			AttributesInterfacePtr attributes;
+		};
+		/// Renders prototype geometry instanced onto a point cloud.
+		/// > Note : It is the caller's responsibility to have
+		/// > prepared `prototypes` based on the value of
+		/// >`PointInstancer::getPrototypes()`. Therefore the renderer
+		/// > need not be concerned with the value of `getPrototypes()`.
+		virtual ObjectInterfacePtr pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes );
 
 		/// Performs the render - should be called after the
 		/// entire scene has been specified using the methods

--- a/include/GafferScene/Private/PointInstancerAlgo.h
+++ b/include/GafferScene/Private/PointInstancerAlgo.h
@@ -1,0 +1,61 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/Private/RendererAlgo.h"
+
+#include "IECoreScene/PointInstancer.h"
+
+/// Utilities to aid in rendering PointInstancers.
+namespace GafferScene::Private::PointInstancerAlgo
+{
+
+/// Returns a combined `SceneAlgo::hierarchyHash()` of all prototypes referenced by any PointInstancer
+/// at the current location. If there is no PointInstancer, returns an empty hash.
+GAFFERSCENE_API IECore::MurmurHash prototypesHash( const ScenePlug *scene );
+
+/// Generates the list of `Renderer::Prototypes` ready for passing to `Renderer::pointInstancer()`.
+GAFFERSCENE_API std::vector<IECoreScenePreview::Renderer::Prototype> prototypes( const IECoreScene::PointInstancer *instancer, const RendererAlgo::RenderOptions &renderOptions, const ScenePlug *scene, IECoreScenePreview::Renderer *renderer );
+
+/// Flattens a PointInstancer so that it refers only to leaf-level locations. Adds additional points
+/// as necessary whenever an input prototype contains multiple leaf locations. Also transfers transforms
+/// from the prototypes onto the points, so we don't need to pass prototype transforms to the Renderer.
+/// Omits invisible points, since there is no point passing them to the renderer.
+GAFFERSCENE_API IECoreScene::PointInstancerPtr flatten( const IECoreScene::PointInstancer *instancer, const RendererAlgo::RenderOptions &renderOptions, const ScenePlug *scene );
+
+} // namespace GafferScene::Private::PointInstancerAlgo

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -133,6 +133,15 @@ struct SampledObject
 	IECoreScenePreview::Renderer::ObjectSamples samples;
 	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 };
+
+struct ObjectHash
+{
+	IECore::MurmurHash value;
+	bool isPointInstancer = false;
+	bool operator==( const ObjectHash &rhs ) const { return value == rhs.value && isPointInstancer == rhs.isPointInstancer; }
+	bool operator!=( const ObjectHash &rhs ) const { return !(*this == rhs); }
+};
+
 /// Samples the object from the current location in preparation for output to the renderer. The
 /// `sampleTimes` should have been obtained from `deformationMotionTimes()` and the current context should
 /// match the frame being output.
@@ -145,10 +154,10 @@ struct SampledObject
 /// sample from the current frame, no matter the values in `sampleTimes`. Therefore the returned `sampleTimes`
 /// may differ from the `sampleTimes` passed in. It is the _returned_ `sampleTimes` that should be passed to
 /// the Renderer.
-GAFFERSCENE_API std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECore::MurmurHash *hash = nullptr );
+GAFFERSCENE_API std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, ObjectHash *hash = nullptr );
 
-/// Outputs a sampled object to the renderer. This takes care of special cases for Capsules.
-GAFFERSCENE_API IECoreScenePreview::Renderer::ObjectInterfacePtr outputObject( const std::string &name, const SampledObject &sampledObject, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const RenderOptions &renderOptions, IECoreScenePreview::Renderer *renderer );
+/// Outputs a sampled object to the renderer. This takes care of special cases for Capsules and PointInstancers.
+GAFFERSCENE_API IECoreScenePreview::Renderer::ObjectInterfacePtr outputObject( const std::string &name, const SampledObject &sampledObject, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const RenderOptions &renderOptions, const ScenePlug *scene, IECoreScenePreview::Renderer *renderer );
 
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, IECoreScenePreview::Renderer *renderer );
 GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -38,6 +38,8 @@ import unittest
 
 import IECore
 
+import GafferDelight
+import GafferOSL
 import GafferSceneTest
 
 class DelightRenderTest( GafferSceneTest.RenderTest ) :
@@ -46,6 +48,7 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 	sceneDescriptionSuffix = ".nsi"
 	# Apparent bug in 3Delight's EXR driver writes M44f as Box2f.
 	unsupportedOutputMetadataTypes = [ IECore.M44fData ]
+	pointInstancerSupported = True
 
 	@unittest.skip( "No light linking support just yet" )
 	def testLightLinking( self ) :
@@ -61,6 +64,23 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 	def testInstanceIDOutput( self ) :
 
 		pass
+
+	def _createConstantShader( self ) :
+
+		shader = GafferOSL.OSLShader()
+		shader.loadShader( "Surface/Constant" )
+		return shader, shader["parameters"]["Cs"], shader["out"]["out"]
+
+	def _createOptions( self ) :
+
+		# Improve anti-aliasing for motion-blur tests.
+
+		options = GafferDelight.DelightOptions()
+
+		options["options"]["dl:oversampling"]["enabled"].setValue( True )
+		options["options"]["dl:oversampling"]["value"].setValue( 16 )
+
+		return options
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightTest/InteractiveDelightRenderTest.py
+++ b/python/GafferDelightTest/InteractiveDelightRenderTest.py
@@ -48,6 +48,7 @@ import GafferDelight
 class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	renderer = "3Delight"
+	pointInstancerSupported = True
 
 	@unittest.skip( "No light linking support just yet" )
 	def testBasicLightLinking( self ) :

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
@@ -119,5 +119,44 @@ class CompoundRendererTest( GafferTest.TestCase ) :
 			self.assertEqual( o.capturedLinks( "lights" ), { r.capturedObject( "l1" ), r.capturedObject( "l2" ) } )
 			self.assertEqual( o.numLinkEdits( "lights" ), 2 )
 
+	def testPointInstancer( self ) :
+
+		renderers = [
+			GafferScene.Private.IECoreScenePreview.Renderer.create( "Capturing" ),
+			GafferScene.Private.IECoreScenePreview.Renderer.create( "Capturing" )
+		]
+		compoundRenderer = GafferScene.Private.IECoreScenePreview.CompoundRenderer( renderers )
+
+		# Object creation
+
+		coreAttributes1 = IECore.CompoundObject( { "x" : IECore.IntData( 1 ) } )
+		attributes1 = compoundRenderer.attributes( coreAttributes1 )
+
+		coreAttributes2 = IECore.CompoundObject( { "x" : IECore.IntData( 2 ) } )
+		attributes2 = compoundRenderer.attributes( coreAttributes2 )
+
+		prototype = compoundRenderer.Prototype(
+			[ IECoreScene.SpherePrimitive() ], [ 0.0 ], attributes2
+		)
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 0 ) ] ) )
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 1 ] ) )
+
+		objectInterface = compoundRenderer.pointInstancer(
+			"pointInstancer", [ pointInstancer ], [ 0.0 ], [ prototype ], attributes1
+		)
+
+		for r in renderers :
+			o = r.capturedObject( "pointInstancer" )
+			self.assertEqual( o.capturedSamples(), [ pointInstancer ] )
+			self.assertEqual( o.capturedSampleTimes(), [ 0.0 ] )
+			self.assertEqual( o.capturedAttributes().attributes(), coreAttributes1 )
+			prototypes = o.capturedPointInstancerPrototypes()
+			self.assertEqual( len( prototypes ), 1 )
+			self.assertEqual( prototypes[0].samples, prototype.samples )
+			self.assertEqual( prototypes[0].times, prototype.times )
+			self.assertEqual( prototypes[0].attributes.attributes(), coreAttributes2 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -56,6 +56,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 	# Derived classes should set `cls.renderer` to the type of
 	# renderer to be tested.
 	renderer = None
+	# Derived classes should set this to `True` for renderers which implement
+	# the `pointInstancer()` call, so that it is tested.
+	## \todo Flip this to `True` by default, and make derived classes opt out.
+	pointInstancerSupported = False
 
 	@classmethod
 	def setUpClass( cls ) :
@@ -3603,6 +3607,167 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		script["shaderAssignment"]["enabled"].setValue( False )
 		self.assertEventually( lambda : assertColor( imath.Color4f( 1 ) ) )
+
+		script["render"]["state"].setValue( script["render"].State.Stopped )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testEditPointInstancer( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		script["catalogue"] = GafferScene.Catalogue()
+
+		script["instancer"] = GafferSceneTest.RenderControllerTest.ExamplePointInstancer()
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["instancer"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ClientDisplayDriver",
+					"displayHost" : "localhost",
+					"displayPort" : str( script["catalogue"].displayDriverServer().portNumber() ),
+					"remoteDisplayType" : "GafferScene::GafferDisplayDriver",
+				}
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = self._createInteractiveRender()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+
+		script["render"]["state"].setValue( script["render"].State.Running )
+
+		# Two instances should be visible.
+
+		self.assertEventually(
+			lambda : self.assertAlmostEqual( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ).a, 1 )
+		)
+		self.assertEventually(
+			lambda : self.assertAlmostEqual( self._color4fAtUV( script["catalogue"], imath.V2f( 0.8 ) ).a, 1 )
+		)
+
+		script["instancer"]["numPoints"].setValue( 1 )
+
+		# Now only one should be visible.
+
+		self.assertEventually(
+			lambda : self.assertAlmostEqual( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ).a, 1 )
+		)
+		self.assertEventually(
+			lambda : self.assertAlmostEqual( self._color4fAtUV( script["catalogue"], imath.V2f( 0.8 ) ).a, 0 )
+		)
+
+		script["instancer"]["transform"]["translate"]["x"].setValue( -2 )
+
+		# Now the instance should have moved.
+
+		self.assertEventually(
+			lambda : self.assertAlmostEqual( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ).a, 0 )
+		)
+		self.assertEventually(
+			lambda : self.assertAlmostEqual( self._color4fAtUV( script["catalogue"], imath.V2f( 0.2, 0.5 ) ).a, 1 )
+		)
+
+		script["render"]["state"].setValue( script["render"].State.Stopped )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testEditPointInstancerPrototypeShader( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		script["catalogue"] = GafferScene.Catalogue()
+
+		script["instancer"] = GafferSceneTest.RenderControllerTest.ExamplePointInstancer()
+
+		script["shader"], colorPlug, shaderOut = self._createConstantShader()
+		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
+
+		script["prototypeFilter"] = GafferScene.PathFilter()
+		script["prototypeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/instancer/prototypes/*" ] ) )
+
+		script["shaderAssignment"] = GafferScene.ShaderAssignment()
+		script["shaderAssignment"]["in"].setInput( script["instancer"]["out"] )
+		script["shaderAssignment"]["filter"].setInput( script["prototypeFilter"]["out"] )
+		script["shaderAssignment"]["shader"].setInput( shaderOut )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["shaderAssignment"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ClientDisplayDriver",
+					"displayHost" : "localhost",
+					"displayPort" : str( script["catalogue"].displayDriverServer().portNumber() ),
+					"remoteDisplayType" : "GafferScene::GafferDisplayDriver",
+				}
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = self._createInteractiveRender()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+
+		script["render"]["state"].setValue( script["render"].State.Running )
+
+		# We should have red instances at first.
+
+		self.assertEventually(
+			lambda : self.assertEqualWithAbsError( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ), imath.Color4f( 1, 0, 0, 1 ), 0.01 )
+		)
+
+		# But if we edit the shader they should change colour.
+
+		colorPlug.setValue( imath.Color3f( 0, 0, 1 ) )
+		self.assertEventually(
+			lambda : self.assertEqualWithAbsError( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ), imath.Color4f( 0, 0, 1, 1 ), 0.01 )
+		)
 
 		script["render"]["state"].setValue( script["render"].State.Stopped )
 

--- a/python/GafferSceneTest/PointInstancerAlgoTest.py
+++ b/python/GafferSceneTest/PointInstancerAlgoTest.py
@@ -1,0 +1,415 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneTest
+
+class PointInstancerAlgoTest( GafferSceneTest.SceneTestCase ) :
+
+	class PrototypeGroup( GafferScene.SceneNode ) :
+
+		def __init__( self, name = "PrototypeGroup" ) :
+
+			GafferScene.SceneNode.__init__( self, name )
+
+			self["name"] = Gaffer.StringPlug( defaultValue = "prototype" )
+			self["transform"] = Gaffer.TransformPlug()
+			self["sphereEnabled"] = Gaffer.BoolPlug( defaultValue = True )
+			self["sphereTransform"] = Gaffer.TransformPlug()
+			self["spherePurpose"] = Gaffer.StringPlug()
+			self["cubeEnabled"] = Gaffer.BoolPlug( defaultValue = True )
+			self["cubeTransform"] = Gaffer.TransformPlug()
+			self["cubeDimensions"] = Gaffer.V3fPlug( defaultValue = imath.V3f( 1 ) )
+			self["cubePurpose"] = Gaffer.StringPlug()
+			self["planeEnabled"] = Gaffer.BoolPlug( defaultValue = True )
+			self["planeTransform"] = Gaffer.TransformPlug()
+
+			self["__sphere"] = GafferScene.Sphere()
+			self["__sphere"]["enabled"].setInput( self["sphereEnabled"] )
+			self["__sphere"]["transform"].setInput( self["sphereTransform"] )
+
+			self["__sphereAttributes"] = GafferScene.CustomAttributes()
+			self["__sphereAttributes"]["in"].setInput( self["__sphere"]["out"] )
+			self["__sphereAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "usd:purpose", "", defaultEnabled = True ) )
+			self["__sphereAttributes"]["attributes"][0]["enabled"].setInput( self["spherePurpose" ] )
+			self["__sphereAttributes"]["attributes"][0]["value"].setInput( self["spherePurpose" ] )
+
+			self["__cube"] = GafferScene.Cube()
+			self["__cube"]["enabled"].setInput( self["cubeEnabled"] )
+			self["__cube"]["transform"].setInput( self["cubeTransform"] )
+			self["__cube"]["dimensions"].setInput( self["cubeDimensions"] )
+
+			self["__plane"] = GafferScene.Plane()
+			self["__plane"]["enabled"].setInput( self["planeEnabled"] )
+			self["__plane"]["transform"].setInput( self["planeTransform"] )
+
+			self["__group"] = GafferScene.Group()
+			self["__group"]["name"].setInput( self["name"] )
+			self["__group"]["transform"].setInput( self["transform"] )
+			self["__group"]["in"][0].setInput( self["__sphereAttributes"]["out"] )
+			self["__group"]["in"][1].setInput( self["__cube"]["out"] )
+			self["__group"]["in"][2].setInput( self["__plane"]["out"] )
+
+			self["out"].setInput( self["__group"]["out"] )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPrototypesHash( self ) :
+
+		prototypeGroup = GafferScene.Group()
+		prototypeGroup["name"].setValue( "prototypes" )
+
+		prototypeNodes = []
+		prototypeRoots = []
+		for i in range( 0, 100 ) :
+
+			prototype = self.PrototypeGroup()
+			prototype["name"].setValue( f"prototype{i}" )
+			prototypeNodes.append( prototype )
+
+			prototypeGroup["in"][i].setInput( prototype["out"] )
+			prototypeRoots.append( f"prototypes/prototype{i}" )
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPrototypes( IECore.StringVectorData( prototypeRoots ) )
+
+		pointInstancerNode = GafferScene.ObjectToScene()
+		pointInstancerNode["object"].setValue( pointInstancer )
+		pointInstancerNode["name"].setValue( "instancer" )
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( pointInstancerNode["out"] )
+		parent["children"][0].setInput( prototypeGroup["out"] )
+		parent["parent"].setValue( "/instancer" )
+
+		hashes = set()
+		with Gaffer.Context() as context :
+
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+
+			# 100 unique transform edits gives 100 unique hashes.
+
+			for i in range( 0, 100 ) :
+				prototypeNodes[i]["sphereTransform"]["translate"].setValue( imath.V3f( i, 0, 0 ) )
+				hashes.add( GafferScene.Private.PointInstancerAlgo.prototypesHash( parent["out"] ) )
+
+			self.assertEqual( len( hashes ), 100 )
+
+			# 100 unique object edits gives 100 unique hashes.
+
+			for i in range( 0, 100 ) :
+				prototypeNodes[i]["cubeDimensions"]["x"].setValue( 2 + i )
+				hashes.add( GafferScene.Private.PointInstancerAlgo.prototypesHash( parent["out"] ) )
+
+			self.assertEqual( len( hashes ), 200 )
+
+			# Attribute edit also affects the hash.
+
+			prototypeNodes[0]["spherePurpose"].setValue( "proxy" )
+			self.assertNotIn( GafferScene.Private.PointInstancerAlgo.prototypesHash( parent["out"] ), hashes )
+
+			# Hash is stable from run to run.
+
+			h = GafferScene.Private.PointInstancerAlgo.prototypesHash( parent["out"] )
+			for i in range( 1, 100 ) :
+				self.assertEqual( GafferScene.Private.PointInstancerAlgo.prototypesHash( parent["out"] ), h )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPrototypesHashWithoutPointInstancer( self ) :
+
+		plane = GafferScene.Plane()
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/plane" )
+			self.assertEqual( GafferScene.Private.PointInstancerAlgo.prototypesHash( plane["out"] ), IECore.MurmurHash() )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPrototypesHashWithMissingPrototype( self ) :
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "prototypes/missing" ] ) )
+
+		pointInstancerNode = GafferScene.ObjectToScene()
+		pointInstancerNode["object"].setValue( pointInstancer )
+		pointInstancerNode["name"].setValue( "instancer" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+			# Missing prototypes are just ignored at this stage. They'll be reported
+			# properly by `flatten()`.
+			self.assertEqual( GafferScene.Private.PointInstancerAlgo.prototypesHash( pointInstancerNode["out"] ), IECore.MurmurHash() )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testFlatten( self ) :
+
+		prototype1 = self.PrototypeGroup()
+		prototype1["name"].setValue( "prototype1" )
+		prototype1["sphereTransform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
+		prototype2 = self.PrototypeGroup()
+		prototype2["name"].setValue( "prototype2" )
+		prototype2["planeEnabled"].setValue( False )
+
+		prototypeGroup = GafferScene.Group()
+		prototypeGroup["name"].setValue( "prototypes" )
+		prototypeGroup["in"][0].setInput( prototype1["out"] )
+		prototypeGroup["in"][1].setInput( prototype2["out"] )
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 1, 0, 0 ) ] ) )
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 1 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "prototypes/prototype1", "prototypes/prototype2" ] ) )
+
+		pointInstancerNode = GafferScene.ObjectToScene()
+		pointInstancerNode["object"].setValue( pointInstancer )
+		pointInstancerNode["name"].setValue( "instancer" )
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( pointInstancerNode["out"] )
+		parent["children"][0].setInput( prototypeGroup["out"] )
+		parent["parent"].setValue( "/instancer" )
+
+		with Gaffer.Context() as context :
+
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+			pointInstancer = parent["out"]["object"].getValue()
+			self.assertEqual( pointInstancer, pointInstancerNode["object"].getValue() )
+
+			flattened = GafferScene.Private.PointInstancerAlgo.flatten(
+				pointInstancer, GafferScene.Private.RendererAlgo.RenderOptions(), parent["out"]
+			)
+
+			self.assertTrue( isinstance( flattened, IECoreScene.PointInstancer ) )
+			self.assertTrue( flattened.arePrimitiveVariablesValid() )
+			self.assertEqual( flattened.numPoints, 5 )
+			self.assertEqual(
+				list( flattened["prototypeRoots"].data ),
+				[
+					"prototypes/prototype1/cube",
+					"prototypes/prototype1/plane",
+					"prototypes/prototype1/sphere",
+					"prototypes/prototype2/cube",
+					"prototypes/prototype2/sphere",
+				]
+			)
+
+			self.assertEqual(
+				list( flattened.getPosition() ),
+				[
+					imath.V3f( 1, 2, 3 ),
+					imath.V3f( 1, 2, 3 ),
+					imath.V3f( 2, 2, 3 ),
+					imath.V3f( 1, 0, 0 ),
+					imath.V3f( 1, 0, 0 ),
+				]
+			)
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testFlattenIncludesRootTransform( self ) :
+
+		prototype = self.PrototypeGroup()
+		prototype["transform"]["scale"].setValue( imath.V3f( 2, 3, 4 ) )
+		prototype["sphereTransform"]["translate"].setValue( imath.V3f( 1, 0, 0 ) )
+		prototype["cubeEnabled"].setValue( False )
+		prototype["planeEnabled"].setValue( False )
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 0 ), imath.V3f( 1, 2, 3 ) ] ) )
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 0 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "prototype" ] ) )
+
+		pointInstancerNode = GafferScene.ObjectToScene()
+		pointInstancerNode["object"].setValue( pointInstancer )
+		pointInstancerNode["name"].setValue( "instancer" )
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( pointInstancerNode["out"] )
+		parent["children"][0].setInput( prototype["out"] )
+		parent["parent"].setValue( "/instancer" )
+
+		with Gaffer.Context() as context :
+
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+			pointInstancer = parent["out"]["object"].getValue()
+			self.assertEqual( pointInstancer, pointInstancerNode["object"].getValue() )
+
+			flattened = GafferScene.Private.PointInstancerAlgo.flatten(
+				pointInstancer, GafferScene.Private.RendererAlgo.RenderOptions(), parent["out"]
+			)
+			self.assertEqual( flattened.numPoints, 2 )
+			self.assertTrue( flattened.arePrimitiveVariablesValid() )
+
+			query = IECoreScene.PointInstancer.TransformQuery( flattened )
+			for i, point in enumerate( pointInstancer.getPosition() ) :
+				self.assertEqual(
+					query.transform( i ),
+					# Strictly speaking we want the relative transform from `instancer`
+					# to `sphere`, but since we know `instancer` has an identify transform
+					# we can use the handy `fullTransform()` method instead.
+					parent["out"].fullTransform( "/instancer/prototype/sphere" ) * imath.M44f().translate( point )
+				)
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testFlattenFilteredByPurpose( self ) :
+
+		prototype = self.PrototypeGroup()
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 1, 0, 0 ) ] ) )
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 0 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "prototype" ] ) )
+
+		pointInstancerNode = GafferScene.ObjectToScene()
+		pointInstancerNode["object"].setValue( pointInstancer )
+		pointInstancerNode["name"].setValue( "instancer" )
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( pointInstancerNode["out"] )
+		parent["children"][0].setInput( prototype["out"] )
+		parent["parent"].setValue( "/instancer" )
+
+		for spherePurpose in ( "proxy", "render" ) :
+
+			with self.subTest( spherePurpose = spherePurpose ) :
+
+				prototype["spherePurpose"].setValue( spherePurpose )
+
+				with Gaffer.Context() as context :
+
+					context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+					pointInstancer = parent["out"]["object"].getValue()
+					options = GafferScene.Private.RendererAlgo.RenderOptions()
+					options.includedPurposes = IECore.StringVectorData( [ "proxy" ] )
+					flattened = GafferScene.Private.PointInstancerAlgo.flatten(
+						pointInstancer, options, parent["out"]
+					)
+
+					self.assertTrue( isinstance( flattened, IECoreScene.PointInstancer ) )
+					self.assertTrue( flattened.arePrimitiveVariablesValid() )
+
+					if spherePurpose == "proxy" :
+						self.assertEqual( flattened.numPoints, 2 )
+						self.assertEqual(
+							list( flattened.getPrototypes() ),
+							[
+								"prototype/sphere",
+							]
+						)
+						self.assertEqual(
+							list( flattened.getPosition() ),
+							[
+								imath.V3f( 1, 2, 3 ),
+								imath.V3f( 1, 0, 0 ),
+							]
+						)
+					else :
+						self.assertEqual( flattened.numPoints, 0 )
+						self.assertEqual( len( flattened.getPrototypes() ), 0 )
+						self.assertEqual( len( flattened.getPosition() ), 0 )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testFlattenFilteredByVisibility( self ) :
+
+		prototype = GafferScene.Sphere()
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( i ) for i in range( 0, 20 ) ] ) )
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0 ] * 20 ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "sphere" ] ) )
+		pointInstancer.setInvisibleIDs( IECore.Int64VectorData( range( 0, 20, 2 ) ) )
+
+		pointInstancerNode = GafferScene.ObjectToScene()
+		pointInstancerNode["object"].setValue( pointInstancer )
+		pointInstancerNode["name"].setValue( "instancer" )
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( pointInstancerNode["out"] )
+		parent["children"][0].setInput( prototype["out"] )
+		parent["parent"].setValue( "/instancer" )
+
+		with Gaffer.Context() as context :
+
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+			pointInstancer = parent["out"]["object"].getValue()
+			flattened = GafferScene.Private.PointInstancerAlgo.flatten(
+				pointInstancer, GafferScene.Private.RendererAlgo.RenderOptions(), parent["out"]
+			)
+
+			self.assertTrue( isinstance( flattened, IECoreScene.PointInstancer ) )
+			self.assertTrue( flattened.arePrimitiveVariablesValid() )
+
+			self.assertEqual( flattened.numPoints, 10 )
+			self.assertEqual( list( flattened.getPosition() ), [ imath.V3f( i ) for i in range( 1, 20, 2 ) ] )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testFlattenWithMissingPrototype( self ) :
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "prototypes/missing" ] ) )
+		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 0 ) ] ) )
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0 ] ) )
+
+		pointInstancerNode = GafferScene.ObjectToScene()
+		pointInstancerNode["object"].setValue( pointInstancer )
+		pointInstancerNode["name"].setValue( "instancer" )
+
+		with Gaffer.Context() as context :
+
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+			pointInstancer = pointInstancerNode["out"]["object"].getValue()
+			with IECore.CapturingMessageHandler() as mh :
+				flattened = GafferScene.Private.PointInstancerAlgo.flatten(
+					pointInstancer, GafferScene.Private.RendererAlgo.RenderOptions( pointInstancerNode["out"] ), pointInstancerNode["out"]
+				)
+
+			self.assertTrue( isinstance( flattened, IECoreScene.PointInstancer ) )
+			self.assertTrue( flattened.arePrimitiveVariablesValid() )
+			self.assertEqual( flattened.numPoints, 0 )
+			self.assertEqual( len( flattened.getPrototypes() ), 0 )
+
+			self.assertEqual( len( mh.messages ), 1 )
+			self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
+			self.assertEqual( mh.messages[0].message, "Prototype `/instancer/prototypes/missing` does not exist for instancer `/instancer`." )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -1945,8 +1945,10 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 
 			self["numPoints"] = Gaffer.IntPlug( defaultValue = 2 )
 			self["sphereRadius"] = Gaffer.FloatPlug( defaultValue = 1 )
+			self["transform"] = Gaffer.TransformPlug()
 
 			self["objectToScene"] = GafferScene.ObjectToScene()
+			self["objectToScene"]["transform"].setInput( self["transform"] )
 			self["objectToScene"]["name"].setValue( "instancer" )
 
 			self["expression"] = Gaffer.Expression()

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import inspect
 import unittest
 
 import imath
@@ -1935,6 +1936,171 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( controller.updateRequired() )
 		controller.update()
 		self.assertTrue( capture.isSame( renderer.capturedObject( "/cube" ) ) )
+
+	class ExamplePointInstancer( GafferScene.SceneNode ) :
+
+		def __init__( self, name = "ExamplePointInstancer" ) :
+
+			GafferScene.SceneNode.__init__( self, name )
+
+			self["numPoints"] = Gaffer.IntPlug( defaultValue = 2 )
+			self["sphereRadius"] = Gaffer.FloatPlug( defaultValue = 1 )
+
+			self["objectToScene"] = GafferScene.ObjectToScene()
+			self["objectToScene"]["name"].setValue( "instancer" )
+
+			self["expression"] = Gaffer.Expression()
+			self["expression"].setExpression( inspect.cleandoc(
+				"""
+				import imath
+				import IECore
+				import IECoreScene
+				numPoints = parent["numPoints"]
+				pointInstancer = IECoreScene.PointInstancer( numPoints )
+				pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( i ) for i in range( numPoints ) ] ) )
+				pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ i % 2 for i in range( numPoints ) ] ) )
+				pointInstancer.setPrototypes( IECore.StringVectorData( [ "./prototypes/sphere", "./prototypes/cube" ] ) )
+
+				parent["objectToScene"]["object"] = pointInstancer
+				"""
+			) )
+
+			self["sphere"] = GafferScene.Sphere()
+			self["sphere"]["radius"].setInput( self["sphereRadius"] )
+			self["sphere"]["type"].setValue( self["sphere"].Type.Primitive )
+			self["cube"] = GafferScene.Cube()
+
+			self["prototypesGroup"] = GafferScene.Group()
+			self["prototypesGroup"]["name"].setValue( "prototypes" )
+			self["prototypesGroup"]["in"][0].setInput( self["sphere"]["out"] )
+			self["prototypesGroup"]["in"][1].setInput( self["cube"]["out"] )
+
+			self["parent"] = GafferScene.Parent()
+			self["parent"]["in"].setInput( self["objectToScene"]["out"] )
+			self["parent"]["children"][0].setInput( self["prototypesGroup"]["out"] )
+			self["parent"]["parent"].setValue( "/instancer" )
+
+			self["out"].setInput( self["parent"]["out"] )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancer( self ) :
+
+		pointInstancer = self.ExamplePointInstancer()
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( pointInstancer["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 100 )
+
+		self.assertTrue( controller.updateRequired() )
+		controller.update()
+
+		self.assertIn( "/instancer", renderer.capturedObjectNames() )
+		self.assertNotIn( "/instancer/prototypes", renderer.capturedObjectNames() )
+		self.assertNotIn( "/instancer/prototypes/sphere", renderer.capturedObjectNames() )
+		self.assertNotIn( "/instancer/prototypes/cube", renderer.capturedObjectNames() )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/instancer" )
+			expectedInstancer = pointInstancer["out"]["object"].getValue()
+			expectedInstancer = GafferScene.Private.PointInstancerAlgo.flatten(
+				expectedInstancer, GafferScene.Private.RendererAlgo.RenderOptions( pointInstancer["out"] ), pointInstancer["out"]
+			)
+
+		capuredInstancer = renderer.capturedObject( "/instancer" )
+		self.assertEqual( capuredInstancer.capturedSamples(), [ expectedInstancer ] )
+		self.assertEqual( capuredInstancer.capturedSampleTimes(), [ 1 ] )
+
+		self.assertEqual( len( capuredInstancer.capturedPointInstancerPrototypes() ), 2 )
+		self.assertEqual( capuredInstancer.capturedPointInstancerPrototypes()[0].samples, [ pointInstancer["out"].object( "/instancer/prototypes/sphere" ) ] )
+		self.assertEqual( capuredInstancer.capturedPointInstancerPrototypes()[0].times, [ 1 ] )
+		self.assertEqual( capuredInstancer.capturedPointInstancerPrototypes()[1].samples, [ pointInstancer["out"].object( "/instancer/prototypes/cube" ) ] )
+		self.assertEqual( capuredInstancer.capturedPointInstancerPrototypes()[1].times, [ 1 ] )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerPointCloudEdit( self ) :
+
+		pointInstancer = self.ExamplePointInstancer()
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( pointInstancer["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 100 )
+
+		self.assertTrue( controller.updateRequired() )
+		controller.update()
+		capture = renderer.capturedObject( "/instancer" )
+		self.assertEqual( capture.capturedSamples()[0].numPoints, 2 )
+		del capture
+
+		pointInstancer["numPoints"].setValue( 4 )
+		self.assertTrue( controller.updateRequired() )
+		controller.update()
+
+		capture = renderer.capturedObject( "/instancer" )
+		self.assertEqual( capture.capturedSamples()[0].numPoints, 4 )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerPrototypeEdit( self ) :
+
+		pointInstancer = self.ExamplePointInstancer()
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( pointInstancer["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 100 )
+
+		self.assertTrue( controller.updateRequired() )
+		controller.update()
+		capture = renderer.capturedObject( "/instancer" )
+		self.assertEqual( capture.capturedPointInstancerPrototypes()[0].samples[0].radius(), 1 )
+		del capture
+
+		pointInstancer["sphereRadius"].setValue( 2 )
+		self.assertTrue( controller.updateRequired() )
+		controller.update()
+
+		capture = renderer.capturedObject( "/instancer" )
+		self.assertEqual( capture.capturedPointInstancerPrototypes()[0].samples[0].radius(), 2 )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerUnrelatedEdits( self ) :
+
+		pointInstancer = self.ExamplePointInstancer()
+
+		sphere = GafferScene.Sphere()
+		parent = GafferScene.Parent()
+		parent["in"].setInput( pointInstancer["out"] )
+		parent["children"][0].setInput( sphere["out"] )
+		parent["parent"].setValue( "/" )
+
+		customOptions = GafferScene.CustomOptions()
+		customOptions["options"].addChild( Gaffer.NameValuePlug( "user:test", 10 ) )
+		customOptions["in"].setInput( parent["out"] )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( customOptions["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 100 )
+
+		self.assertTrue( controller.updateRequired() )
+		controller.update()
+		capture = renderer.capturedObject( "/instancer" )
+		self.assertEqual( capture.capturedPointInstancerPrototypes()[0].samples[0].radius(), 1 )
+
+		# Sphere has nothing to do with `/instancer`, so editing it should
+		# not invalidate the captured instancer, no matter how many times we
+		# do it.
+
+		for i in range( 0, 5 ) :
+			sphere["radius"].setValue( 10 + i )
+			self.assertTrue( controller.updateRequired() )
+			controller.update()
+			self.assertTrue( renderer.capturedObject( "/instancer" ).isSame( capture ) )
+
+		# Likewise, the custom option should not cause invalidation.
+
+		customOptions["options"][0]["value"].setValue( 20 )
+		self.assertTrue( controller.updateRequired() )
+		controller.update()
+
+		self.assertTrue( renderer.capturedObject( "/instancer" ).isSame( capture ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import inspect
 import pathlib
 import struct
 import subprocess
@@ -63,6 +64,10 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	# May be filled with types that aren't supported as `header:*` output
 	# metadata parameters.
 	unsupportedOutputMetadataTypes = []
+	# Derived classes should set this to `True` for renderers which implement
+	# the `pointInstancer()` call, so that it is tested.
+	## \todo Flip this to `True` by default, and make derived classes opt out.
+	pointInstancerSupported = False
 
 	@classmethod
 	def setUpClass( cls ) :
@@ -811,6 +816,568 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 				imath.V2i( 640, 240 )
 			)
 		)
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancer( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		pointInstancer = IECoreScene.PointInstancer( 4 )
+		pointInstancer.setPosition(
+			IECore.V3fVectorData( [
+				imath.V3f( -1, -1, 0 ), imath.V3f( 1, -1, 0 ),
+				imath.V3f( 1, 1, 0 ), imath.V3f( -1, 1, 0 ),
+			] )
+		)
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 0, 0, 0 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "./sphere" ] ) )
+
+		script["pointInstancer"] = GafferScene.ObjectToScene()
+		script["pointInstancer"]["name"].setValue( "instancer" )
+		script["pointInstancer"]["object"].setValue( pointInstancer )
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["radius"].setValue( 0.5 )
+
+		script["prototypeParent"] = GafferScene.Parent()
+		script["prototypeParent"]["in"].setInput( script["pointInstancer"]["out"] )
+		script["prototypeParent"]["children"][0].setInput( script["sphere"]["out"] )
+		script["prototypeParent"]["parent"].setValue( "/instancer" )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["prototypeParent"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba"
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		for prototypeTranslation, pixelOffset in [
+			( 0, 0 ),
+			( 1, 140 ),
+		] :
+
+			script["sphere"]["transform"]["translate"]["x"].setValue( prototypeTranslation )
+			script["render"]["task"].execute()
+			reader["refreshCount"].setValue( reader["refreshCount"].getValue() + 1 )
+
+			for centre in [
+				imath.V2f( 180 + pixelOffset, 102 ),
+				imath.V2f( 456 + pixelOffset, 102 ),
+				imath.V2f( 179 + pixelOffset, 379 ),
+				imath.V2f( 456 + pixelOffset, 379 ),
+			] :
+
+				with self.subTest( centre = centre, prototypeTranslation = prototypeTranslation ) :
+
+					# Assert there's an instance where we expect it.
+					sampler["pixel"].setValue( centre )
+					self.assertEqual( sampler["color"]["a"].getValue(), 1 )
+					# And that it's not a fluke by asserting there is empty
+					# space around it.
+					for offset in [
+						imath.V2f( 80, 0 ), imath.V2f( -80, 0 ),
+						imath.V2f( 0, 80 ), imath.V2f( 0, -80 ),
+					] :
+						sampler["pixel"].setValue( centre + offset )
+						self.assertAlmostEqual( sampler["color"]["a"].getValue(), 0, delta = 0.01 )
+
+			# The prototypes are at the origin, and shouldn't be rendered.
+			sampler["pixel"].setValue( imath.V2f( 320 + pixelOffset, 240 ) )
+			self.assertEqual( sampler["color"]["a"].getValue(), 0 )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerPrototypeIndices( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPosition(
+			IECore.V3fVectorData( [
+				imath.V3f( -1, 0, 0 ), imath.V3f( 1, 0, 0 ),
+			] )
+		)
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 1 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "./sphere", "./cube" ] ) )
+
+		script["pointInstancer"] = GafferScene.ObjectToScene()
+		script["pointInstancer"]["name"].setValue( "instancer" )
+		script["pointInstancer"]["object"].setValue( pointInstancer )
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["radius"].setValue( 0.5 )
+
+		script["redShader"], redColorPlug, redShaderOut = self._createConstantShader()
+		redColorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
+		script["redShaderAssignment"] = GafferScene.ShaderAssignment()
+		script["redShaderAssignment"]["in"].setInput( script["sphere"]["out"] )
+		script["redShaderAssignment"]["shader"].setInput( redShaderOut )
+
+		script["cube"] = GafferScene.Cube()
+
+		script["greenShader"], greenColorPlug, greenShaderOut = self._createConstantShader()
+		greenColorPlug.setValue( imath.Color3f( 0, 1, 0 ) )
+		script["greenShaderAssignment"] = GafferScene.ShaderAssignment()
+		script["greenShaderAssignment"]["in"].setInput( script["cube"]["out"] )
+		script["greenShaderAssignment"]["shader"].setInput( greenShaderOut )
+
+		script["prototypeParent"] = GafferScene.Parent()
+		script["prototypeParent"]["in"].setInput( script["pointInstancer"]["out"] )
+		script["prototypeParent"]["children"][0].setInput( script["redShaderAssignment"]["out"] )
+		script["prototypeParent"]["children"][1].setInput( script["greenShaderAssignment"]["out"] )
+		script["prototypeParent"]["parent"].setValue( "/instancer" )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["prototypeParent"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba"
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+
+		script["render"]["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		for position, expectedColor in [
+			( imath.V2f( 186, 234 ), imath.Color4f( 1, 0, 0, 1 ) ),
+			( imath.V2f( 484, 234 ), imath.Color4f( 0, 1, 0, 1 ) ),
+		] :
+
+			with self.subTest( position = position ) :
+
+				# Assert there's an instance where we expect it.
+				sampler["pixel"].setValue( position )
+				self.assertEqual( sampler["color"].getValue(), expectedColor )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerInvisibleIds( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		pointInstancer = IECoreScene.PointInstancer( 4 )
+		pointInstancer.setPosition(
+			IECore.V3fVectorData( [
+				imath.V3f( -1, -1, 0 ), imath.V3f( 1, -1, 0 ),
+				imath.V3f( 1, 1, 0 ), imath.V3f( -1, 1, 0 ),
+			] )
+		)
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 0, 0, 0 ] ) )
+		pointInstancer.setInvisibleIDs( IECore.Int64VectorData( [ 0, 2 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "./sphere" ] ) )
+
+		script["pointInstancer"] = GafferScene.ObjectToScene()
+		script["pointInstancer"]["name"].setValue( "instancer" )
+		script["pointInstancer"]["object"].setValue( pointInstancer )
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["radius"].setValue( 0.5 )
+
+		script["prototypeParent"] = GafferScene.Parent()
+		script["prototypeParent"]["in"].setInput( script["pointInstancer"]["out"] )
+		script["prototypeParent"]["children"][0].setInput( script["sphere"]["out"] )
+		script["prototypeParent"]["parent"].setValue( "/instancer" )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["prototypeParent"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba"
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+		script["render"]["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		for ( centre, expectedAlpha ) in [
+			( imath.V2f( 180, 102 ), 0 ),
+			( imath.V2f( 456, 102 ), 1 ),
+			( imath.V2f( 179, 379 ), 1 ),
+			( imath.V2f( 456, 379 ), 0 ),
+		] :
+
+			with self.subTest( centre = centre ) :
+
+				sampler["pixel"].setValue( centre )
+				self.assertAlmostEqual( sampler["color"]["a"].getValue(), expectedAlpha )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerInvisibleIdsAndIdPrimitiveVariable( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		pointInstancer = IECoreScene.PointInstancer( 4 )
+		pointInstancer.setPosition(
+			IECore.V3fVectorData( [
+				imath.V3f( -1, -1, 0 ), imath.V3f( 1, -1, 0 ),
+				imath.V3f( 1, 1, 0 ), imath.V3f( -1, 1, 0 ),
+			] )
+		)
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 0, 0, 0 ] ) )
+		pointInstancer.setID( IECore.Int64VectorData( [ 3, 2, 1, 0 ] ) )
+		pointInstancer.setInvisibleIDs( IECore.Int64VectorData( [ 0, 2 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "./sphere" ] ) )
+
+		script["pointInstancer"] = GafferScene.ObjectToScene()
+		script["pointInstancer"]["name"].setValue( "instancer" )
+		script["pointInstancer"]["object"].setValue( pointInstancer )
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["radius"].setValue( 0.5 )
+
+		script["prototypeParent"] = GafferScene.Parent()
+		script["prototypeParent"]["in"].setInput( script["pointInstancer"]["out"] )
+		script["prototypeParent"]["children"][0].setInput( script["sphere"]["out"] )
+		script["prototypeParent"]["parent"].setValue( "/instancer" )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["prototypeParent"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba"
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+		script["render"]["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		for ( centre, expectedAlpha ) in [
+			( imath.V2f( 180, 102 ), 1 ),
+			( imath.V2f( 456, 102 ), 0),
+			( imath.V2f( 179, 379 ), 0 ),
+			( imath.V2f( 456, 379 ), 1 ),
+		] :
+
+			with self.subTest( centre = centre ) :
+
+				sampler["pixel"].setValue( centre )
+				self.assertAlmostEqual( sampler["color"]["a"].getValue(), expectedAlpha )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerWithGroupPrototype( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		pointInstancer = IECoreScene.PointInstancer( 1 )
+		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 0, 1, 0 ) ] ) )
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "./group" ] ) )
+
+		script["pointInstancer"] = GafferScene.ObjectToScene()
+		script["pointInstancer"]["name"].setValue( "instancer" )
+		script["pointInstancer"]["object"].setValue( pointInstancer )
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["transform"]["translate"]["x"].setValue( -1 )
+		script["sphere"]["radius"].setValue( 0.25 )
+
+		script["cube"] = GafferScene.Cube()
+		script["cube"]["transform"]["translate"]["x"].setValue( 1 )
+		script["cube"]["dimensions"].setValue( imath.V3f( 0.5 ) )
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["sphere"]["out"] )
+		script["group"]["in"][1].setInput( script["cube"]["out"] )
+
+		script["prototypeParent"] = GafferScene.Parent()
+		script["prototypeParent"]["in"].setInput( script["pointInstancer"]["out"] )
+		script["prototypeParent"]["children"][0].setInput( script["group"]["out"] )
+		script["prototypeParent"]["parent"].setValue( "/instancer" )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["prototypeParent"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba"
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+
+		script["render"]["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		for centre in [
+			imath.V2f( 183, 378 ),
+			imath.V2f( 462, 382 ),
+		] :
+
+			with self.subTest( centre = centre ) :
+
+				# Assert there's an instance where we expect it.
+				sampler["pixel"].setValue( centre )
+				self.assertEqual( sampler["color"]["a"].getValue(), 1 )
+				# And that it's not a fluke by asserting there is empty
+				# space around it.
+				for offset in [
+					imath.V2f( 60, 0 ), imath.V2f( -60, 0 ),
+					imath.V2f( 0, 60 ), imath.V2f( 0, -60 ),
+				] :
+					sampler["pixel"].setValue( centre + offset )
+					self.assertAlmostEqual( sampler["color"]["a"].getValue(), 0, delta = 0.01 )
+
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerMotionBlur( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		script["pointInstancer"] = GafferScene.ObjectToScene()
+		script["pointInstancer"]["name"].setValue( "instancer" )
+
+		script["pointInstancerExpression"] = Gaffer.Expression()
+		script["pointInstancerExpression"].setExpression( inspect.cleandoc(
+			"""
+			import IECore
+			import IECoreScene
+
+			pointInstancer = IECoreScene.PointInstancer( 1 )
+			pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( ( context.getFrame() - 1 ) * 10, 0, 0 ) ] ) )
+			pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0 ] ) )
+			pointInstancer.setPrototypes( IECore.StringVectorData( [ "./sphere" ] ) )
+
+			parent["pointInstancer"]["object"] = pointInstancer
+			"""
+		) )
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["radius"].setValue( 0.5 )
+
+		script["prototypeParent"] = GafferScene.Parent()
+		script["prototypeParent"]["in"].setInput( script["pointInstancer"]["out"] )
+		script["prototypeParent"]["children"][0].setInput( script["sphere"]["out"] )
+		script["prototypeParent"]["parent"].setValue( "/instancer" )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["prototypeParent"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba"
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+		script["options"]["options"]["render:deformationBlur"]["enabled"].setValue( True )
+		script["options"]["options"]["render:deformationBlur"]["value"].setValue( True )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+		script["render"]["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		for x in range( 1, 638 ) :
+
+			# Assert there's an instance where we expect it,
+			# streaked horizontally across the centre of the image.
+			sampler["pixel"].setValue( imath.V2f( x, 240 ) )
+			self.assertGreater( sampler["color"]["a"].getValue(), 0.1 )
+			# And check it's not a fluke by asserting there is empty
+			# space above and below.
+			for y in ( 150, 320 ) :
+				sampler["pixel"].setValue( imath.V2f( x, y ) )
+				self.assertEqualWithAbsError( sampler["color"]["a"].getValue(), 0, 0.005 )
+
+	## Should be implemented by derived classes to return
+	# an appropriate Shader node with a constant surface shader loaded, along
+	# with the plug for the colour parameter and the output plug to be connected
+	# to a ShaderAssignment.
+	def _createConstantShader( self ) :
+
+		raise NotImplementedError
 
 	## Should be implemented by derived classes to return
 	# an appropriate Shader node with a diffuse surface shader loaded, along

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -505,21 +505,21 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 			c["scene:path"] = IECore.InternedStringVectorData( [ "sphere" ] )
 
-			h1 = IECore.MurmurHash()
+			h1 = GafferScene.Private.RendererAlgo.ObjectHash()
 			sampledObject1 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h1 )
 			self.assertEqual( sampledObject1.samples[0].radius(), 1 )
 			self.assertEqual( sampledObject1.sampleTimes, [ 1.0 ] )
-			self.assertNotEqual( h1, IECore.MurmurHash() )
+			self.assertNotEqual( h1.value, IECore.MurmurHash() )
 
 			sphere["radius"].setValue( 2 )
-			h2 = IECore.MurmurHash( h1 )
+			h2 = GafferScene.Private.RendererAlgo.ObjectHash( h1 )
 			sampledObject2 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h2 )
 			self.assertEqual( sampledObject2.samples[0].radius(), 2 )
 			self.assertEqual( sampledObject2.sampleTimes, [ 1.0 ] )
-			self.assertNotEqual( h2, IECore.MurmurHash() )
+			self.assertNotEqual( h2.value, IECore.MurmurHash() )
 			self.assertNotEqual( h2, h1 )
 
-			h3 = IECore.MurmurHash( h2 )
+			h3 = GafferScene.Private.RendererAlgo.ObjectHash( h2 )
 			sampledObject3 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h3 )
 			self.assertIsNone( sampledObject3 ) # Hash matched, so no samples generated
 			self.assertEqual( h3, h2 )
@@ -570,20 +570,20 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		with cancelledContext :
 
-			h = IECore.MurmurHash()
+			h = GafferScene.Private.RendererAlgo.ObjectHash()
 			with self.assertRaises( IECore.Cancelled ) :
 				GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h )
 
 			# The hash should not have been updated, so that when we use
 			# it in a non-cancelled context, we get some samples returned.
-			self.assertEqual( h, IECore.MurmurHash() )
+			self.assertEqual( h, GafferScene.Private.RendererAlgo.ObjectHash() )
 
 		with context :
 
 			sampledObject = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h )
 			self.assertEqual( [ s.radius() for s in sampledObject.samples ], [ 1.0 ] )
 			self.assertEqual( sampledObject.sampleTimes, [ 1.0 ] )
-			self.assertNotEqual( h, IECore.MurmurHash() )
+			self.assertNotEqual( h, GafferScene.Private.RendererAlgo.ObjectHash() )
 
 	def testObjectSamplesWithoutObject( self ) :
 

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -200,6 +200,7 @@ from .CurvesInterpolationTest import CurvesInterpolationTest
 from .CurvesTangentsTest import CurvesTangentsTest
 from .PrimitiveQueryTest import PrimitiveQueryTest
 from .SceneStatsTest import SceneStatsTest
+from .PointInstancerAlgoTest import PointInstancerAlgoTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -991,6 +991,11 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
+		ObjectInterfacePtr pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes ) override
+		{
+			return object( name, staticSamplesCast<IECore::ConstObjectPtr>( samples ), times, attributes );
+		}
+
 		void render() override
 		{
 			IECore::MessageHandler::Scope s( m_messageHandler.get() );

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -176,6 +176,13 @@ Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name,
 	return result;
 }
 
+Renderer::ObjectInterfacePtr CapturingRenderer::pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes )
+{
+	auto result = object( name, staticSamplesCast<ConstObjectPtr>( samples ), times, attributes );
+	static_cast<CapturedObject *>( result.get() )->m_capturedPointInstancerPrototypes = prototypes;
+	return result;
+}
+
 void CapturingRenderer::render()
 {
 	IECore::MessageHandler::Scope s( m_messageHandler.get() );
@@ -264,6 +271,11 @@ const IECoreScenePreview::Renderer::ObjectSamples &CapturingRenderer::CapturedOb
 const IECoreScenePreview::Renderer::SampleTimes &CapturingRenderer::CapturedObject::capturedSampleTimes() const
 {
 	return m_capturedSampleTimes;
+}
+
+const std::vector<IECoreScenePreview::Renderer::Prototype> &CapturingRenderer::CapturedObject::capturedPointInstancerPrototypes() const
+{
+	return m_capturedPointInstancerPrototypes;
 }
 
 const IECoreScenePreview::Renderer::TransformSamples &CapturingRenderer::CapturedObject::capturedTransforms() const

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -385,6 +385,22 @@ Renderer::ObjectInterfacePtr CompoundRenderer::object( const std::string &name, 
 	return result;
 }
 
+Renderer::ObjectInterfacePtr CompoundRenderer::pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes )
+{
+	auto compoundAttributes = static_cast<const CompoundAttributesInterface *>( attributes );
+	CompoundObjectInterfacePtr result = new CompoundObjectInterface;
+	vector<Prototype> rendererPrototypes( prototypes );
+	for( size_t i = 0; i < m_renderers.size(); ++i )
+	{
+		for( size_t pi = 0; pi < prototypes.size(); ++pi )
+		{
+			rendererPrototypes[pi].attributes = static_cast<const CompoundAttributesInterface *>( prototypes[pi].attributes.get() )->attributes[i];
+		}
+		result->objects[i] = m_renderers[i]->pointInstancer( name, samples, times, rendererPrototypes, compoundAttributes->attributes[i].get() );
+	}
+	return result;
+}
+
 void CompoundRenderer::render()
 {
 	for( auto &r : m_renderers )

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -111,6 +111,12 @@ Renderer::ObjectInterfacePtr Renderer::object( const std::string &name, const IE
 	return this->object( name, { object }, { 0.0f }, attributes );
 }
 
+Renderer::ObjectInterfacePtr Renderer::pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes )
+{
+	IECore::msg( IECore::Msg::Warning, "Renderer::pointInstancer", "Not implemented" );
+	return nullptr;
+}
+
 IECore::DataPtr Renderer::command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters )
 {
 	throw IECore::NotImplementedException( "Renderer::command" );

--- a/src/GafferScene/PointInstancerAlgo.cpp
+++ b/src/GafferScene/PointInstancerAlgo.cpp
@@ -1,0 +1,413 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/Private/PointInstancerAlgo.h"
+
+#include "GafferScene/SceneAlgo.h"
+
+#include "IECore/NullObject.h"
+
+#include "Imath/ImathMatrixAlgo.h"
+
+#include <limits>
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+namespace
+{
+
+ScenePlug::ScenePath fullPrototypePath( const std::string &prototypePath, const ScenePlug::ScenePath &pointInstancerPath )
+{
+	if( prototypePath.empty() )
+	{
+		throw IECore::Exception( "Prototype path empty" );
+	}
+
+	if( prototypePath[0] == '/' )
+	{
+		return ScenePlug::stringToPath( prototypePath );
+	}
+	else
+	{
+		ScenePlug::ScenePath result;
+		if( prototypePath[0] == '.' && prototypePath.size() >= 2 && prototypePath[1] == '/' )
+		{
+			ScenePlug::stringToPath( prototypePath.substr( 2 ), result );
+		}
+		else
+		{
+			ScenePlug::stringToPath( prototypePath, result );
+		}
+		result.insert( result.begin(), pointInstancerPath.begin(), pointInstancerPath.end() );
+		return result;
+	}
+}
+
+} // namespace
+
+IECore::MurmurHash Private::PointInstancerAlgo::prototypesHash( const ScenePlug *scene )
+{
+	MurmurHash result;
+	ConstObjectPtr object = scene->objectPlug()->getValue();
+	auto pointInstancer = runTimeCast<const PointInstancer>( object.get() );
+	if( !pointInstancer )
+	{
+		return result;
+	}
+
+	const auto &currentPath = Context::current()->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+
+	const ThreadState &threadState = ThreadState::current();
+	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+
+	auto prototypePaths = pointInstancer->getPrototypes();
+	using PrototypeRange = tbb::blocked_range<PrimitiveVariable::IndexedView<string>::Iterator>;
+
+	return tbb::parallel_deterministic_reduce(
+
+		PrototypeRange( prototypePaths.begin(), prototypePaths.end() ),
+		MurmurHash(),
+
+		[&] ( const PrototypeRange &range, MurmurHash hash )
+		{
+			Context::EditableScope scope( threadState );
+			for( auto it = range.begin(); it != range.end(); ++it )
+			{
+				auto fullPath = fullPrototypePath( *it, currentPath );
+				if( scene->exists( fullPath ) )
+				{
+					hash.append( SceneAlgo::hierarchyHash( scene, fullPath ) );
+				}
+			}
+			return hash;
+		},
+
+		[] ( MurmurHash x, const MurmurHash &y ) {
+			x.append( y );
+			return x;
+		},
+
+		tbb::simple_partitioner(),
+		taskGroupContext
+	);
+}
+
+std::vector<IECoreScenePreview::Renderer::Prototype> Private::PointInstancerAlgo::prototypes( const IECoreScene::PointInstancer *instancer, const RendererAlgo::RenderOptions &renderOptions, const ScenePlug *scene, IECoreScenePreview::Renderer *renderer )
+{
+	auto prototypePaths = instancer->getPrototypes();
+	if( !prototypePaths )
+	{
+		return {};
+	}
+
+	std::vector<IECoreScenePreview::Renderer::Prototype> result;
+	result.resize( prototypePaths.size() );
+
+	const auto &currentPath = Context::current()->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	const ThreadState &threadState = ThreadState::current();
+	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+
+	tbb::parallel_for(
+
+		tbb::blocked_range<size_t>( 0, prototypePaths.size() ),
+
+		[&]( const tbb::blocked_range<size_t> &r )
+		{
+			ScenePlug::PathScope prototypeScope( threadState );
+			IECoreScenePreview::Renderer::SampleTimes sampleTimes;
+
+			for( size_t prototypeIndex = r.begin(); prototypeIndex != r.end(); ++prototypeIndex )
+			{
+				auto fullPath = fullPrototypePath( prototypePaths[prototypeIndex], currentPath );
+				prototypeScope.setPath( &fullPath );
+				if( !scene->existsPlug()->getValue() )
+				{
+					IECore::msg(
+						IECore::Msg::Warning, "PointInstancer", "Prototype `{}` does not exist for instancer `{}`.",
+						ScenePlug::pathToString( fullPath ), ScenePlug::pathToString( currentPath )
+					);
+					continue;
+				}
+
+				ConstCompoundObjectPtr rootAttributes = scene->fullAttributes( fullPath );
+
+				IECoreScenePreview::Renderer::Prototype &prototype = result[prototypeIndex];
+
+				deformationMotionTimes( renderOptions, rootAttributes.get(), prototype.times );
+				auto sampledObject = GafferScene::Private::RendererAlgo::objectSamples( scene->objectPlug(), prototype.times );
+				prototype.samples = sampledObject->samples;
+				prototype.times = sampledObject->sampleTimes;
+				prototype.attributes = renderer->attributes( rootAttributes.get() );
+			}
+
+		},
+
+		taskGroupContext
+	);
+
+
+	return result;
+}
+
+namespace
+{
+
+struct PrototypeLocation
+{
+	string path;
+	Imath::M44f transform;
+	int index = 0;
+};
+
+using FlattenedPrototype = vector<PrototypeLocation>;
+
+M44f flattenedTransform( const ScenePlug *scene, ScenePlug::ScenePath path, size_t rootPathSize )
+{
+	ScenePlug::PathScope pathScope( Context::current() );
+
+	Imath::M44f result;
+	while( path.size() >= rootPathSize )
+	{
+		pathScope.setPath( &path );
+		result = result * scene->transformPlug()->getValue();
+		path.pop_back();
+	}
+
+	return result;
+}
+
+FlattenedPrototype flattenedPrototype( const Private::RendererAlgo::RenderOptions &renderOptions, const ScenePlug *scene, const string &rootPath, const ScenePlug::ScenePath &fullRootPath )
+{
+	FlattenedPrototype result;
+	SceneAlgo::parallelGatherLocations(
+		scene,
+		[&]( const ScenePlug *scene, const ScenePlug::ScenePath &path ) -> std::optional<PrototypeLocation> {
+
+			ConstCompoundObjectPtr fullAttributes = scene->fullAttributes( path );
+			if( !renderOptions.purposeIncluded( fullAttributes.get() ) )
+			{
+				return std::nullopt;
+			}
+
+			ConstObjectPtr o = scene->objectPlug()->getValue();
+			if( runTimeCast<const IECore::NullObject>( o.get() ) )
+			{
+				return std::nullopt;
+			}
+
+			ScenePlug::ScenePath relativePath( path.begin() + fullRootPath.size(), path.end() );
+			// Note : `PrototypeLocation::index` is filled later.
+			return PrototypeLocation{
+				rootPath + ScenePlug::pathToString( relativePath ),
+				flattenedTransform( scene, path, fullRootPath.size() )
+			};
+		},
+		[&]( std::optional<PrototypeLocation> location ) {
+			if( location )
+			{
+				result.push_back( *location );
+			}
+		},
+		fullRootPath
+	);
+
+	// `parallelGatherLocations()` doesn't guarantee order - sort so we
+	// have a deterministic order for testing and debugging.
+	std::sort(
+		result.begin(), result.end(),
+		[]( const PrototypeLocation &a, const PrototypeLocation &b ) {
+			return a.path < b.path;
+		}
+	);
+
+	return result;
+}
+
+} // namespace
+
+IECoreScene::PointInstancerPtr Private::PointInstancerAlgo::flatten( const IECoreScene::PointInstancer *instancer, const RendererAlgo::RenderOptions &renderOptions, const ScenePlug *scene )
+{
+	auto prototypePaths = instancer->getPrototypes();
+	auto prototypeIndex = instancer->getPrototypeIndex();
+
+	if( !prototypePaths || !prototypeIndex )
+	{
+		return instancer->copy();
+	}
+
+	// For each prototype, get a flattened list of descendant locations
+	// with non-empty objects.
+
+	vector<FlattenedPrototype> flattenedPrototypes;
+	flattenedPrototypes.resize( prototypePaths.size() );
+
+	const auto &currentPath = Context::current()->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	const ThreadState &threadState = ThreadState::current();
+	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+
+	tbb::parallel_for(
+
+		tbb::blocked_range<size_t>( 0, prototypePaths.size() ),
+
+		[&]( const tbb::blocked_range<size_t> &r )
+		{
+			ScenePlug::PathScope prototypeScope( threadState );
+
+			for( size_t prototypeIndex = r.begin(); prototypeIndex != r.end(); ++prototypeIndex )
+			{
+				auto fullPath = fullPrototypePath( prototypePaths[prototypeIndex], currentPath );
+				prototypeScope.setPath( &fullPath );
+				if( !scene->existsPlug()->getValue() )
+				{
+					IECore::msg(
+						IECore::Msg::Warning, "PointInstancer", "Prototype `{}` does not exist for instancer `{}`.",
+						ScenePlug::pathToString( fullPath ), ScenePlug::pathToString( currentPath )
+					);
+					continue;
+				}
+
+				flattenedPrototypes[prototypeIndex] = flattenedPrototype( renderOptions, scene, prototypePaths[prototypeIndex], fullPath );
+			}
+
+		},
+
+		taskGroupContext
+	);
+
+	// Assign indices to flattened prototypes.
+
+	StringVectorDataPtr flattenedPrototypeRootsData = new StringVectorData;
+	auto &flattenedPrototypeRoots = flattenedPrototypeRootsData->writable();
+	int offset = 0;
+	for( auto &flattenedPrototype : flattenedPrototypes )
+	{
+		for( auto &location : flattenedPrototype )
+		{
+			location.index = offset++;
+			flattenedPrototypeRoots.push_back( location.path );
+		}
+	}
+
+	// Figure out how many points we'll have after flattening and allocate
+	// vertex data for them. Also calculate per-point offsets into the data so
+	// we can fill it in parallel.
+
+	PointInstancer::VisibilityQuery visibilityQuery( *instancer );
+
+	vector<size_t> pointOffsets; pointOffsets.reserve( prototypeIndex.size() );
+	size_t numFlattenedPoints = 0;
+	const size_t hiddenPointOffset = std::numeric_limits<size_t>::max(); // Sentinel to indicate a point has been hidden.
+	for( size_t pointIndex = 0; pointIndex < prototypeIndex.size(); ++pointIndex )
+	{
+		if( visibilityQuery.visible( pointIndex ) )
+		{
+			pointOffsets[pointIndex] = numFlattenedPoints;
+			numFlattenedPoints += flattenedPrototypes[prototypeIndex[pointIndex]].size();
+		}
+		else
+		{
+			pointOffsets[pointIndex] = hiddenPointOffset;
+		}
+	}
+
+	PointInstancerPtr result = new PointInstancer( numFlattenedPoints );
+	result->setPrototypes( flattenedPrototypeRootsData );
+
+	IntVectorDataPtr flattenedPrototypeIndicesData = new IntVectorData;
+	result->setPrototypeIndex( flattenedPrototypeIndicesData );
+	auto &flattenedPrototypeIndices = flattenedPrototypeIndicesData->writable();
+	flattenedPrototypeIndices.resize( numFlattenedPoints );
+
+	V3fVectorDataPtr flattenedPositionData = new V3fVectorData;
+	result->setPosition( flattenedPositionData );
+	auto &flattenedPosition = flattenedPositionData->writable();
+	flattenedPosition.resize( numFlattenedPoints );
+
+	V3fVectorDataPtr flattenedScaleData = new V3fVectorData;
+	result->setScale( flattenedScaleData );
+	auto &flattenedScale = flattenedScaleData->writable();
+	flattenedScale.resize( numFlattenedPoints );
+
+	QuatfVectorDataPtr flattenedOrientationData = new QuatfVectorData;
+	result->setOrientation( flattenedOrientationData );
+	auto &flattenedOrientation = flattenedOrientationData->writable();
+	flattenedOrientation.resize( numFlattenedPoints );
+
+	// Fill the vertex data, parallelising across points.
+
+	PointInstancer::TransformQuery transformQuery( *instancer );
+
+	tbb::parallel_for(
+
+		tbb::blocked_range<size_t>( 0, prototypeIndex.size() ),
+
+		[&]( const tbb::blocked_range<size_t> &r )
+		{
+
+			for( size_t pointIndex = r.begin(); pointIndex < r.end(); ++pointIndex )
+			{
+				if( pointOffsets[pointIndex] == hiddenPointOffset )
+				{
+					continue;
+				}
+				size_t flattenedPointIndex = pointOffsets[pointIndex];
+				for( const auto &location : flattenedPrototypes[prototypeIndex[pointIndex]] )
+				{
+					flattenedPrototypeIndices[flattenedPointIndex] = location.index;
+
+					M44f m = location.transform * transformQuery.transform( pointIndex );
+					flattenedPosition[flattenedPointIndex] = m.translation();
+
+					V3f discardedShear( 0 );
+					extractAndRemoveScalingAndShear( m, flattenedScale[flattenedPointIndex], discardedShear );
+					flattenedOrientation[flattenedPointIndex] = extractQuat( m );
+
+					flattenedPointIndex++;
+				}
+			}
+
+		},
+
+		taskGroupContext
+	);
+
+	return result;
+}

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -573,12 +573,18 @@ class RenderController::SceneGraph
 				// Account for `Capsule::setRenderOptions()` being called by
 				// `RendererAlgo::outputObject()` in `updateObject()`.
 				m_dirtyComponents |= ObjectComponent;
-				m_objectHash = MurmurHash();
+				m_objectHash = Private::RendererAlgo::ObjectHash();
 			}
 
+			const bool hadPointInstancer = m_objectHash.isPointInstancer;
 			if( ( m_dirtyComponents & ObjectComponent ) && updateObject( controller->m_scene.get(), type, controller->m_renderer.get(), controller->m_renderOptions, controller->m_lightLinks.get() ) )
 			{
 				m_changedComponents |= ObjectComponent;
+				if( hadPointInstancer != m_objectHash.isPointInstancer )
+				{
+					// Account for `updateChildren()` checking `isPointInstancer` flag.
+					m_dirtyComponents |= ChildNamesComponent;
+				}
 			}
 
 			if( m_objectInterface )
@@ -599,7 +605,7 @@ class RenderController::SceneGraph
 						else
 						{
 							// Failed to apply attributes - must replace entire object.
-							m_objectHash = MurmurHash();
+							m_objectHash = Private::RendererAlgo::ObjectHash();
 							if( updateObject( controller->m_scene.get(), type, controller->m_renderer.get(), controller->m_renderOptions, controller->m_lightLinks.get() ) )
 							{
 								m_changedComponents |= ObjectComponent;
@@ -938,7 +944,7 @@ class RenderController::SceneGraph
 			else
 			{
 				m_objectInterface.assign(
-					Private::RendererAlgo::outputObject( name, *sampledObject, attributesInterface( renderer ), renderOptions, renderer ),
+					Private::RendererAlgo::outputObject( name, *sampledObject, attributesInterface( renderer ), renderOptions, scene, renderer ),
 					ObjectInterfaceHandle::RemovalCallback(),
 					/* isCapsule = */ sampledObject->samples[0]->isInstanceOf( Capsule::staticTypeId() )
 				);
@@ -949,7 +955,7 @@ class RenderController::SceneGraph
 		void clearObject()
 		{
 			m_objectInterface = nullptr;
-			m_objectHash = MurmurHash();
+			m_objectHash = Private::RendererAlgo::ObjectHash();
 		}
 
 		bool updateVisibleSet( const ScenePlug::ScenePath &path, const GafferScene::VisibleSet &visibleSet, size_t minimumExpansionDepth )
@@ -971,6 +977,17 @@ class RenderController::SceneGraph
 		// will subsequently be updated in parallel by update().
 		bool updateChildren( const InternedStringVectorDataPlug *childNamesPlug )
 		{
+			if( m_objectHash.isPointInstancer )
+			{
+				// By convention, we don't render the children of
+				// PointInstancers. This allows prototypes to be nested without
+				// fear of them being rendered in their own right.
+				const bool hadChildren = m_children.size();
+				m_children.clear();
+				m_childNamesHash = IECore::MurmurHash();
+				return hadChildren;
+			}
+
 			const IECore::MurmurHash childNamesHash = childNamesPlug->hash();
 			if( childNamesHash == m_childNamesHash )
 			{
@@ -1080,7 +1097,7 @@ class RenderController::SceneGraph
 
 		const SceneGraph *m_parent;
 
-		IECore::MurmurHash m_objectHash;
+		Private::RendererAlgo::ObjectHash m_objectHash;
 		ObjectInterfaceHandle m_objectInterface;
 		IECoreScenePreview::Renderer::SampleTimes m_deformationTimes;
 

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferScene/Capsule.h"
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+#include "GafferScene/Private/PointInstancerAlgo.h"
 #include "GafferScene/SceneAlgo.h"
 #include "GafferScene/SceneProcessor.h"
 #include "GafferScene/SetAlgo.h"
@@ -53,6 +54,7 @@
 #include "IECoreScene/CoordinateSystem.h"
 #include "IECoreScene/Output.h"
 #include "IECoreScene/Primitive.h"
+#include "IECoreScene/PointInstancer.h"
 #include "IECoreScene/Shader.h"
 #include "IECoreScene/VisibleRenderable.h"
 
@@ -547,7 +549,7 @@ std::optional<SampledTransform> transformSamples( const M44fPlug *transformPlug,
 	return result;
 }
 
-std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, IECore::MurmurHash *hash )
+std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug, const IECoreScenePreview::Renderer::SampleTimes &sampleTimes, ObjectHash *hash )
 {
 	IECoreScenePreview::Renderer::Samples<IECore::MurmurHash> sampleHashes;
 	if( !sampleTimes.size() )
@@ -594,7 +596,12 @@ std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug
 			}
 		}
 
-		if( combinedHash == *hash )
+		if( hash->isPointInstancer )
+		{
+			combinedHash.append( PointInstancerAlgo::prototypesHash( objectPlug->parent<ScenePlug>() ) );
+		}
+
+		if( combinedHash == hash->value )
 		{
 			return std::nullopt;
 		}
@@ -678,7 +685,8 @@ std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug
 				// at a time )
 				if( hash )
 				{
-					*hash = combinedHash;
+					hash->value = combinedHash;
+					hash->isPointInstancer = false;
 				}
 
 				return objectSamples( objectPlug, {} );
@@ -694,13 +702,27 @@ std::optional<SampledObject> objectSamples( const Gaffer::ObjectPlug *objectPlug
 
 	if( hash )
 	{
-		*hash = combinedHash;
+		hash->value = combinedHash;
+		const bool isPointInstancer = result.samples.size() && result.samples[0]->isInstanceOf( PointInstancer::staticTypeId() );
+		if( isPointInstancer )
+		{
+			if( !hash->isPointInstancer )
+			{
+				// Hash was either uninitialised, or we didn't find a PointInstancer last time round.
+				hash->value.append( PointInstancerAlgo::prototypesHash( objectPlug->parent<ScenePlug>() ) );
+			}
+			else
+			{
+				// We already applied the `prototypesHash` above, when testing for early return.
+			}
+		}
+		hash->isPointInstancer = isPointInstancer;
 	}
 
 	return result;
 }
 
-IECoreScenePreview::Renderer::ObjectInterfacePtr outputObject( const std::string &name, const SampledObject &sampledObject, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const RenderOptions &renderOptions, IECoreScenePreview::Renderer *renderer )
+IECoreScenePreview::Renderer::ObjectInterfacePtr outputObject( const std::string &name, const SampledObject &sampledObject, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const RenderOptions &renderOptions, const ScenePlug *scene, IECoreScenePreview::Renderer *renderer )
 {
 	if( sampledObject.samples.size() == 1 )
 	{
@@ -710,6 +732,35 @@ IECoreScenePreview::Renderer::ObjectInterfacePtr outputObject( const std::string
 			capsuleCopy->setRenderOptions( renderOptions );
 			return renderer->object( name, { capsuleCopy }, sampledObject.sampleTimes, attributes );
 		}
+	}
+
+	if( runTimeCast<const IECoreScene::PointInstancer>( sampledObject.samples[0].get() ) )
+	{
+		IECoreScenePreview::Renderer::PointInstancerSamples samples = IECoreScenePreview::Renderer::staticSamplesCast<IECoreScene::ConstPointInstancerPtr>( sampledObject.samples );
+		for( auto &sample : samples )
+		{
+			// We flatten PointInstancers for several reasons :
+			//
+			// - Not all our Renderer backends implement `procedural()`, which is currently
+			//   our only mechanism for instancing a group rather than a single primitive.
+			// - Flattening vs hierarchical instancing has memory and performance implications
+			//   that are highly situation specific. Therefore we prefer the user to make an
+			//   informed decision and use the Encapsulate node on the prototypes if hierarchical
+			//   instancing is preferred (and the backend supports it).
+			// - Users often unwittingly make prototypes with multiple locations but only
+			//   a single renderable object - for example by having an intermediate transform
+			//   or separate `proxy` and `render` geometry. Flattening this reduces to simple
+			//   single-primitive instancing without the overhead of additional hierarchy.
+			sample = PointInstancerAlgo::flatten( sample.get(), renderOptions, scene );
+		}
+
+		auto prototypes = PointInstancerAlgo::prototypes( samples[0].get(), renderOptions, scene, renderer );
+		if( prototypes.empty() )
+		{
+			// Warning already emitted by `pointInstancerPrototypes()`.
+			return nullptr;
+		}
+		return renderer->pointInstancer( name, samples, sampledObject.sampleTimes, prototypes, attributes );
 	}
 
 	return renderer->object( name, sampledObject.samples, sampledObject.sampleTimes, attributes );
@@ -1673,7 +1724,7 @@ struct ObjectOutput : public LocationOutput
 		}
 
 		IECoreScenePreview::Renderer::AttributesInterfacePtr attributesInterface = this->attributesInterface();
-		IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface = outputObject( name( path ), *sampledObject, attributesInterface.get(), renderOptions(), renderer() );
+		IECoreScenePreview::Renderer::ObjectInterfacePtr objectInterface = outputObject( name( path ), *sampledObject, attributesInterface.get(), renderOptions(), scene, renderer() );
 
 		if( objectInterface )
 		{
@@ -1690,7 +1741,9 @@ struct ObjectOutput : public LocationOutput
 			}
 		}
 
-		return true;
+		// By convention, we don't render the children of PointInstancers. This allows prototypes to
+		// be nested without fear of them being rendered in their own right.
+		return !runTimeCast<const IECoreScene::PointInstancer>( sampledObject->samples[0].get() );
 	}
 
 	const PathMatcher &m_cameraSet;

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -186,6 +186,19 @@ IECoreScenePreview::Renderer::ObjectInterfacePtr rendererObject2( Renderer &rend
 	return renderer.object( name, samples, times, attributes );
 }
 
+IECoreScenePreview::Renderer::ObjectInterfacePtr rendererPointInstancer( Renderer &renderer, const std::string &name, object pythonSamples, object pythonTimes, object pythonPrototypes, const Renderer::AttributesInterface *attributes )
+{
+	IECoreScenePreview::Renderer::PointInstancerSamples samples;
+	container_utils::extend_container( samples, pythonSamples );
+
+	IECoreScenePreview::Renderer::SampleTimes times;
+	container_utils::extend_container( times, pythonTimes );
+
+	std::vector<IECoreScenePreview::Renderer::Prototype> prototypes;
+	container_utils::extend_container( prototypes, pythonPrototypes );
+
+	return renderer.pointInstancer( name, samples, times, prototypes, attributes );
+}
 
 IECoreScenePreview::Renderer::ObjectInterfacePtr rendererCamera1( Renderer &renderer, const std::string &name, const IECoreScene::Camera *camera, const Renderer::AttributesInterface *attributes )
 {
@@ -402,6 +415,57 @@ object capturedObjectCapturedLinks( const CapturingRenderer::CapturedObject &o, 
 	}
 }
 
+Renderer::Prototype *prototypeConstructor( object pythonSamples, object pythonTimes, Renderer::AttributesInterfacePtr attributes )
+{
+	auto p = std::make_unique<Renderer::Prototype>();
+	container_utils::extend_container( p->samples, pythonSamples );
+	container_utils::extend_container( p->times, pythonTimes );
+	p->attributes = attributes;
+	return p.release();
+}
+
+list prototypeSamplesGetter( const Renderer::Prototype &p )
+{
+	list result;
+	for( const auto &s : p.samples )
+	{
+		result.append( boost::const_pointer_cast<IECore::Object>( s ) );
+	}
+	return result;
+}
+
+void prototypeSamplesSetter( Renderer::Prototype &p, object pythonSamples )
+{
+	p.samples.clear();
+	container_utils::extend_container( p.samples, pythonSamples );
+}
+
+list prototypeTimesGetter( const Renderer::Prototype &p )
+{
+	list result;
+	for( float t : p.times )
+	{
+		result.append( t );
+	}
+	return result;
+}
+
+void prototypeTimesSetter( Renderer::Prototype &p, object pythonTimes )
+{
+	p.times.clear();
+	container_utils::extend_container( p.times, pythonTimes );
+}
+
+Renderer::AttributesInterfacePtr prototypeAttributesGetter( const Renderer::Prototype &p )
+{
+	return p.attributes;
+}
+
+void prototypeAttributesSetter( Renderer::Prototype &p, Renderer::AttributesInterfacePtr attributes )
+{
+	p.attributes = attributes;
+}
+
 void transformPrimitiveWrapper( IECoreScene::Primitive &primitive, Imath::M44f matrix, const IECore::Canceller *canceller = nullptr )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -461,6 +525,17 @@ void GafferSceneModule::bindIECoreScenePreview()
 			.def( "assignID", &Renderer::ObjectInterface::assignID )
 			.def( "assignInstanceID", &Renderer::ObjectInterface::assignInstanceID )
 		;
+
+		class_<Renderer::Prototype>( "Prototype" )
+			.def( "__init__", make_constructor(
+				prototypeConstructor,
+				default_call_policies(),
+				( arg( "samples" ) = list(), arg( "times" ) = list(), arg( "attributes" ) = object() )
+			) )
+			.add_property( "samples", &prototypeSamplesGetter, &prototypeSamplesSetter )
+			.add_property( "times", &prototypeTimesGetter, &prototypeTimesSetter )
+			.add_property( "attributes", &prototypeAttributesGetter, &prototypeAttributesSetter )
+		;
 	}
 
 	renderer
@@ -488,6 +563,8 @@ void GafferSceneModule::bindIECoreScenePreview()
 
 		.def( "object", &rendererObject1 )
 		.def( "object", &rendererObject2 )
+
+		.def( "pointInstancer", &rendererPointInstancer )
 
 		.def( "render", render )
 		.def( "pause", &Renderer::pause )

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -361,6 +361,16 @@ list capturedObjectCapturedSampleTimes( const CapturingRenderer::CapturedObject 
 	return result;
 }
 
+list capturedObjectCapturedPointInstancerPrototypes( const CapturingRenderer::CapturedObject &o )
+{
+	list result;
+	for( auto &p : o.capturedPointInstancerPrototypes() )
+	{
+		result.append( p );
+	}
+	return result;
+}
+
 list capturedObjectCapturedTransforms( const CapturingRenderer::CapturedObject &o )
 {
 	list result;
@@ -651,6 +661,7 @@ void GafferSceneModule::bindIECoreScenePreview()
 		.def( "capturedName", &capturedObjectCapturedName )
 		.def( "capturedSamples", &capturedObjectCapturedSamples )
 		.def( "capturedSampleTimes", &capturedObjectCapturedSampleTimes )
+		.def( "capturedPointInstancerPrototypes", &capturedObjectCapturedPointInstancerPrototypes )
 		.def( "capturedTransforms", &capturedObjectCapturedTransforms )
 		.def( "capturedTransformTimes", &capturedObjectCapturedTransformTimes )
 		.def( "capturedAttributes", &capturedObjectCapturedAttributes )

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -116,7 +116,7 @@ list sampledObjectSampleTimes( const Private::RendererAlgo::SampledObject &sampl
 	return result;
 }
 
-object objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, object pythonSampleTimes, IECore::MurmurHash *hash, bool copy )
+object objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, object pythonSampleTimes, GafferScene::Private::RendererAlgo::ObjectHash *hash, bool copy )
 {
 	IECoreScenePreview::Renderer::SampleTimes sampleTimes;
 	boost::python::container_utils::extend_container( sampleTimes, pythonSampleTimes );
@@ -299,6 +299,14 @@ void GafferSceneModule::bindRender()
 				.def( "__init__", make_constructor( sampledObjectConstructor, default_call_policies() ) )
 				.add_property( "samples", &sampledObjectSamples )
 				.add_property( "sampleTimes", &sampledObjectSampleTimes )
+			;
+
+			class_<GafferScene::Private::RendererAlgo::ObjectHash>( "ObjectHash" )
+				.def( init<const GafferScene::Private::RendererAlgo::ObjectHash &>() )
+				.def_readwrite( "value", &GafferScene::Private::RendererAlgo::ObjectHash::value )
+				.def_readwrite( "isPointInstancer", &GafferScene::Private::RendererAlgo::ObjectHash::isPointInstancer )
+				.def( self == self )
+				.def( self != self )
 			;
 
 			def( "objectSamples", &objectSamplesWrapper, ( arg( "objectPlug" ), arg( "sampleTimes" ), arg( "hash" ) = object(), arg( "_copy" ) = true ) );

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -39,6 +39,7 @@
 #include "boost/python.hpp"
 
 #include "GafferScene/InteractiveRender.h"
+#include "GafferScene/Private/PointInstancerAlgo.h"
 #include "GafferScene/Private/RendererAlgo.h"
 #include "GafferScene/Render.h"
 
@@ -219,6 +220,19 @@ struct RenderSlotCaller
 	}
 };
 
+
+MurmurHash prototypesHashWrapper( const ScenePlug &scene )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return GafferScene::Private::PointInstancerAlgo::prototypesHash( &scene );
+}
+
+IECoreScene::PointInstancerPtr flattenWrapper( IECoreScene::PointInstancer &instancer, const  GafferScene::Private::RendererAlgo::RenderOptions &renderOptions, const ScenePlug &scene )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return GafferScene::Private::PointInstancerAlgo::flatten( &instancer, renderOptions, &scene );
+}
+
 } // namespace
 
 void GafferSceneModule::bindRender()
@@ -300,6 +314,16 @@ void GafferSceneModule::bindRender()
 			def( "outputCameras", &outputCamerasWrapper );
 			def( "outputLights", &outputLightsWrapper );
 			def( "outputObjects", &outputObjectsWrapper, ( arg( "scene" ), arg( "globals" ), arg( "renderSets" ), arg( "lightLinks" ), arg( "renderer" ), arg( "root" ) = "/", arg( "renderManifest" ) = object() ) );
+		}
+
+		{
+			object pointInstancerAlgoModule( borrowed( PyImport_AddModule( "GafferScene.Private.PointInstancerAlgo" ) ) );
+			scope().attr( "Private" ).attr( "PointInstancerAlgo" ) = pointInstancerAlgoModule;
+
+			scope pointInstancerAlgoModuleScope( pointInstancerAlgoModule );
+
+			def( "prototypesHash", &prototypesHashWrapper );
+			def( "flatten", &flattenWrapper );
 		}
 	}
 

--- a/src/IECoreDelight/ParameterList.cpp
+++ b/src/IECoreDelight/ParameterList.cpp
@@ -274,6 +274,16 @@ NSIParam_t ParameterList::parameter( const char *name, const IECore::Data *value
 			result.count = isSingleArray ? 1 : v.size();
 			break;
 		}
+		case M44dVectorDataTypeId :
+		{
+			const vector<M44d> &v = static_cast<const M44dVectorData *>( value )->readable();
+			result.type = NSITypeDoubleMatrix;
+			result.arraylength = isSingleArray ? v.size() : 1;
+			result.flags |= isSingleArray ? NSIParamIsArray : 0;
+			result.data = v.data();
+			result.count = isSingleArray ? 1 : v.size();
+			break;
+		}
 		default :
 			result.type = NSITypeInvalid;
 			msg( Msg::Warning, "ParameterList", fmt::format( "Attribute \"{}\" has unsupported datatype \"{}\".", name, value->typeName() ) );

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -693,7 +693,7 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 
 		DelightAttributes( NSIContext_t context, const IECore::CompoundObject *attributes, ShaderCache *shaderCache, DelightHandle::Ownership ownership )
 			:	m_handle( context, "attributes:" + attributes->Object::hash().toString(), ownership, "attributes", {} ),
-				m_lightMute( false )
+				m_lightMute( false ), m_hash( attributes->Object::hash() )
 		{
 			for( const auto &attributeName : g_surfaceShaderAttributeNames )
 			{
@@ -830,6 +830,11 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 			return m_lightMute;
 		}
 
+		const IECore::MurmurHash hash() const
+		{
+			return m_hash;
+		}
+
 	private :
 
 		static ConstDelightShaderPtr shader( const IECore::InternedString &name, const IECore::CompoundObject *attributes, ShaderCache *shaderCache )
@@ -851,6 +856,7 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 
 		ConstShaderNetworkPtr m_usdLightShader;
 		bool m_lightMute;
+		const IECore::MurmurHash m_hash;
 
 };
 
@@ -981,7 +987,7 @@ class PrototypeCache : public IECore::RefCounted
 				{
 					// Only one reference - this is ours, so
 					// nothing outside of the cache is using the
-					// instance.
+					// prototype.
 					toErase.push_back( it->first );
 				}
 			}
@@ -1141,7 +1147,7 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 	protected :
 
 		const DelightHandle m_transformHandle;
-		// We keep a reference to the instance and attributes so that they
+		// We keep a reference to the prototype and attributes so that they
 		// remain alive for at least as long as the object does.
 		ConstDelightAttributesPtr m_attributes;
 
@@ -1290,6 +1296,234 @@ IE_CORE_DECLAREPTR( DelightLight );
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
+// PointInstancerCache
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct InstancerHandles
+{
+	// The `instancer` node itself.
+	DelightHandleSharedPtr instancer;
+	// The converted prototypes, or `sourcemodels` in 3Delight's parlance.
+	// We need to keep these alive as long as the `instancer` is in
+	// use.
+	std::vector<DelightHandleSharedPtr> prototypes;
+	// The attributes applies to the prototypes. We also need
+	// to keep these alive.
+	std::vector<IECoreScenePreview::Renderer::AttributesInterfacePtr> prototypeAttributes;
+};
+
+using InstancerHandlesSharedPtr = std::shared_ptr<InstancerHandles>;
+
+class PointInstancerCache : public IECore::RefCounted
+{
+
+	public :
+
+		PointInstancerCache( const PrototypeCachePtr &prototypeCache, NSIContext_t context, DelightHandle::Ownership ownership )
+			:	m_prototypeCache( prototypeCache ), m_context( context ), m_ownership( ownership )
+		{
+		}
+
+		InstancerHandlesSharedPtr get( const IECoreScenePreview::Renderer::PointInstancerSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const std::vector<IECoreScenePreview::Renderer::Prototype> &prototypes )
+		{
+			IECore::MurmurHash hash;
+			for( const auto &sample : samples )
+			{
+				sample->hash( hash );
+			}
+			hash.append( times.data(), times.size() );
+
+			for( const auto &p : prototypes )
+			{
+				for( const auto &sample : p.samples )
+				{
+					sample->hash( hash );
+				}
+				hash.append( p.times.data(), p.times.size() );
+				hash.append( static_cast<const DelightAttributes *>( p.attributes.get() )->hash() );
+			}
+
+			Cache::accessor a;
+			m_cache.insert( a, hash );
+
+			if( !a->second )
+			{
+				const std::string name = "prototype:" + hash.toString();
+				a->second = convert( samples, times, prototypes, name.c_str() );
+			}
+
+			return a->second;
+		}
+
+		// Must not be called concurrently with anything.
+		void clearUnused()
+		{
+			vector<IECore::MurmurHash> toErase;
+			for( Cache::iterator it = m_cache.begin(), eIt = m_cache.end(); it != eIt; ++it )
+			{
+				if( it->second.use_count() == 1 )
+				{
+					// Only one reference - this is ours, so
+					// nothing outside of the cache is using the
+					// prototype.
+					toErase.push_back( it->first );
+				}
+			}
+			for( vector<IECore::MurmurHash>::const_iterator it = toErase.begin(), eIt = toErase.end(); it != eIt; ++it )
+			{
+				m_cache.erase( *it );
+			}
+		}
+
+	private :
+
+		InstancerHandlesSharedPtr convert(
+			const IECoreScenePreview::Renderer::PointInstancerSamples &samples,
+			const IECoreScenePreview::Renderer::SampleTimes &times,
+			const std::vector<IECoreScenePreview::Renderer::Prototype> &prototypes, const char *handle
+		)
+		{
+			// Preferring direct access rather than the `PointInstancer::getPrototypeIndex()` accessor,
+			// because the latter returns an IndexedView and we want IntVectorData for use with
+			// ParameterList. In the common case of `PrimitiveVariable::indices` being null, `expandedData()`
+			// is zero-copy and therefore our most efficient option.
+			auto prototypeIndex = samples[0]->expandedVariableData<IntVectorData>( "prototypeIndex", PrimitiveVariable::Vertex );
+			if( !prototypeIndex )
+			{
+				return nullptr;
+			}
+
+			NSICreate( m_context, handle, "instances", 0, nullptr );
+
+			ParameterList parameters;
+			parameters.add( "modelindices", prototypeIndex.get() );
+
+			NSISetAttribute( m_context, handle, parameters.size(), parameters.data() );
+
+			// Convert prototypes and connect to `sourcemodels` attribute.
+
+			std::vector<DelightHandleSharedPtr> prototypeHandles;
+			prototypeHandles.reserve( prototypes.size() );
+			std::vector<IECoreScenePreview::Renderer::AttributesInterfacePtr> prototypeAttributes;
+			prototypeAttributes.reserve( prototypes.size() );
+
+			IntDataPtr modelIndexData = new IntData();
+			for( size_t prototypeIndex = 0; prototypeIndex < prototypes.size(); ++prototypeIndex )
+			{
+				const auto &prototype = prototypes[prototypeIndex];
+				DelightHandleSharedPtr prototypeHandle = m_prototypeCache->get( prototype.samples, prototype.times );
+
+				if( prototypeHandle )
+				{
+					string transformHandle = fmt::format( "{}Prototype{}", handle, prototypeIndex );
+					NSICreate( m_context, transformHandle.c_str(), "transform", 0, nullptr );
+
+					auto typedAttributes = static_cast<const DelightAttributes *>( prototype.attributes.get() );
+
+					NSIConnect(
+						m_context,
+						typedAttributes->handle().name(), "",
+						transformHandle.c_str(), "geometryattributes",
+						0, nullptr
+
+					);
+					NSIConnect(
+						m_context,
+						typedAttributes->handle().name(), "",
+						transformHandle.c_str(), "shaderattributes",
+						0, nullptr
+
+					);
+
+					NSIConnect(
+						m_context,
+						prototypeHandle->name(), "",
+						transformHandle.c_str(), "objects",
+						0, nullptr
+					);
+
+					modelIndexData->writable() = prototypeIndex;
+					ParameterList connectionParameters;
+					connectionParameters.add( "index", modelIndexData.get() );
+					NSIConnect(
+						m_context,
+						transformHandle.c_str(), "",
+						handle, "sourcemodels",
+						connectionParameters.size(), connectionParameters.data()
+					);
+
+					prototypeHandles.push_back( prototypeHandle );
+					prototypeAttributes.push_back( prototype.attributes );
+				}
+			}
+
+			// Convert transforms.
+
+			M44dVectorDataPtr instanceMatricesData = new M44dVectorData();
+			std::vector<M44d> &instanceMatrices = instanceMatricesData->writable();
+			for( size_t sampleIndex = 0; sampleIndex < samples.size(); ++sampleIndex )
+			{
+				IECoreScene::PointInstancer::TransformQuery query( *samples[sampleIndex] );
+				instanceMatrices.clear();
+				instanceMatrices.reserve( samples[0]->getNumPoints() );
+				for( size_t instanceIndex = 0, e = samples[0]->getNumPoints(); instanceIndex < e; ++instanceIndex )
+				{
+					instanceMatrices.push_back( M44d( query.transform( instanceIndex ) ) );
+				}
+				parameters.add( "transformationmatrices", instanceMatricesData.get() );
+				NSISetAttributeAtTime( m_context, handle, times[sampleIndex], parameters.size(), parameters.data() );
+			}
+
+			return std::make_shared<InstancerHandles>( InstancerHandles{
+				make_shared<DelightHandle>( m_context, handle, m_ownership ),
+				std::move( prototypeHandles ), std::move( prototypeAttributes )
+			} );
+			return nullptr;
+		}
+
+		PrototypeCachePtr m_prototypeCache;
+		NSIContext_t m_context;
+		DelightHandle::Ownership m_ownership;
+
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, InstancerHandlesSharedPtr>;
+		Cache m_cache;
+
+};
+
+IE_CORE_DECLAREPTR( PointInstancerCache )
+
+} // namespace
+
+
+//////////////////////////////////////////////////////////////////////////
+// DelightInstancerObject
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class DelightInstancerObject : public DelightObject
+{
+
+	public :
+
+		DelightInstancerObject( NSIContext_t context, const std::string &name, const InstancerHandlesSharedPtr &handles, DelightHandle::Ownership ownership )
+			:	DelightObject( context, name, handles->instancer, ownership ), m_handles( handles )
+		{
+		}
+
+	private :
+
+		InstancerHandlesSharedPtr m_handles;
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
 // DelightRenderer
 //////////////////////////////////////////////////////////////////////////
 
@@ -1405,6 +1639,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 			m_context = NSIBegin( params.size(), params.data() );
 			m_prototypeCache = new PrototypeCache( m_context, ownership() );
+			m_pointInstancerCache = new PointInstancerCache( m_prototypeCache, m_context, ownership() );
 			m_attributesCache = new AttributesCache( m_context, ownership() );
 
 			NSICreate( m_context, g_screenHandle, "screen", 0, nullptr );
@@ -1417,6 +1652,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			// Delete nodes we own before we destroy context
 			stop();
 			m_attributesCache.reset();
+			m_pointInstancerCache.reset();
 			m_prototypeCache.reset();
 			m_outputs.clear();
 			m_defaultCamera.reset();
@@ -1618,10 +1854,26 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			return result;
 		}
 
+		ObjectInterfacePtr pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes ) override
+		{
+			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
+			auto handles = m_pointInstancerCache->get( samples, times, prototypes );
+			if( !handles )
+			{
+				return nullptr;
+			}
+
+			ObjectInterfacePtr result = new DelightInstancerObject( m_context, name, handles, ownership() );
+			result->attributes( attributes );
+			return result;
+		}
+
 		void render() override
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
+			m_pointInstancerCache->clearUnused();
 			m_prototypeCache->clearUnused();
 			m_attributesCache->clearUnused();
 
@@ -1884,6 +2136,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 		bool m_rendering = false;
 
 		PrototypeCachePtr m_prototypeCache;
+		PointInstancerCachePtr m_pointInstancerCache;
 		AttributesCachePtr m_attributesCache;
 
 		unordered_map<InternedString, ConstDelightOutputPtr> m_outputs;


### PR DESCRIPTION
This adds the infrastructure needed for rendering the new `IECoreScene::PointInstancer` directly. In this PR I've made the necessary changes to RendererAlgo/RenderController and added a bunch of unit tests, and updated the 3Delight backend to take advantage of it. Other renderers will come in future PRs, so the reviews are a bit more digestible (and to buy me time to finish them).

Note that by default USD PointInstancer objects still render via the previous code path using the `_PointInstancerAdaptor` . Removing an object from the `usd:pointInstancers` set is a reasonable way of bypassing that and using the new code path for testing. Later on I anticipate adding a more explicit opt-in (or opt-out) mechanism for the new code path. For Gaffer 1.7 we'll maintain both paths in parallel with the goal of removing the old adaptor in 1.8.

In terms of useful results, a simple benchmark rendering 1 million instances in 3Delight goes from 27s to 3s with this new approach (with the render tuned so that the raytracing part is pretty neglible and we're mostly measuring scene setup time).