### PR TITLE
Renderman : Add Stylized Looks specific AOVs for line generation sign…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Features
 - SceneStats : Added a new node for computing aggregate scene statistics.
 - SceneInspector : Added Statistics tab with aggregated geometry statistics for the entire scene.
 
+Improvements
+------------
+
+- Outputs : Added output presets for RenderMan's NPR AOVs.
+
 Fixes
 -----
 

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -546,9 +546,43 @@ if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
 			( "specular_mse", "lpe CS[DS]*[LO]", "mse" ),
 			( "subsurface", "lpe C<TD>.*[<L.>O]", "filter" ),
 			( "transmission", "lpe C<TS>.*[<L.>O]", "filter" ),
+			( "P", "color P", "filter" ),
+			( "Nn", "color Nn", "filter" ),
+			( "Tn", "vector Tn", "filter" ),
+			( "motionFore", "vector motionFore", "filter" ),
+			( "sampleCount", "float sampleCount", "sum" ),
+			( "NPRshadow", "lpe C[DS]+<L.>", "filter" ),
+			( "NPRtoonOut", "color NPRtoonOut", "filter" ),
+			( "NPRhatchOut", "color NPRhatchOut", "filter" ),
+			( "NPRhatchTriplanar1to3", "color NPRhatchTriplanar1to3", "filter" ),
+			( "NPRhatchTriplanar4to6", "color NPRhatchTriplanar4to6", "filter" ),
+			( "NPRhatchTriplanar7to8", "color NPRhatchTriplanar7to8", "filter" ),
+			( "NPRlineOut", "color NPRlineOut", "filter" ),
+			( "NPRlineOutAlpha", "float NPRlineOutAlpha", "filter" ),
+			( "NPRoutline", "color NPRoutline", "filter" ),
+			( "NPRlineNZ", "color NPRlineNZ", "filter" ),
+			( "NPRsections", "color NPRsections", "filter" ),
+			( "NPRlineCamdist", "color NPRlineCamdist", "filter" ),
+			( "NPRlineAlbedo", "color NPRlineAlbedo", "filter" ),
+			( "NPRlineWidth", "color NPRlineWidth", "filter" ),
+			( "NPRmask", "color NPRmask", "filter" ),
+			( "NPRcurvature", "color NPRcurvature", "filter" ),
+			( "NPRnormals", "color NPRnormals", "filter" ),
+			( "NPRalbedo", "color NPRalbedo", "filter" ),
+			( "NPRalbedo2", "color NPRalbedo2", "filter" ),
+			( "NPRalbedo3", "color NPRalbedo3", "filter" ),
+			( "NPRtextureCoords", "color NPRtextureCoords", "filter" ),
+			( "NPRPtriplanar", "color NPRPtriplanar", "filter" ),
+			( "NPRNtriplanar", "color NPRNtriplanar", "filter" ),
+			( "NPRdistort", "color NPRdistort", "filter" ),
+			( "NPRpainterly", "color NPRpainterly", "filter" ),
 		] :
 
-			label = IECore.CamelCase.toSpaced( name )
+			if name.startswith( "NPR" ) :
+				label = "NPR/{}".format( name[3:] )
+			else :
+				label = IECore.CamelCase.toSpaced( name )
+
 			parameters = {
 				"ri:accumulationRule" : accumulationRule,
 				"ri:relativePixelVariance" : 0.0,


### PR DESCRIPTION
This PR is to include the required AOVs for Stylized Looks display filters and even control nodes to function properly. This include the full list of AOVs as is found in other bridges. The AOVs are listed under RenderMan in the Output node.

### Related issues ###

- README: Several stylized looks filters were not producing any output due to missing AOVs, for example the default `PxrStylizedLineXPU` looks for the AOV `Nn` for the line generation mode. This is the default signal and when placing the node no lines were generated until the AOV is added to the output node.

### Dependencies ###

- None

### Breaking changes ###

- There are no breaking changes

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
