### PR TITLE
Arnold Renderer : Fix fallback to facing ratio shader

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Features
 - SceneStats : Added a new node for computing aggregate scene statistics.
 - SceneInspector : Added Statistics tab with aggregated geometry statistics for the entire scene.
 
+Fixes
+-----
+
+- Arnold : Fixed fallback to a facing ratio shader when a shader is removed during an interactive render.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,9 @@ Features
 Fixes
 -----
 
-- Arnold : Fixed fallback to a facing ratio shader when a shader is removed during an interactive render.
+- Arnold :
+  - Fixed fallback to a facing ratio shader when a shader is removed during an interactive render.
+  - Fixed crash attempting to render with a shader that doesn't exist.
 
 API
 ---

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -3532,6 +3532,80 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["render"]["state"].setValue( s["render"].State.Stopped )
 
+	def testRemoveShader( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["catalogue"] = GafferScene.Catalogue()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["transform"]["translate"].setValue( imath.V3f( 0, 0, -10 ) )
+
+		constantShader, colorPlug, shaderOutPlug = self._createConstantShader()
+		script["shader"] = constantShader
+		colorPlug.setValue( imath.Color3f( 1, 0.5, 0.25 ) )
+
+		script["shaderAssignment"] = GafferScene.ShaderAssignment()
+		script["shaderAssignment"]["in"].setInput( script["sphere"]["out"] )
+		script["shaderAssignment"]["shader"].setInput( shaderOutPlug )
+		script["shaderAssignment"]["enabled"].setValue( False )
+
+		script["camera"] = GafferScene.Camera()
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["shaderAssignment"]["out"] )
+		script["group"]["in"][1].setInput( script["camera"]["out"] )
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ClientDisplayDriver",
+					"displayHost" : "localhost",
+					"displayPort" : str( script["catalogue"].displayDriverServer().portNumber() ),
+					"remoteDisplayType" : "GafferScene::GafferDisplayDriver",
+				}
+			)
+		)
+		script["outputs"]["in"].setInput( script["group"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/group/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = self._createInteractiveRender()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["state"].setValue( script["render"].State.Running )
+
+		def assertColor( expectedColor ) :
+
+			color = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
+			self.assertEqualWithAbsError( color, expectedColor, 0.01 )
+
+		# Shader assignment disabled, so should get white from default facing
+		# ratio shader.
+
+		self.assertEventually( lambda : assertColor( imath.Color4f( 1 ) ) )
+
+		# Shader assignment enabled, so should get colour from shader.
+
+		script["shaderAssignment"]["enabled"].setValue( True )
+		self.assertEventually( lambda : assertColor( imath.Color4f( 1, 0.5, 0.25, 1 ) ) )
+
+		# Back to default facing ratio.
+
+		script["shaderAssignment"]["enabled"].setValue( False )
+		self.assertEventually( lambda : assertColor( imath.Color4f( 1 ) ) )
+
+		script["render"]["state"].setValue( script["render"].State.Stopped )
+
 	def tearDown( self ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -1381,5 +1381,20 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( len( messageHandler.messages ), 0 )
 
+	def testMissingShaderWithBlindData( self ) :
+
+		shader = IECoreScene.Shader( "NonExistent" )
+		shader.blindData()["test"] = "test"
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = { "outputHandle" : shader },
+			output = "outputHandle"
+		)
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			nodes = IECoreArnold.ShaderNetworkAlgo.convert( network, universe, "test" )
+			self.assertEqual( len( nodes ), 0 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -1253,7 +1253,7 @@ IECoreScene::ConstShaderNetworkPtr g_facingRatio = []() {
 		"utility", new IECoreScene::Shader( "utility" )
 	);
 
-	result->setOutput( { "utility", "out" } );
+	result->setOutput( { utilityHandle, "out" } );
 
 	return result;
 
@@ -1642,7 +1642,15 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				}
 
 				AiNodeSetBool( node, g_matteArnoldString, m_shadingFlags & ArnoldAttributes::Matte );
-				AiNodeSetPtr( node, g_shaderArnoldString, preferredShader( geometry ) );
+
+				if( AtNode *shader = preferredShader( geometry ) )
+				{
+					AiNodeSetPtr( node, g_shaderArnoldString, shader );
+				}
+				else
+				{
+					AiNodeResetParameter( node, g_shaderArnoldString );
+				}
 
 				if( m_traceSets && m_traceSets->readable().size() )
 				{
@@ -2294,8 +2302,8 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			}
 
 			// Otherwise use the surface shader. We use this even for volume geometry,
-			// because Gaffer has always assigned volume shaders as `ai:surface`.
-			return m_surfaceShader ? m_surfaceShader->root() : nullptr;
+			// because Gaffer historically assigned volume shaders as `ai:surface`.
+			return m_surfaceShader->root();
 		}
 
 		unsigned char m_visibility;

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -1245,6 +1245,20 @@ IECore::InternedString g_lightFilterPrefix( "ai:lightFilter:" );
 
 IECore::InternedString g_filteredLights( "filteredLights" );
 
+IECoreScene::ConstShaderNetworkPtr g_facingRatio = []() {
+
+	IECoreScene::ShaderNetworkPtr result = new IECoreScene::ShaderNetwork;
+
+	const IECore::InternedString utilityHandle = result->addShader(
+		"utility", new IECoreScene::Shader( "utility" )
+	);
+
+	result->setOutput( { "utility", "out" } );
+
+	return result;
+
+} ();
+
 const std::vector<IECore::InternedString> g_surfaceShaderAttributeNames = {
 	"ai:surface",
 	"osl:surface",
@@ -1313,6 +1327,11 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			updateShadingFlag( g_arnoldMatteAttributeName, Matte, attributes );
 
 			m_surfaceShader = shaderCache->get( g_surfaceShaderAttributeNames, attributes );
+			if( !m_surfaceShader )
+			{
+				m_surfaceShader = shaderCache->get( g_facingRatio.get(), "", nullptr );
+			}
+
 			m_volumeShader = shaderCache->get( g_volumeShaderAttributeNames, attributes );
 			m_filterMap = shaderCache->get( g_filterMapAttributeNames, attributes );
 			m_uvRemap = shaderCache->get( g_uvRemapAttributeNames, attributes );
@@ -1623,15 +1642,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				}
 
 				AiNodeSetBool( node, g_matteArnoldString, m_shadingFlags & ArnoldAttributes::Matte );
-
-				if( AtNode *shader = preferredShader( geometry ) )
-				{
-					AiNodeSetPtr( node, g_shaderArnoldString, shader );
-				}
-				else
-				{
-					AiNodeResetParameter( node, g_shaderArnoldString );
-				}
+				AiNodeSetPtr( node, g_shaderArnoldString, preferredShader( geometry ) );
 
 				if( m_traceSets && m_traceSets->readable().size() )
 				{

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -451,9 +451,12 @@ std::vector<AtNode *> convert( const IECoreScene::ShaderNetwork *shaderNetwork, 
 			return AiNode( universe, nodeType, nodeName, parentNode );
 		};
 		convertWalk( network->getOutput(), network.get(), name, nodeCreator, result, converted, nodeParameters );
-		for( const auto &kv : network->outputShader()->blindData()->readable() )
+		if( result.size() )
 		{
-			ParameterAlgo::setParameter( result.back(), AtString( kv.first.c_str() ), kv.second.get() );
+			for( const auto &kv : network->outputShader()->blindData()->readable() )
+			{
+				ParameterAlgo::setParameter( result.back(), AtString( kv.first.c_str() ), kv.second.get() );
+			}
 		}
 	}
 	return result;


### PR DESCRIPTION
It seems that something in Arnold has changed, and a second call to `AiNodeResetParameter()` on a `polymesh.shader` parameter removes the shader and renders pink rather than reverting to the default facing ratio. So now we always explicitly assign the shader we want, doing our own fallback to facing ratio.
