### PR TITLE
cameraVisibilityAdaptor, matteAdaptor : Output all attributes to OpenGL

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.20.0)
 =======
 
+Fixes
+-----
 
+- Viewer : Fixed regression introduced in 1.6.16.0 that prevented visualisation of the renderer-specific camera visibility and matte attributes authored by the Render Pass Editor's render adaptors.
 
 1.6.20.0 (relative to 1.6.19.2)
 ========

--- a/python/GafferSceneTest/RenderAdaptorTest.py
+++ b/python/GafferSceneTest/RenderAdaptorTest.py
@@ -482,7 +482,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 				( "3Delight", "dl:visibility.camera" ),
 				( "3Delight Cloud", "dl:visibility.camera" ),
 				( "RenderMan", "ri:visibility:camera" ),
-				( "RenderMan XPU", "ri:visibility:camera" ),
+				( "RenderManXPU", "ri:visibility:camera" ),
 			) :
 
 				with self.subTest( rendererName = rendererName, attribute = attribute ) :
@@ -637,7 +637,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 				( "3Delight", "dl:matte" ),
 				( "3Delight Cloud", "dl:matte" ),
 				( "RenderMan", "ri:Ri:Matte" ),
-				( "RenderMan XPU", "ri:Ri:Matte" ),
+				( "RenderManXPU", "ri:Ri:Matte" ),
 			) :
 
 				with self.subTest( rendererName = rendererName, attribute = attribute ) :

--- a/python/GafferSceneTest/RenderPassTypeAdaptorTest.py
+++ b/python/GafferSceneTest/RenderPassTypeAdaptorTest.py
@@ -329,7 +329,7 @@ class RenderPassTypeAdaptorTest( GafferSceneTest.SceneTestCase ) :
 			( "3Delight", "osl:surface", "dl:visibility.shadow" ),
 			( "3Delight Cloud", "osl:surface", "dl:visibility.shadow" ),
 			( "RenderMan", "ri:surface", "ri:visibility:transmission" ),
-			( "RenderMan XPU", "ri:surface", "ri:visibility:transmission" ),
+			( "RenderManXPU", "ri:surface", "ri:visibility:transmission" ),
 		) :
 			with self.subTest( renderer = renderer, shaderAttribute = shaderAttribute, visibilityAttribute = visibilityAttribute ) :
 				# Everything is a shadow catcher by default
@@ -565,7 +565,7 @@ class RenderPassTypeAdaptorTest( GafferSceneTest.SceneTestCase ) :
 			( "3Delight", "osl:surface", "dl:visibility.reflection" ),
 			( "3Delight Cloud", "osl:surface", "dl:visibility.reflection" ),
 			( "RenderMan", "ri:surface", "ri:visibility:indirect" ),
-			( "RenderMan XPU", "ri:surface", "ri:visibility:indirect" ),
+			( "RenderManXPU", "ri:surface", "ri:visibility:indirect" ),
 		) :
 			with self.subTest( renderer = renderer, shaderAttribute = shaderAttribute, visibilityAttribute = visibilityAttribute ) :
 				# Everything is a reflection catcher by default
@@ -830,7 +830,7 @@ class RenderPassTypeAdaptorTest( GafferSceneTest.SceneTestCase ) :
 			( "3Delight", "osl:surface" ),
 			( "3Delight Cloud", "osl:surface" ),
 			( "RenderMan", "ri:surface" ),
-			( "RenderMan XPU", "ri:surface" ),
+			( "RenderManXPU", "ri:surface" ),
 		) :
 			with self.subTest( renderer = renderer, shaderAttribute = shaderAttribute ) :
 				# Nothing is a reflection caster by default

--- a/startup/GafferScene/cameraVisibilityAdaptor.py
+++ b/startup/GafferScene/cameraVisibilityAdaptor.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import functools
 import inspect
 
 import IECore
@@ -41,24 +42,9 @@ import IECore
 import Gaffer
 import GafferScene
 
-def __cameraVisibilityAdaptor() :
+def __cameraVisibilityAdaptor( attributeName ) :
 
 	processor = GafferScene.SceneProcessor()
-
-	processor["renderer"] = Gaffer.StringPlug()
-
-	processor["__attributeSpreadsheet"] = Gaffer.Spreadsheet()
-	processor["__attributeSpreadsheet"]["selector"].setInput( processor["renderer"] )
-	processor["__attributeSpreadsheet"]["rows"].addColumn( Gaffer.StringPlug( "name" ) )
-	for renderer, attributeName in (
-		( "Arnold", "ai:visibility:camera" ),
-		( "Cycles", "cycles:visibility:camera" ),
-		( "3Delight*", "dl:visibility.camera" ),
-		( "RenderMan*", "ri:visibility:camera" )
-	) :
-		row = processor["__attributeSpreadsheet"]["rows"].addRow()
-		row["name"].setValue( renderer )
-		row["cells"]["name"]["value"].setValue( attributeName )
 
 	processor["__optionQuery"] = GafferScene.OptionQuery()
 	processor["__optionQuery"]["scene"].setInput( processor["in"] )
@@ -88,8 +74,7 @@ def __cameraVisibilityAdaptor() :
 
 	processor["__cameraInclusions"] = GafferScene.AttributeTweaks()
 	processor["__cameraInclusions"]["in"].setInput( processor["in"] )
-	processor["__cameraInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__cameraInclusions"]["tweaks"][0]["name"].setInput( processor["__attributeSpreadsheet"]["out"]["name"] )
+	processor["__cameraInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attributeName, Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__cameraInclusions"]["filter"].setInput( processor["__cameraInclusionsFilter"]["out"] )
 	# __cameraInclusions is only required when `render:cameraInclusions` exists
@@ -100,8 +85,7 @@ def __cameraVisibilityAdaptor() :
 
 	processor["__cameraExclusions"] = GafferScene.AttributeTweaks()
 	processor["__cameraExclusions"]["in"].setInput( processor["__cameraInclusions"]["out"] )
-	processor["__cameraExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__cameraExclusions"]["tweaks"][0]["name"].setInput( processor["__attributeSpreadsheet"]["out"]["name"] )
+	processor["__cameraExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attributeName, Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__cameraExclusions"]["filter"].setInput( processor["__cameraExclusionsFilter"]["out"] )
 	# __cameraExclusions is only required when `render:cameraExclusions` exists
@@ -112,8 +96,7 @@ def __cameraVisibilityAdaptor() :
 
 	processor["__rootExclusions"] = GafferScene.AttributeTweaks()
 	processor["__rootExclusions"]["in"].setInput( processor["__cameraExclusions"]["out"] )
-	processor["__rootExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__rootExclusions"]["tweaks"][0]["name"].setInput( processor["__attributeSpreadsheet"]["out"]["name"] )
+	processor["__rootExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attributeName, Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__rootExclusions"]["filter"].setInput( processor["__rootPaths"]["out"] )
 	# All children of / are excluded from camera visibility when `render:cameraInclusions` exists and does not match the root of the scene.
@@ -126,4 +109,12 @@ def __cameraVisibilityAdaptor() :
 
 	return processor
 
-GafferScene.SceneAlgo.registerRenderAdaptor( "CameraVisibilityAdaptor", __cameraVisibilityAdaptor )
+for renderer, attributeName in (
+	( "Arnold", "ai:visibility:camera" ),
+	( "Cycles", "cycles:visibility:camera" ),
+	( "3Delight*", "dl:visibility.camera" ),
+	( "RenderMan*", "ri:visibility:camera" )
+) :
+	# Adaptors are registered to both `renderer` and "OpenGL" so these attributes are also
+	# available for use with the Viewer's OpenGL diagnostic shading modes.
+	GafferScene.SceneAlgo.registerRenderAdaptor( "{}CameraVisibilityAdaptor".format( renderer.rstrip( "*" ) ), functools.partial( __cameraVisibilityAdaptor, attributeName ), renderer = "{} OpenGL".format( renderer ) )

--- a/startup/GafferScene/matteAdaptor.py
+++ b/startup/GafferScene/matteAdaptor.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import functools
 import inspect
 
 import IECore
@@ -41,24 +42,9 @@ import IECore
 import Gaffer
 import GafferScene
 
-def __matteAdaptor() :
+def __matteAdaptor( attributeName ) :
 
 	processor = GafferScene.SceneProcessor()
-
-	processor["renderer"] = Gaffer.StringPlug()
-
-	processor["__attributeSpreadsheet"] = Gaffer.Spreadsheet()
-	processor["__attributeSpreadsheet"]["selector"].setInput( processor["renderer"] )
-	processor["__attributeSpreadsheet"]["rows"].addColumn( Gaffer.StringPlug( "name" ) )
-	for renderer, attributeName in (
-		( "Arnold", "ai:matte" ),
-		( "Cycles", "cycles:use_holdout" ),
-		( "3Delight*", "dl:matte" ),
-		( "RenderMan*", "ri:Ri:Matte" )
-	) :
-		row = processor["__attributeSpreadsheet"]["rows"].addRow()
-		row["name"].setValue( renderer )
-		row["cells"]["name"]["value"].setValue( attributeName )
 
 	processor["__optionQuery"] = GafferScene.OptionQuery()
 	processor["__optionQuery"]["scene"].setInput( processor["in"] )
@@ -88,8 +74,7 @@ def __matteAdaptor() :
 
 	processor["__matteInclusions"] = GafferScene.AttributeTweaks()
 	processor["__matteInclusions"]["in"].setInput( processor["in"] )
-	processor["__matteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__matteInclusions"]["tweaks"][0]["name"].setInput( processor["__attributeSpreadsheet"]["out"]["name"] )
+	processor["__matteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attributeName, Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__matteInclusions"]["filter"].setInput( processor["__matteInclusionsFilter"]["out"] )
 	# __matteInclusions is only required when `render:matteInclusions` exists and the root of the scene hasn't been set as matte
@@ -103,8 +88,7 @@ def __matteAdaptor() :
 
 	processor["__matteExclusions"] = GafferScene.AttributeTweaks()
 	processor["__matteExclusions"]["in"].setInput( processor["__matteInclusions"]["out"] )
-	processor["__matteExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__matteExclusions"]["tweaks"][0]["name"].setInput( processor["__attributeSpreadsheet"]["out"]["name"] )
+	processor["__matteExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attributeName, Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__matteExclusions"]["filter"].setInput( processor["__matteExclusionsFilter"]["out"] )
 	# __matteExclusions is only required when `render:matteExclusions` exists
@@ -115,8 +99,7 @@ def __matteAdaptor() :
 
 	processor["__rootMatteInclusions"] = GafferScene.AttributeTweaks()
 	processor["__rootMatteInclusions"]["in"].setInput( processor["__matteExclusions"]["out"] )
-	processor["__rootMatteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__rootMatteInclusions"]["tweaks"][0]["name"].setInput( processor["__attributeSpreadsheet"]["out"]["name"] )
+	processor["__rootMatteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attributeName, Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__rootMatteInclusions"]["filter"].setInput( processor["__rootPaths"]["out"] )
 	# All children of / are matte if `render:matteInclusions` matches the root of the scene.
@@ -128,4 +111,12 @@ def __matteAdaptor() :
 
 	return processor
 
-GafferScene.SceneAlgo.registerRenderAdaptor( "MatteAdaptor", __matteAdaptor )
+for renderer, attributeName in (
+	( "Arnold", "ai:matte" ),
+	( "Cycles", "cycles:use_holdout" ),
+	( "3Delight*", "dl:matte" ),
+	( "RenderMan*", "ri:Ri:Matte" )
+) :
+	# Adaptors are registered to both `renderer` and "OpenGL" so these attributes are also
+	# available for use with the Viewer's OpenGL diagnostic shading modes.
+	GafferScene.SceneAlgo.registerRenderAdaptor( "{}MatteAdaptor".format( renderer.rstrip( "*" ) ), functools.partial( __matteAdaptor, attributeName ), renderer = "{} OpenGL".format( renderer ) )


### PR DESCRIPTION
The previous change in https://github.com/GafferHQ/gaffer/commit/8f52d5f75e9bab965dfd599cccbdbefb8c8a71b8 introduced a regression in behaviour when attempting to visualise these attributes in OpenGL, such as when using the Viewer's renderer-specific "Matte" or "Camera Visibility" diagnostic shading modes, as these adaptors would no longer generate attributes for other renderers (such as "ai:matte", "ri:visibility:camera", etc) with the Viewer renderer set to "OpenGL".

We still want to keep the behaviour of outputting only the necessary attributes for the current renderer for renderers other than OpenGL, so rather than reverting, we instead refactor these adaptors into individual renderer-specific adaptors that are registered to both the target renderer and "OpenGL".