### PR TITLE
RenderMan Globals : Fix hang in `InteractiveRenderThead::pause()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - NodeEditor : Fixed redundant updates when editing private plugs, such as when repositioning the currently viewed node in the Graph Editor.
 - RenderPassEditor : Fixed errors displaying presets while editing the `type` column [^1].
+- RenderMan : Fixed potential hang when updating the Visible Set immediately after starting an interactive render with `useVisibleSet` enabled [^1].
 
 Breaking Changes
 ----------------

--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -238,6 +238,7 @@ struct Globals::InteractiveRenderThread
 					m_state = m_requestedState.value();
 					m_requestedState.reset();
 				}
+				m_stateCondition.notify_one();
 
 				if( m_state == State::Stopped )
 				{


### PR DESCRIPTION
We've been seeing intermittent [hangs](https://github.com/GafferHQ/gaffer/actions/runs/28171101295/job/83456903088#step:17:366) with the RenderMan tests on CI run from `main`. I've been able to reproduce one locally where the hang is in `IECoreRenderMan::Globals::pause()` through `InteractiveRender::update()` triggered by an update to the VisibleSet metadata in `InteractiveRenderManRenderTest.testVisibleSetRenderCameraUpdate`. 

From the looks of it, updating the VisibleSet metadata immediately after starting an interactive render can cause `InteractiveRenderThread::pause()` to be called before `InteractiveRenderThread::threadFunction()` is scheduled, `pause()` requests `State::Waiting` then waits as m_state is currently `State::Stopped` (as `threadFunction()` has yet to first set it to `State::Waiting`). `pause()` is never notified of the subsequent m_state change to `State::Waiting` and waits forever.

```
Thread 2 (Thread 0x7fdd20dff6c0 (LWP 1231511) "gaffer"): 
0  0x00007fde4fc89422 in __syscall_cancel_arch () from /lib64/libc.so.6 
1  0x00007fde4fc7d71c in __internal_syscall_cancel () from /lib64/libc.so.6 
2  0x00007fde4fc7dd8c in __futex_abstimed_wait_common () from /lib64/libc.so.6 
3  0x00007fde4fc8045e in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6 
4  0x00007fde4fe1cd37 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib64/libstdc++.so.6 
5  0x00007fdde885b91b in IECoreRenderMan::Globals::InteractiveRenderThread::threadFunction() () from .../gaffer/renderMan/26.3/lib/libIECoreRenderMan.so 
6  0x00007fde4fe4e424 in execute_native_thread_routine () from /lib64/libstdc++.so.6 
7  0x00007fde4fc80f14 in start_thread () from /lib64/libc.so.6 
8  0x00007fde4fd0432c in __clone3 () from /lib64/libc.so.6

Thread 1 (Thread 0x7fde508567c0 (LWP 1229970) "gaffer"): 
0  0x00007fde4fc89422 in __syscall_cancel_arch () from /lib64/libc.so.6 
1  0x00007fde4fc7d71c in __internal_syscall_cancel () from /lib64/libc.so.6 
2  0x00007fde4fc7dd8c in __futex_abstimed_wait_common () from /lib64/libc.so.6 
3  0x00007fde4fc8045e in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6 
4  0x00007fde4fe1cd37 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib64/libstdc++.so.6 
5  0x00007fdde88564e3 in IECoreRenderMan::Globals::pause() () from .../gaffer/renderMan/26.3/lib/libIECoreRenderMan.so 
6  0x00007fdde886e395 in (anonymous namespace)::RenderManRenderer::pause() () from .../gaffer/renderMan/26.3/lib/libIECoreRenderMan.so 
7  0x00007fde31b6cb54 in GafferScene::InteractiveRender::update() () from .../gaffer/lib/libGafferScene.so 
8  0x00007fde3bbdac51 in Gaffer::Signals::Signal<void (Gaffer::Node*, IECore::InternedString, Gaffer::Metadata::ValueChangedReason), Gaffer::Signals::CatchingCombiner<void> >::operator()(Gaffer::Node*, IECore::InternedString, Gaffer::Metadata::ValueChangedReason) const () from .../gaffer/lib/libGaffer.so 
9  0x00007fde3bbd7bf7 in (anonymous namespace)::registerInstanceValueAction(Gaffer::GraphComponent*, IECore::InternedString, std::optional<boost::intrusive_ptr<IECore::Data const> >, bool) () from .../gaffer/lib/libGaffer.so 
10 0x00007fde3bbd9eb0 in std::_Function_handler<void (), boost::_bi::bind_t<void, void (*)(Gaffer::GraphComponent*, IECore::InternedString, std::optional<boost::intrusive_ptr<IECore::Data const> >, bool), boost::_bi::list<boost::_bi::value<Gaffer::GraphComponent*>, boost::_bi::value<IECore::InternedString>, boost::_bi::value<std::optional<boost::intrusive_ptr<IECore::Data const> > >, boost::_bi::value<bool> > > >::_M_invoke(std::_Any_data const&) () from .../gaffer/lib/libGaffer.so 
11 0x00007fde3bc49e65 in Gaffer::ScriptNode::addAction(boost::intrusive_ptr<Gaffer::Action>) () from .../gaffer/lib/libGaffer.so 
12 0x00007fde3bb05d6d in Gaffer::Action::enact(boost::intrusive_ptr<Gaffer::Action>) () from .../gaffer/lib/libGaffer.so 
13 0x00007fde3bb05f6c in Gaffer::Action::enact(boost::intrusive_ptr<Gaffer::GraphComponent>, std::function<void ()> const&, std::function<void ()> const&, bool) () from .../gaffer/lib/libGaffer.so 
14 0x00007fde3bbd39f8 in (anonymous namespace)::registerInstanceValue(Gaffer::GraphComponent*, IECore::InternedString, std::optional<boost::intrusive_ptr<IECore::Data const> >, bool) () from .../gaffer/lib/libGaffer.so 
15 0x00007fde3bbd3c27 in Gaffer::Metadata::registerValue(Gaffer::GraphComponent*, IECore::InternedString, boost::intrusive_ptr<IECore::Data const>, bool) () from .../gaffer/lib/libGaffer.so 
16 0x00007fde3c242bea in (anonymous namespace)::registerInstanceValue(Gaffer::GraphComponent&, IECore::InternedString, boost::intrusive_ptr<IECore::Data const>, bool) () from .../gaffer/python/Gaffer/_Gaffer.so
```