### PR TITLE
Arnold Renderer, RenderMan Renderer : Implement `pointInstancer()` method

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -62,6 +62,7 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 
 	renderer = "Arnold"
 	sceneDescriptionSuffix = ".ass"
+	pointInstancerSupported = True
 
 	def setUp( self ) :
 
@@ -1626,6 +1627,12 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			with GafferTest.TestRunner.PerformanceScope() :
 				s["render"]["task"].execute()
 
+	def _createConstantShader( self ) :
+
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "flat" )
+		return shader, shader["parameters"]["color"], shader["out"]
+
 	def _createDiffuseShader( self ) :
 
 		shader = GafferArnold.ArnoldShader()
@@ -1657,6 +1664,11 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 
 		options["options"]["ai:GI_total_depth"]["enabled"].setValue( True )
 		options["options"]["ai:GI_total_depth"]["value"].setValue( 0 )
+
+		# Improve sampling for motion blur tests.
+
+		options["options"]["ai:AA_samples"]["enabled"].setValue( True )
+		options["options"]["ai:AA_samples"]["value"].setValue( 3 )
 
 		return options
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -56,6 +56,7 @@ import GafferArnold
 class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	renderer = "Arnold"
+	pointInstancerSupported = True
 
 	# Arnold outputs licensing warnings that would cause failures
 	failureMessageLevel = IECore.MessageHandler.Level.Error

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -49,6 +49,7 @@ import GafferRenderMan
 class InteractiveRenderManRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	renderer = "RenderMan"
+	pointInstancerSupported = True
 
 	def testEditCropWindowWithInteractiveDenoiser( self ) :
 

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -53,6 +53,7 @@ import GafferSceneTest
 class RenderManRenderTest( GafferSceneTest.RenderTest ) :
 
 	renderer = "RenderMan"
+	pointInstancerSupported = True
 
 	def testRepeatedRender( self ) :
 
@@ -107,6 +108,12 @@ class RenderManRenderTest( GafferSceneTest.RenderTest ) :
 			self.assertAlmostEqual( middlePixel.a, 1, delta = 0.01 )
 			self.assertEqual( lowerPixel, imath.Color4f( 0 ) )
 
+	def _createConstantShader( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrConstant" )
+		return shader, shader["parameters"]["emitColor"], shader["out"]
+
 	def _createDiffuseShader( self ) :
 
 		shader = GafferRenderMan.RenderManShader()
@@ -151,6 +158,11 @@ class RenderManXPURenderTest( RenderManRenderTest ) :
 	# or update OpenImageIOReader to load integer IDs via `reinterpret_cast`.
 	@unittest.skip( "XPU only renders integer ID outputs, but we want floats" )
 	def testIDOutput( self ) :
+
+		pass
+
+	@unittest.skip( "Apparent bounding box bug clips motion" )
+	def testPointInstancerMotionBlur( self ) :
 
 		pass
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -1457,6 +1457,80 @@ class RendererTest( GafferTest.TestCase ) :
 				"polyAdaptiveSubdivideLinearAttributes2",
 			)
 
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerInstancing( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.ass" )
+		)
+
+		pointInstancer1 = IECoreScene.PointInstancer( 1 )
+		pointInstancer1.setPosition( IECore.V3fVectorData( [ imath.V3f( 0 ) ] ) )
+		pointInstancer1.setPrototypeIndex( IECore.IntVectorData( [ 0 ] ) )
+
+		pointInstancer2 = pointInstancer1.copy()
+		pointInstancer2.setPosition( IECore.V3fVectorData( [ imath.V3f( 1 ) ] ) )
+
+		attributes1 = renderer.attributes( IECore.CompoundObject() )
+
+		noInstanceAttributes = renderer.attributes(
+			IECore.CompoundObject( {
+				"gaffer:automaticInstancing" : IECore.BoolData( 0 ),
+			} )
+		)
+
+		prototype1 = GafferScene.Private.IECoreScenePreview.Renderer.Prototype(
+			[ IECoreScene.SpherePrimitive() ], [ 0.0 ], attributes1
+		)
+
+		prototype2 = GafferScene.Private.IECoreScenePreview.Renderer.Prototype(
+			[ IECoreScene.SpherePrimitive( 2 ) ], [ 0.0 ], attributes1
+		)
+
+		renderer.pointInstancer( "instancer1_attributes1_prototype1_A", [ pointInstancer1 ], [ 0.0 ], [ prototype1 ], attributes1 )
+		renderer.pointInstancer( "instancer1_attributes1_prototype1_B", [ pointInstancer1 ], [ 0.0 ], [ prototype1 ], attributes1 )
+
+		renderer.pointInstancer( "instancer2_attributes1_prototype1_A", [ pointInstancer2 ], [ 0.0 ], [ prototype1 ], attributes1 )
+		renderer.pointInstancer( "instancer2_attributes1_prototype1_B", [ pointInstancer2 ], [ 0.0 ], [ prototype1 ], attributes1 )
+
+		renderer.pointInstancer( "instancer1_noInstancing_A", [ pointInstancer1 ], [ 0.0 ], [ prototype1 ], noInstanceAttributes )
+		renderer.pointInstancer( "instancer1_noInstancing_B", [ pointInstancer1 ], [ 0.0 ], [ prototype1 ], noInstanceAttributes )
+
+		renderer.render()
+		del attributes1, noInstanceAttributes, prototype1, prototype2
+		del renderer
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, str( self.temporaryDirectory() / "test.ass" ), None )
+
+			shapes = self.__allNodes( universe, type = arnold.AI_NODE_SHAPE )
+			numGInstances = len( [ s for s in shapes if arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( s ) ) == "ginstance" ] )
+			numInstancers = len( [ s for s in shapes if arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( s ) ) == "instancer" ] )
+
+			self.assertEqual( numInstancers, 4 )
+			self.assertEqual( numGInstances, 4 )
+
+			self.__assertInstanced(
+				universe,
+				"instancer1_attributes1_prototype1_A",
+				"instancer1_attributes1_prototype1_B",
+			)
+
+			self.__assertInstanced(
+				universe,
+				"instancer2_attributes1_prototype1_A",
+				"instancer2_attributes1_prototype1_B",
+			)
+
+			self.__assertNotInstanced(
+				universe,
+				"instancer1_noInstancing_A",
+				"instancer1_noInstancing_B",
+			)
+
 	def testTransformTypeAttribute( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -397,7 +397,7 @@ namespace
 class ArnoldGlobals;
 class Instance;
 IE_CORE_FORWARDDECLARE( ShaderCache );
-IE_CORE_FORWARDDECLARE( InstanceCache );
+IE_CORE_FORWARDDECLARE( PrototypeCache );
 IE_CORE_FORWARDDECLARE( ArnoldObject );
 
 /// This class implements the basics of outputting attributes
@@ -428,7 +428,7 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 		NodeDeleter m_nodeDeleter;
 		AtUniverse *m_universe;
 		ShaderCachePtr m_shaderCache;
-		InstanceCachePtr m_instanceCache;
+		PrototypeCachePtr m_prototypeCache;
 
 		IECore::MessageHandlerPtr m_messageHandler;
 
@@ -1385,7 +1385,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		// go on the shape rather than the ginstance. These are problematic because they
 		// must be taken into account when determining the hash for instancing, and
 		// because they cannot be edited interactively. This method applies those
-		// attributes, and is called from InstanceCache during geometry conversion.
+		// attributes, and is called from PrototypeCache during geometry conversion.
 		void applyGeometry( const IECore::Object *object, AtNode *node ) const
 		{
 			if( const IECoreScene::MeshPrimitive *mesh = IECore::runTimeCast<const IECoreScene::MeshPrimitive>( object ) )
@@ -2357,12 +2357,26 @@ IE_CORE_DECLAREPTR( ArnoldAttributes )
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
-// InstanceCache
+// PrototypeCache
 //////////////////////////////////////////////////////////////////////////
 
 namespace
 {
 
+// Arnold doesn't have a clear separation between prototypes and instances.
+// For example, a `polymesh` has its own `shader` and `matrix` parameters
+// allowing it to be rendered directly. But it can also be referenced by a
+// `ginstance` node that has its own shader and matrix.
+//
+// We want to avoid the overhead of the `ginstance` node when we know we're
+// not going to be instancing a shape more than once. The Instance class
+// can therefore exist in two states :
+//
+// 1. A uniquely owned `ginstance` referencing a potentially shared shape.
+// 2. A uniquely owned shape node with no `ginstance`.
+//
+// In both cases, the `node()` function returns the uniquely owned node,
+// which we apply transforms and shaders etc to.
 class Instance
 {
 
@@ -2381,7 +2395,7 @@ class Instance
 			}
 			else
 			{
-				// Technically the node was created in `InstanceCache.get()`
+				// Technically the node was created in `PrototypeCache.createInstance()`
 				// rather than by us directly, but we are the sole owner and
 				// this is the most natural place to report the creation.
 				nodes.push_back( m_node.get() );
@@ -2391,8 +2405,8 @@ class Instance
 	private :
 
 		// Constructors are private as they are only intended for use in
-		// `InstanceCache::get()`. See comment in `nodesCreated()`.
-		friend class InstanceCache;
+		// `PrototypeCache::createInstance()`. See comment in `nodesCreated()`.
+		friend class PrototypeCache;
 
 		// Non-instanced
 		Instance( const SharedAtNodePtr &node )
@@ -2406,7 +2420,6 @@ class Instance
 		{
 			if( node )
 			{
-				AiNodeSetByte( node.get(), g_visibilityArnoldString, 0 );
 				m_ginstance = SharedAtNodePtr(
 					AiNode( universe, g_ginstanceArnoldString, AtString( instanceName.c_str() ), parent ),
 					nodeDeleter
@@ -2423,28 +2436,26 @@ class Instance
 // Forward declaration
 AtNode *convertProcedural( IECoreScenePreview::ConstProceduralPtr procedural, const ArnoldAttributes *attributes, AtUniverse *universe, const std::string &nodeName, AtNode *parentNode );
 
-class InstanceCache : public IECore::RefCounted
+class PrototypeCache : public IECore::RefCounted
 {
 
 	public :
 
-		InstanceCache( NodeDeleter nodeDeleter, AtUniverse *universe, AtNode *parentNode )
+		PrototypeCache( NodeDeleter nodeDeleter, AtUniverse *universe, AtNode *parentNode )
 			:	m_nodeDeleter( nodeDeleter ), m_universe( universe ), m_parentNode( parentNode )
 		{
 		}
 
-		Instance get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &nodeName )
+		// Converts `samples` to an appropriate Arnold node, reusing previous
+		// conversions when the same samples are passed more than once. Does not
+		// respect `ArnoldAttributes::canInstanceGeometry()` - all conversions
+		// are cached and reused where possible. The result must therefore always
+		// be used with a `ginstance` node.
+		ConstSharedAtNodePtr get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &messageContext )
 		{
 			if( samples.empty() )
 			{
-				return Instance( SharedAtNodePtr() );
-			}
-
-			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
-
-			if( !arnoldAttributes->canInstanceGeometry( samples.front().get() ) )
-			{
-				return Instance( convert( samples, times, arnoldAttributes, nodeName, /* messageContext = */ nodeName ) );
+				return nullptr;
 			}
 
 			IECore::MurmurHash h;
@@ -2453,14 +2464,15 @@ class InstanceCache : public IECore::RefCounted
 				sample->hash( h );
 			}
 			h.append( times.data(), times.size() );
+
+			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
 			arnoldAttributes->hashGeometry( samples.front().get(), h );
 
 			SharedAtNodePtr node;
 			Cache::const_accessor readAccessor;
 			if( m_cache.find( readAccessor, h ) )
 			{
-				node = readAccessor->second;
-				readAccessor.release();
+				return readAccessor->second;
 			}
 			else
 			{
@@ -2469,7 +2481,11 @@ class InstanceCache : public IECore::RefCounted
 				{
 					try
 					{
-						writeAccessor->second = convert( samples, times, arnoldAttributes, "instance:" + h.toString(), /* messageContext = */ nodeName );
+						writeAccessor->second = convert( samples, times, arnoldAttributes, "instance:" + h.toString(), messageContext );
+						if( writeAccessor->second )
+						{
+							AiNodeSetByte( writeAccessor->second.get(), g_visibilityArnoldString, 0 );
+						}
 					}
 					catch( const IECore::Cancelled & )
 					{
@@ -2480,11 +2496,28 @@ class InstanceCache : public IECore::RefCounted
 						throw;
 					}
 				}
-				node = writeAccessor->second;
-				writeAccessor.release();
+				return writeAccessor->second;
+			}
+		}
+
+		// Creates an Instance, using `get()` where `ArnoldAttributes::canInstanceGeometry()` allows it,
+		// otherwise creating a unique shape node.
+		Instance createInstance( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &nodeName )
+		{
+			if( samples.empty() )
+			{
+				return Instance( nullptr );
 			}
 
-			return Instance( node, m_nodeDeleter, m_universe, nodeName, m_parentNode );
+			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
+			if( !arnoldAttributes->canInstanceGeometry( samples.front().get() ) )
+			{
+				return Instance( convert( samples, times, arnoldAttributes, nodeName, /* messageContext = */ nodeName ) );
+			}
+			else
+			{
+				return Instance( get( samples, times, attributes, nodeName ), m_nodeDeleter, m_universe, nodeName, m_parentNode );
+			}
 		}
 
 		// Must not be called concurrently with anything.
@@ -2556,7 +2589,7 @@ class InstanceCache : public IECore::RefCounted
 
 };
 
-IE_CORE_DECLAREPTR( InstanceCache )
+IE_CORE_DECLAREPTR( PrototypeCache )
 
 } // namespace
 
@@ -3238,7 +3271,7 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			{
 				nodes.insert( nodes.end(), nodesCreated.begin(), nodesCreated.end() );
 			}
-			m_instanceCache->nodesCreated( nodes );
+			m_prototypeCache->nodesCreated( nodes );
 			m_shaderCache->nodesCreated( nodes );
 		}
 
@@ -3307,7 +3340,7 @@ AtNode *convertProcedural( IECoreScenePreview::ConstProceduralPtr procedural, co
 	tbb::this_task_arena::isolate(
 		// Isolate in case procedural spawns TBB tasks, because
 		// `convertProcedural()` is called behind a lock in
-		// `InstanceCache.get()`.
+		// `PrototypeCache.get()`.
 		[&]() {
 			procedural->render( renderer.get() );
 		}
@@ -4576,7 +4609,7 @@ ArnoldRendererBase::ArnoldRendererBase( NodeDeleter nodeDeleter, AtUniverse *uni
 	:	m_nodeDeleter( nodeDeleter ),
 		m_universe( universe ),
 		m_shaderCache( new ShaderCache( nodeDeleter, universe, parentNode ) ),
-		m_instanceCache( new InstanceCache( nodeDeleter, universe, parentNode ) ),
+		m_prototypeCache( new PrototypeCache( nodeDeleter, universe, parentNode ) ),
 		m_messageHandler( messageHandler ),
 		m_parentNode( parentNode )
 {
@@ -4602,7 +4635,7 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::st
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( ObjectSamples( samples.begin(), samples.end() ), times, attributes, name );
+	Instance instance = m_prototypeCache->createInstance( ObjectSamples( samples.begin(), samples.end() ), times, attributes, name );
 
 	ObjectInterfacePtr result = new ArnoldObject( instance );
 	if( attributes )
@@ -4616,7 +4649,7 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::light( const std::str
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( samples, times, attributes, name );
+	Instance instance = m_prototypeCache->createInstance( samples, times, attributes, name );
 	ObjectInterfacePtr result = new ArnoldLight( name, instance, m_nodeDeleter, m_universe, m_parentNode );
 	result->attributes( attributes );
 	return result;
@@ -4626,7 +4659,7 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::lightFilter( const st
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( samples, times,  attributes, name );
+	Instance instance = m_prototypeCache->createInstance( samples, times,  attributes, name );
 	ObjectInterfacePtr result = new ArnoldLightFilter( name, instance, m_nodeDeleter, m_universe, m_parentNode );
 	result->attributes( attributes );
 
@@ -4637,7 +4670,7 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::object( const std::st
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-	Instance instance = m_instanceCache->get( samples, times, attributes, name );
+	Instance instance = m_prototypeCache->createInstance( samples, times, attributes, name );
 	ObjectInterfacePtr result = new ArnoldObject( instance );
 	result->attributes( attributes );
 	return result;
@@ -4674,7 +4707,7 @@ class ArnoldRenderer final : public ArnoldRendererBase
 		{
 			pause();
 			// Delete cached nodes before universe is destroyed.
-			m_instanceCache.reset( nullptr );
+			m_prototypeCache.reset( nullptr );
 			m_shaderCache.reset( nullptr );
 		}
 
@@ -4702,7 +4735,7 @@ class ArnoldRenderer final : public ArnoldRendererBase
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
 			m_shaderCache->preRender( m_globals->renderType() );
-			m_instanceCache->clearUnused();
+			m_prototypeCache->clearUnused();
 			m_globals->render();
 		}
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -312,6 +312,10 @@ const AtString g_funcPtrArnoldString( "funcptr" );
 const AtString g_ginstanceArnoldString( "ginstance" );
 const AtString g_ignoreMotionBlurArnoldString( "ignore_motion_blur" );
 const AtString g_inputArnoldString( "input" );
+const AtString g_instanceMatrixArnoldString( "instance_matrix" );
+const AtString g_instanceShaderArnoldString( "instance_shader" );
+const AtString g_instanceVisibilityArnoldString( "instance_visibility" );
+const AtString g_instancerArnoldString( "instancer" );
 const AtString g_lightGroupArnoldString( "light_group" );
 const AtString g_shadowGroupArnoldString( "shadow_group" );
 const AtString g_linearArnoldString( "linear" );
@@ -326,6 +330,8 @@ const AtString g_motionStartArnoldString( "motion_start" );
 const AtString g_motionEndArnoldString( "motion_end" );
 const AtString g_nameArnoldString( "name" );
 const AtString g_nodeArnoldString("node");
+const AtString g_nodeIndexesArnoldString( "node_idxs" );
+const AtString g_nodesArnoldString( "nodes" );
 const AtString g_objectArnoldString( "object" );
 const AtString g_opaqueArnoldString( "opaque" );
 const AtString g_pointsArnoldString( "points" );
@@ -398,6 +404,7 @@ class ArnoldGlobals;
 class Instance;
 IE_CORE_FORWARDDECLARE( ShaderCache );
 IE_CORE_FORWARDDECLARE( PrototypeCache );
+IE_CORE_FORWARDDECLARE( PointInstancerCache );
 IE_CORE_FORWARDDECLARE( ArnoldObject );
 
 /// This class implements the basics of outputting attributes
@@ -420,6 +427,7 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 		ObjectInterfacePtr light( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr lightFilter( const std::string &name, const ObjectSamples &objectSamples, const SampleTimes &times, const AttributesInterface *attributes ) override;
 		ObjectInterfacePtr object( const std::string &name, const ObjectSamples &samples, const SampleTimes &times, const AttributesInterface *attributes ) override;
+		ObjectInterfacePtr pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes ) override;
 
 	protected :
 
@@ -429,6 +437,7 @@ class ArnoldRendererBase : public IECoreScenePreview::Renderer
 		AtUniverse *m_universe;
 		ShaderCachePtr m_shaderCache;
 		PrototypeCachePtr m_prototypeCache;
+		PointInstancerCachePtr m_pointInstancerCache;
 
 		IECore::MessageHandlerPtr m_messageHandler;
 
@@ -1608,8 +1617,11 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			// Early out for IECoreScene::Procedurals. Arnold's inheritance rules for procedurals are back
 			// to front, with any explicitly set parameters on the procedural node overriding parameters of child
 			// nodes completely. We emulate the inheritance we want in ArnoldProceduralRenderer.
+			//
+			// Since Arnold's `instancer` node is implemented as a procedural, it suffers from the same problems,
+			// so we treat it the same way.
 
-			if( isConvertedProcedural( geometry ) )
+			if( isConvertedProcedural( geometry ) || AiNodeIs( geometry, g_instancerArnoldString ) )
 			{
 				// Arnold neither inherits nor overrides visibility parameters. Instead
 				// it does a bitwise `&` between the procedural and its children. The
@@ -1728,6 +1740,33 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 			return true;
 
+		}
+
+		unsigned char visibility() const
+		{
+			return m_visibility;
+		}
+
+		AtNode *preferredShader( const AtNode *geometry ) const
+		{
+			if( m_volumeShader )
+			{
+				// Prefer the volume shader if we have one, and the geometry is either
+				// a volume or a shape being rendered as a volume (non-zero step size).
+				bool preferVolume = AiNodeIs( geometry, g_volumeArnoldString );
+				if( !preferVolume && AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( geometry ), g_stepSizeArnoldString ) )
+				{
+					preferVolume = AiNodeGetFlt( geometry, g_stepSizeArnoldString ) > 0.0f;
+				}
+				if( preferVolume )
+				{
+					return m_volumeShader->root();
+				}
+			}
+
+			// Otherwise use the surface shader. We use this even for volume geometry,
+			// because Gaffer historically assigned volume shaders as `ai:surface`.
+			return m_surfaceShader->root();
 		}
 
 		const IECoreScene::ShaderNetwork *lightShader() const
@@ -2284,28 +2323,6 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			h.append( m_sssSetName.c_str() ? m_sssSetName.c_str() : "" );
 		}
 
-		AtNode *preferredShader( const AtNode *geometry ) const
-		{
-			if( m_volumeShader )
-			{
-				// Prefer the volume shader if we have one, and the geometry is either
-				// a volume or a shape being rendered as a volume (non-zero step size).
-				bool preferVolume = AiNodeIs( geometry, g_volumeArnoldString );
-				if( !preferVolume && AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( geometry ), g_stepSizeArnoldString ) )
-				{
-					preferVolume = AiNodeGetFlt( geometry, g_stepSizeArnoldString ) > 0.0f;
-				}
-				if( preferVolume )
-				{
-					return m_volumeShader->root();
-				}
-			}
-
-			// Otherwise use the surface shader. We use this even for volume geometry,
-			// because Gaffer historically assigned volume shaders as `ai:surface`.
-			return m_surfaceShader->root();
-		}
-
 		unsigned char m_visibility;
 		unsigned char m_sidedness;
 		unsigned char m_shadingFlags;
@@ -2407,6 +2424,7 @@ class Instance
 		// Constructors are private as they are only intended for use in
 		// `PrototypeCache::createInstance()`. See comment in `nodesCreated()`.
 		friend class PrototypeCache;
+		friend class PointInstancerCache;
 
 		// Non-instanced
 		Instance( const SharedAtNodePtr &node )
@@ -2451,7 +2469,7 @@ class PrototypeCache : public IECore::RefCounted
 		// respect `ArnoldAttributes::canInstanceGeometry()` - all conversions
 		// are cached and reused where possible. The result must therefore always
 		// be used with a `ginstance` node.
-		ConstSharedAtNodePtr get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &messageContext )
+		SharedAtNodePtr get( const IECoreScenePreview::Renderer::ObjectSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::string &messageContext )
 		{
 			if( samples.empty() )
 			{
@@ -2590,6 +2608,220 @@ class PrototypeCache : public IECore::RefCounted
 };
 
 IE_CORE_DECLAREPTR( PrototypeCache )
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// PointInstancerCache
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct InstancerNodes
+{
+	SharedAtNodePtr node;
+	std::vector<SharedAtNodePtr> prototypeNodes;
+	std::vector<ArnoldAttributesPtr> prototypeAttributes;
+};
+
+using InstancerNodesSharedPtr = std::shared_ptr<InstancerNodes>;
+
+class PointInstancerCache : public IECore::RefCounted
+{
+
+	public :
+
+		PointInstancerCache( const PrototypeCachePtr &prototypeCache, NodeDeleter nodeDeleter, AtUniverse *universe, AtNode *parentNode )
+			:	m_prototypeCache( prototypeCache ), m_nodeDeleter( nodeDeleter ), m_universe( universe ), m_parentNode( parentNode )
+		{
+		}
+
+		std::pair<Instance, InstancerNodesSharedPtr> createInstance(
+			const IECoreScenePreview::Renderer::PointInstancerSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times,
+			const std::vector<IECoreScenePreview::Renderer::Prototype> &prototypes, const IECoreScenePreview::Renderer::AttributesInterface *attributes,
+			const std::string &nodeName
+		)
+		{
+			if( samples.empty() )
+			{
+				return { Instance( nullptr ), nullptr };
+			}
+
+			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
+			if( !arnoldAttributes->canInstanceGeometry( samples.front().get() ) )
+			{
+				auto nodes = convert( samples, times, prototypes, nodeName );
+				return { Instance( nodes->node ), nodes };
+			}
+			else
+			{
+				auto nodes = get( samples, times, prototypes );
+				return { Instance( nodes->node, m_nodeDeleter, m_universe, nodeName, m_parentNode ), nodes };
+			}
+		}
+
+		// Must not be called concurrently with anything.
+		void clearUnused()
+		{
+			vector<IECore::MurmurHash> toErase;
+			for( Cache::iterator it = m_cache.begin(), eIt = m_cache.end(); it != eIt; ++it )
+			{
+				if( it->second.use_count() == 1 )
+				{
+					// Only one reference - this is ours, so
+					// nothing outside of the cache is using the
+					// node.
+					toErase.push_back( it->first );
+				}
+			}
+			for( vector<IECore::MurmurHash>::const_iterator it = toErase.begin(), eIt = toErase.end(); it != eIt; ++it )
+			{
+				m_cache.erase( *it );
+			}
+		}
+
+		void nodesCreated( vector<AtNode *> &nodes ) const
+		{
+			for( Cache::const_iterator it = m_cache.begin(), eIt = m_cache.end(); it != eIt; ++it )
+			{
+				if( it->second )
+				{
+					nodes.push_back( it->second->node.get() );
+				}
+			}
+		}
+
+	private :
+
+		InstancerNodesSharedPtr get( const IECoreScenePreview::Renderer::PointInstancerSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times, const std::vector<IECoreScenePreview::Renderer::Prototype> &prototypes )
+		{
+			IECore::MurmurHash hash;
+			for( const auto &sample : samples )
+			{
+				sample->hash( hash );
+			}
+			hash.append( times.data(), times.size() );
+
+			for( const auto &p : prototypes )
+			{
+				for( const auto &sample : p.samples )
+				{
+					sample->hash( hash );
+				}
+				hash.append( p.times.data(), p.times.size() );
+				auto prototypeAttributes = static_cast<const ArnoldAttributes *>( p.attributes.get() );
+				prototypeAttributes->hashGeometry( p.samples.front().get(), hash );
+				/// \todo This is unnecessarily pessimistic - not all attributes affect the prototype.
+				prototypeAttributes->allAttributes()->hash( hash );
+			}
+
+			Cache::const_accessor readAccessor;
+			if( m_cache.find( readAccessor, hash ) )
+			{
+				return readAccessor->second;
+			}
+			else
+			{
+				Cache::accessor writeAccessor;
+				if( m_cache.insert( writeAccessor, hash ) )
+				{
+					writeAccessor->second = convert( samples, times, prototypes, fmt::format( "instancer:{}", hash.toString() ) );
+				}
+				return writeAccessor->second;
+			}
+		}
+
+		/// \todo Experiment with Arnold's new `instance_matrix` feature, where you can add an
+		/// array of instancing matrices directly onto a `polymesh`. This could potentially give
+		/// much better time to first pixel.
+		InstancerNodesSharedPtr convert(
+			const IECoreScenePreview::Renderer::PointInstancerSamples &samples,
+			const IECoreScenePreview::Renderer::SampleTimes &times,
+			const std::vector<IECoreScenePreview::Renderer::Prototype> &prototypes, const std::string &nodeName
+		)
+		{
+			auto instancerNode = SharedAtNodePtr( AiNode( m_universe, g_instancerArnoldString, AtString( nodeName.c_str() ), m_parentNode ), m_nodeDeleter );
+
+			vector<SharedAtNodePtr> prototypeNodes;
+			std::vector<ArnoldAttributesPtr> prototypeAttributes;
+			std::vector<AtNode *> prototypeShaders;
+			prototypeNodes.reserve( prototypes.size() );
+			prototypeAttributes.reserve( prototypes.size() );
+			prototypeShaders.reserve( prototypeShaders.size() );
+			AtArray *prototypesArray = AiArrayAllocate( prototypes.size(), 1, AI_TYPE_NODE );
+
+			for( size_t prototypeIndex = 0; prototypeIndex < prototypes.size(); prototypeIndex++ ) // TODO : parallel_for
+			{
+				const auto &prototype = prototypes[prototypeIndex];
+				prototypeNodes.push_back( m_prototypeCache->get(
+					prototype.samples, prototype.times, prototype.attributes.get(),
+					/* messageContext = */ fmt::format( "{}:prototype{}", nodeName, prototypeIndex ) )
+				);
+				AiArraySetPtr( prototypesArray, prototypeIndex, prototypeNodes[prototypeIndex].get() );
+				prototypeAttributes.push_back( boost::static_pointer_cast<ArnoldAttributes>( prototype.attributes ) );
+				prototypeShaders.push_back( prototypeAttributes[prototypeIndex]->preferredShader( prototypeNodes[prototypeIndex].get() ) );
+			}
+
+			AiNodeSetArray( instancerNode.get(), g_nodesArnoldString, prototypesArray );
+
+			// Convert transforms
+
+			AiNodeSetFlt( instancerNode.get(), g_motionStartArnoldString, times.front() );
+			AiNodeSetFlt( instancerNode.get(), g_motionEndArnoldString, times.back() );
+
+			vector<IECoreScene::PointInstancer::TransformQuery> sampleQueries;
+			for( const auto &sample : samples )
+			{
+				sampleQueries.push_back( IECoreScene::PointInstancer::TransformQuery( *sample ) );
+			}
+
+			auto matrixArray = AiArrayAllocate( samples[0]->getNumPoints(), sampleQueries.size(), AI_TYPE_MATRIX );
+			size_t matrixArrayIndex = 0;
+			for( const auto &query : sampleQueries )
+			{
+				for( size_t instanceIndex = 0, e = samples[0]->getNumPoints(); instanceIndex < e; ++instanceIndex )
+				{
+					Imath::M44f m = query.transform( instanceIndex );
+					AiArraySetMtx( matrixArray, matrixArrayIndex++, reinterpret_cast<const AtMatrix&>( m.x ) );
+				}
+			}
+
+			auto prototypeIndices = samples[0]->getPrototypeIndex();
+			auto indexArray = AiArrayAllocate( samples[0]->getNumPoints(), 1, AI_TYPE_UINT );
+			auto visibilityArray = AiArrayAllocate( samples[0]->getNumPoints(), 1, AI_TYPE_BYTE );
+			auto shaderArray = AiArrayAllocate( samples[0]->getNumPoints(), 1, AI_TYPE_NODE );
+			for( size_t instanceIndex = 0, e = samples[0]->getNumPoints(); instanceIndex < e; ++instanceIndex )
+			{
+				const int prototypeIndex = prototypeIndices ? prototypeIndices[instanceIndex] : 0;
+				AiArraySetInt( indexArray, instanceIndex, prototypeIndex );
+				AiArraySetByte( visibilityArray, instanceIndex, prototypeAttributes[prototypeIndex]->visibility() );
+				AiArraySetPtr( shaderArray, instanceIndex, prototypeShaders[prototypeIndex] );
+			}
+
+			AiNodeSetArray( instancerNode.get(), g_instanceMatrixArnoldString, matrixArray );
+			AiNodeSetArray( instancerNode.get(), g_nodeIndexesArnoldString, indexArray );
+			AiNodeSetArray( instancerNode.get(), g_instanceVisibilityArnoldString, visibilityArray );
+			AiNodeSetArray( instancerNode.get(), g_instanceShaderArnoldString, shaderArray );
+
+			AiNodeSetByte( instancerNode.get(), g_visibilityArnoldString, 0 );
+
+			return std::make_shared<InstancerNodes>( InstancerNodes{
+				instancerNode, std::move( prototypeNodes ), std::move( prototypeAttributes )
+			} );
+		}
+
+		PrototypeCachePtr m_prototypeCache;
+		NodeDeleter m_nodeDeleter;
+		AtUniverse *m_universe;
+		AtNode *m_parentNode;
+
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, InstancerNodesSharedPtr>;
+		Cache m_cache;
+
+};
+
+IE_CORE_DECLAREPTR( PointInstancerCache )
 
 } // namespace
 
@@ -3159,6 +3391,31 @@ IE_CORE_DECLAREPTR( ArnoldLight )
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
+// ArnoldInstancerObject
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class ArnoldInstancerObject : public ArnoldObject
+{
+
+	public :
+
+		ArnoldInstancerObject( const Instance &instance, const InstancerNodesSharedPtr &instancerNodes )
+			:	ArnoldObject( instance ), m_nodes( instancerNodes )
+		{
+		}
+
+	private :
+
+		InstancerNodesSharedPtr m_nodes;
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
 // Procedurals
 //////////////////////////////////////////////////////////////////////////
 
@@ -3271,6 +3528,7 @@ class ProceduralRenderer final : public ArnoldRendererBase
 			{
 				nodes.insert( nodes.end(), nodesCreated.begin(), nodesCreated.end() );
 			}
+			m_pointInstancerCache->nodesCreated( nodes );
 			m_prototypeCache->nodesCreated( nodes );
 			m_shaderCache->nodesCreated( nodes );
 		}
@@ -4610,6 +4868,7 @@ ArnoldRendererBase::ArnoldRendererBase( NodeDeleter nodeDeleter, AtUniverse *uni
 		m_universe( universe ),
 		m_shaderCache( new ShaderCache( nodeDeleter, universe, parentNode ) ),
 		m_prototypeCache( new PrototypeCache( nodeDeleter, universe, parentNode ) ),
+		m_pointInstancerCache( new PointInstancerCache( m_prototypeCache, nodeDeleter, universe, parentNode ) ),
 		m_messageHandler( messageHandler ),
 		m_parentNode( parentNode )
 {
@@ -4627,7 +4886,6 @@ IECore::InternedString ArnoldRendererBase::name() const
 ArnoldRendererBase::AttributesInterfacePtr ArnoldRendererBase::attributes( const IECore::CompoundObject *attributes )
 {
 	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
-
 	return new ArnoldAttributes( attributes, m_shaderCache.get() );
 }
 
@@ -4676,6 +4934,17 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::object( const std::st
 	return result;
 }
 
+ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes )
+{
+	const IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
+	auto [instance, nodes] = m_pointInstancerCache->createInstance( samples, times, prototypes, attributes, name );
+	ObjectInterfacePtr result = new ArnoldInstancerObject( instance, nodes );
+	result->attributes( attributes );
+
+	return result;
+}
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -4707,6 +4976,7 @@ class ArnoldRenderer final : public ArnoldRendererBase
 		{
 			pause();
 			// Delete cached nodes before universe is destroyed.
+			m_pointInstancerCache.reset( nullptr );
 			m_prototypeCache.reset( nullptr );
 			m_shaderCache.reset( nullptr );
 		}
@@ -4735,6 +5005,7 @@ class ArnoldRenderer final : public ArnoldRendererBase
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
 			m_shaderCache->preRender( m_globals->renderType() );
+			m_pointInstancerCache->clearUnused();
 			m_prototypeCache->clearUnused();
 			m_globals->render();
 		}

--- a/src/IECoreRenderMan/Attributes.cpp
+++ b/src/IECoreRenderMan/Attributes.cpp
@@ -292,6 +292,19 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 			continue;
 		}
 
+		auto it = g_prototypeAttributes.find( name );
+		if( it != g_prototypeAttributes.end() )
+		{
+			ParamListAlgo::convertParameter( it->second, data, m_prototypeAttributes );
+			if( m_prototypeHash )
+			{
+				/// \todo Make the hash match between non-specified attributes and attributes which
+				/// are explicitly specified with their default values.
+				data->hash( *m_prototypeHash );
+			}
+			continue;
+		}
+
 		if( name == g_lightMuteAttributeName )
 		{
 			ParamListAlgo::convertParameter( Loader::strings().k_lighting_mute, data, m_instanceAttributes );
@@ -312,28 +325,17 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 				RtUString( withUserPrefix.c_str() ), data, m_instanceAttributes
 			);
 		}
-
-		if( !boost::starts_with( name.c_str(), g_renderManPrefix.c_str() ) )
+		else if( !boost::starts_with( name.c_str(), g_renderManPrefix.c_str() ) )
 		{
+			// Avoid appending to `m_instanceAttributesHash`.
 			continue;
-		}
-
-		auto it = g_prototypeAttributes.find( name );
-		if( it != g_prototypeAttributes.end() )
-		{
-			ParamListAlgo::convertParameter( it->second, data, m_prototypeAttributes );
-			if( m_prototypeHash )
-			{
-				/// \todo Make the hash match between non-specified attributes and attributes which
-				/// are explicitly specified with their default values.
-				data->hash( *m_prototypeHash );
-			}
 		}
 		else
 		{
 			ParamListAlgo::convertParameter( RtUString( name.c_str() + g_renderManPrefix.size() ), data, m_instanceAttributes );
-
 		}
+
+		value->hash( m_instanceAttributesHash );
 	}
 
 	m_lightFilter = attribute<ShaderNetwork>( attributes->members(), g_renderManLightFilterAttributeName );
@@ -356,6 +358,11 @@ const RtParamList &Attributes::prototypeAttributes() const
 const RtParamList &Attributes::instanceAttributes() const
 {
 	return m_instanceAttributes;
+}
+
+const IECore::MurmurHash &Attributes::instanceAttributesHash() const
+{
+	return m_instanceAttributesHash;
 }
 
 const Material *Attributes::material() const

--- a/src/IECoreRenderMan/Attributes.h
+++ b/src/IECoreRenderMan/Attributes.h
@@ -63,6 +63,7 @@ class Attributes : public IECoreScenePreview::Renderer::AttributesInterface
 		const RtParamList &prototypeAttributes() const;
 		/// Attributes to be applied to GeometryInstances.
 		const RtParamList &instanceAttributes() const;
+		const IECore::MurmurHash &instanceAttributesHash() const;
 
 		const Material *material() const;
 		const Displacement *displacement() const { return m_displacement.get(); }
@@ -80,6 +81,7 @@ class Attributes : public IECoreScenePreview::Renderer::AttributesInterface
 		std::optional<IECore::MurmurHash> m_prototypeHash;
 		RtParamList m_prototypeAttributes;
 		RtParamList m_instanceAttributes;
+		IECore::MurmurHash m_instanceAttributesHash;
 		ConstMaterialPtr m_material;
 		ConstDisplacementPtr m_displacement;
 		IECoreScene::ConstShaderNetworkPtr m_lightShader;

--- a/src/IECoreRenderMan/PointInstancerCache.cpp
+++ b/src/IECoreRenderMan/PointInstancerCache.cpp
@@ -1,0 +1,189 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "PointInstancerCache.h"
+
+#include "Loader.h"
+#include "Transform.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+PointInstancerCache::PointInstancer::~PointInstancer()
+{
+	if( m_session->renderType == IECoreScenePreview::Renderer::Interactive )
+	{
+		// Delete instances before the prototypes they refer to.
+		for( const auto &id : m_instances )
+		{
+			m_session->riley->DeleteGeometryInstance( group->id(), id );
+		}
+		m_prototypeGeometries.clear();
+		m_prototypeAttributes.clear();
+	}
+}
+
+PointInstancerCache::PointInstancerCache( Session *session, GeometryPrototypeCache *geometryPrototypeCache )
+	:	m_session( session ), m_geometryPrototypeCache( geometryPrototypeCache )
+{
+}
+
+PointInstancerCache::ConstPointInstancerPtr PointInstancerCache::get(
+	const IECoreScenePreview::Renderer::PointInstancerSamples &samples,
+	const IECoreScenePreview::Renderer::SampleTimes &sampleTimes,
+	const std::vector<IECoreScenePreview::Renderer::Prototype> &prototypes,
+	const Attributes *attributes, const std::string &messageContext
+)
+{
+	auto converter = [&] ( PointInstancerPtr &result ) {
+
+		result = new PointInstancer;
+		result->m_session = m_session;
+
+		riley::DisplacementId displacement;
+		if( auto d = attributes->displacement() )
+		{
+			displacement = d->id();
+		}
+
+		result->m_prototypeGeometries.reserve( prototypes.size() );
+		result->m_prototypeAttributes.reserve( prototypes.size() );
+		for( size_t prototypeIndex = 0; prototypeIndex < prototypes.size(); ++prototypeIndex )
+		{
+			const auto &prototype = prototypes[prototypeIndex];
+			result->m_prototypeAttributes.push_back( boost::static_pointer_cast<Attributes>( prototypes[prototypeIndex].attributes ) );
+			result->m_prototypeGeometries.push_back(
+				m_geometryPrototypeCache->get(
+					prototype.samples, prototype.times, result->m_prototypeAttributes.back().get(),
+					/* messageContext = */ fmt::format( "{}:prototype{}", messageContext, prototypeIndex )
+				)
+			);
+		}
+
+		result->group = new GeometryPrototype(
+			m_session->riley->CreateGeometryPrototype( riley::UserId(), Loader::strings().k_Ri_Group, displacement, RtPrimVarList() ),
+			m_session
+		);
+
+		vector<IECoreScene::PointInstancer::TransformQuery> sampleQueries;
+		for( const auto &sample : samples )
+		{
+			sampleQueries.push_back( IECoreScene::PointInstancer::TransformQuery( *sample ) );
+		}
+
+		auto prototypeIndices = samples[0]->getPrototypeIndex();
+
+		IECoreScenePreview::Renderer::TransformSamples transformSamples;
+		transformSamples.resize( samples.size() );
+		result->m_instances.reserve( samples[0]->getNumPoints() );
+		for( size_t instanceIndex = 0, e = samples[0]->getNumPoints(); instanceIndex < e; ++instanceIndex )
+		{
+			for( size_t sampleIndex = 0; sampleIndex < sampleQueries.size(); ++sampleIndex )
+			{
+				transformSamples[sampleIndex] = sampleQueries[sampleIndex].transform( instanceIndex );
+			}
+
+			const size_t prototypeIndex = prototypeIndices ? prototypeIndices[instanceIndex] : 0;
+			if( !result->m_prototypeGeometries[prototypeIndex] )
+			{
+				continue;
+			}
+
+			/// \todo Investigate `Riley::CreateGeometryInstances()` (plural) to see if
+			/// it offers any performance advantage.
+			result->m_instances.push_back(
+				m_session->riley->CreateGeometryInstance(
+					riley::UserId(), result->group->id(), result->m_prototypeGeometries[prototypeIndex]->id(),
+					result->m_prototypeAttributes[prototypeIndex]->material()->id(), riley::CoordinateSystemList(),
+					AnimatedTransform( transformSamples, sampleTimes ),
+					result->m_prototypeAttributes[prototypeIndex]->instanceAttributes()
+				)
+			);
+		}
+	};
+
+	if( !attributes->prototypeHash() )
+	{
+		// Automatic instancing disabled.
+		PointInstancerPtr result;
+		converter( result );
+		return result;
+	}
+
+	IECore::MurmurHash h;
+	for( const auto &sample : samples )
+	{
+		sample->hash( h );
+	}
+	h.append( sampleTimes.data(), sampleTimes.size() );
+
+	for( const auto &prototype : prototypes )
+	{
+		for( const auto &sample : prototype.samples )
+		{
+			sample->hash( h );
+		}
+		h.append( prototype.times.data(), prototype.times.size() );
+		h.append( static_cast<const Attributes *>( prototype.attributes.get() )->instanceAttributesHash() );
+		h.append( static_cast<const Attributes *>( prototype.attributes.get() )->material()->id().AsUInt32() );
+	}
+
+	auto [it, inserted] = m_cache.emplace(
+		std::piecewise_construct, std::forward_as_tuple( h ), std::make_tuple()
+	);
+	std::call_once( it->second.onceFlag, converter, it->second.instancer );
+
+	return it->second.instancer;
+}
+
+void PointInstancerCache::clearUnused()
+{
+	for( auto it = m_cache.begin(); it != m_cache.end(); )
+	{
+		if( it->second.instancer->refCount() == 1 )
+		{
+			// Only one reference - this is ours, so nothing outside of the
+			// cache is using the instancer.
+			it = m_cache.unsafe_erase( it );
+		}
+		else
+		{
+			++it;
+		}
+	}
+}

--- a/src/IECoreRenderMan/PointInstancerCache.h
+++ b/src/IECoreRenderMan/PointInstancerCache.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,59 +36,69 @@
 
 #pragma once
 
+#include "IECore/RefCounted.h"
+
 #include "Attributes.h"
 #include "GeometryPrototypeCache.h"
-#include "LightLinker.h"
 #include "Session.h"
 
-#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+#include "tbb/concurrent_unordered_map.h"
+
+#include <mutex>
 
 namespace IECoreRenderMan
 {
 
-class Object : public IECoreScenePreview::Renderer::ObjectInterface
+class PointInstancerCache
 {
 
 	public :
 
-		Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, LightLinker *lightLinker, const Session *session );
-		~Object() override;
+		PointInstancerCache( Session *session, GeometryPrototypeCache *geometryPrototypeCache );
 
-		void transform( const IECoreScenePreview::Renderer::TransformSamples &samples, const IECoreScenePreview::Renderer::SampleTimes &times ) override;
-		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
-		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
-		void assignID( uint32_t id ) override;
-		void assignInstanceID( uint32_t id ) override;
-
-	protected :
-
-		const Session *m_session;
-		LightLinker *m_lightLinker;
-		riley::GeometryInstanceId m_geometryInstance;
-		/// Used to keep material etc alive as long as we need it.
-		ConstAttributesPtr m_attributes;
-		/// Used to keep geometry prototype alive as long as we need it.
-		ConstGeometryPrototypePtr m_geometryPrototype;
-		RtParamList m_extraAttributes;
-		IECoreScenePreview::Renderer::ConstObjectSetPtr m_linkedLights;
-		IECoreScenePreview::Renderer::ConstObjectSetPtr m_shadowedLights;
-
-};
-
-class PointInstancerObject : public Object
-{
-
-	public :
-
-		PointInstancerObject( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, LightLinker *lightLinker, const Session *session, const IECore::ConstRefCountedPtr &prototypesOwner )
-			:	Object( name, geometryPrototype, attributes, lightLinker, session ), m_prototypesOwner( prototypesOwner )
+		struct PointInstancer : public IECore::RefCounted
 		{
-		}
+
+			~PointInstancer() override;
+
+			// Group below which instances are parented.
+			GeometryPrototypePtr group;
+
+			private :
+
+				friend class PointInstancerCache;
+
+				Session *m_session;
+				std::vector<GeometryPrototypePtr> m_prototypeGeometries; // Maintains lifetime of prototypes
+				std::vector<AttributesPtr> m_prototypeAttributes; // Maintains lifetime of attributes
+				std::vector<riley::GeometryInstanceId> m_instances; // Maintains lifetime of instances
+
+		};
+		IE_CORE_DECLAREPTR( PointInstancer );
+
+		// Can be called concurrently with other calls to `get()`.
+		ConstPointInstancerPtr get(
+			const IECoreScenePreview::Renderer::PointInstancerSamples &samples,
+			const IECoreScenePreview::Renderer::SampleTimes &sampleTimes,
+			const std::vector<IECoreScenePreview::Renderer::Prototype> &prototypes,
+			const Attributes *attributes, const std::string &messageContext
+		);
+
+		// Must not be called concurrently with anything.
+		void clearUnused();
 
 	private :
 
-		// Keeps the referenced prototypes alive as long as the object.
-		IECore::ConstRefCountedPtr m_prototypesOwner;
+		Session *m_session;
+		GeometryPrototypeCache *m_geometryPrototypeCache;
+
+		struct CacheEntry
+		{
+			std::once_flag onceFlag;
+			PointInstancerPtr instancer;
+		};
+		using Cache = tbb::concurrent_unordered_map<IECore::MurmurHash, CacheEntry>;
+		Cache m_cache;
 
 };
 

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -42,10 +42,12 @@
 #include "Light.h"
 #include "LightFilter.h"
 #include "LightLinker.h"
+#include "Loader.h"
 #include "MaterialCache.h"
 #include "Globals.h"
 #include "Object.h"
 #include "ParamListAlgo.h"
+#include "PointInstancerCache.h"
 #include "Session.h"
 #include "Transform.h"
 #include "Volume.h"
@@ -106,6 +108,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 		{
 			m_materialCache.reset();
 			m_geometryPrototypeCache.reset();
+			m_pointInstancerCache.reset();
 			m_lightLinker.reset();
 			m_globals.reset();
 		}
@@ -197,11 +200,22 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 			}
 		}
 
+		ObjectInterfacePtr pointInstancer( const std::string &name, const PointInstancerSamples &samples, const SampleTimes &times, const std::vector<Prototype> &prototypes, const AttributesInterface *attributes ) override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			acquireSession();
+
+			auto typedAttributes = static_cast<const Attributes *>( attributes );
+			auto instancer = m_pointInstancerCache->get( samples, times, prototypes, typedAttributes, /* messageContext = */ name );
+			return new IECoreRenderMan::PointInstancerObject( name, instancer->group, typedAttributes, m_lightLinker.get(), m_session, instancer );
+		}
+
 		void render() override
 		{
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
 			acquireSession();
 			m_lightLinker->updateDirtyLinks();
+			m_pointInstancerCache->clearUnused();
 			m_geometryPrototypeCache->clearUnused();
 			m_materialCache->clearUnused();
 			m_globals->render();
@@ -257,6 +271,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 					m_session = m_globals->acquireSession();
 					m_materialCache = std::make_unique<MaterialCache>( m_session );
 					m_geometryPrototypeCache = std::make_unique<GeometryPrototypeCache>( m_session );
+					m_pointInstancerCache = std::make_unique<PointInstancerCache>( m_session, m_geometryPrototypeCache.get() );
 					m_lightLinker = std::make_unique<LightLinker>();
 				}
 			}
@@ -269,6 +284,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 		Session *m_session;
 		std::unique_ptr<MaterialCache> m_materialCache;
 		std::unique_ptr<GeometryPrototypeCache> m_geometryPrototypeCache;
+		std::unique_ptr<PointInstancerCache> m_pointInstancerCache;
 		std::unique_ptr<LightLinker> m_lightLinker;
 
 };


### PR DESCRIPTION
This gives us handsome speedups in the case of Arnold, and not much in the case of RenderMan. And interestingly they are both roughly the same now. There are still opportunities for optimising both though - the main point of this PR is to get baseline functionality in place, so we can start thinking about what a PointInstancer node looks like.