### PR TITLE
RenderMan _StylizedAOVAdaptor : Fix for rendering with XPU

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - Viewer : Fixed regression introduced in 1.6.16.0 that prevented visualisation of the renderer-specific camera visibility and matte attributes authored by the Render Pass Editor's render adaptors.
 - RenderMan : Fixed `R10043` warning when using PxrDisplace.
+- RenderMan : Fixed automatic creation of required AOVs for PxrStylized filters in XPU.
 
 1.6.20.0 (relative to 1.6.19.2)
 ========

--- a/python/GafferRenderMan/_StylizedAOVAdaptor.py
+++ b/python/GafferRenderMan/_StylizedAOVAdaptor.py
@@ -69,10 +69,6 @@ class _StylizedAOVAdaptor( GafferScene.SceneProcessor ) :
 			"""
 		) )
 
-	__stylizedFilters = {
-		"PxrStylizedCanvas", "PxrStylizedHatching", "PxrStylizedLines", "PxrStylizedToon",
-	}
-
 	__aovDefinitions = {
 
 		"albedo" : "lpe nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;C<.S'passthru'>*((U2L)|O)",
@@ -104,11 +100,7 @@ class _StylizedAOVAdaptor( GafferScene.SceneProcessor ) :
 		if displayFilter is None or not isinstance( displayFilter, IECoreScene.ShaderNetwork ) :
 			return inputGlobals
 
-		displayFilters = {
-			shader.name for shader in displayFilter.shaders().values()
-		}
-
-		if not displayFilters.intersection( _StylizedAOVAdaptor.__stylizedFilters ) :
+		if not any( shader.name.startswith( "PxrStylized" ) for shader in displayFilter.shaders().values() ) :
 			return inputGlobals
 
 		# Stylized Looks are in use, so make sure we have all the AOVs needed.
@@ -141,4 +133,4 @@ class _StylizedAOVAdaptor( GafferScene.SceneProcessor ) :
 
 IECore.registerRunTimeTyped( _StylizedAOVAdaptor, typeName = "GafferRenderMan::_StylizedAOVAdaptor" )
 
-GafferScene.SceneAlgo.registerRenderAdaptor( "RenderManStylizedAOVAdaptor", _StylizedAOVAdaptor, "*Render", "RenderMan" )
+GafferScene.SceneAlgo.registerRenderAdaptor( "RenderManStylizedAOVAdaptor", _StylizedAOVAdaptor, "*Render", "RenderMan*" )


### PR DESCRIPTION
- Register against "RenderMan*" so we pick up "RenderMan XPU" too.
- Account for XPU display filters having different names.
