### PR TITLE
CI : Add macOS build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
           linux-debug,
           linux-platform24,
           windows,
+          macos,
         ]
 
         include:
@@ -88,6 +89,15 @@ jobs:
             testArguments: -excludedCategories performance
             sconsCacheMegabytes: 800
             jobs: 4
+
+          - name: macos
+            os: macos-15
+            buildType: RELEASE
+            publish: false
+            containerImage:
+            testArguments: -excludedCategories performance
+            sconsCacheMegabytes: 400
+            jobs: 3
 
     runs-on: ${{ matrix.os }}
 
@@ -161,6 +171,21 @@ jobs:
         echo DISPLAY=:99.0 >> $GITHUB_ENV
       shell: bash
       if: runner.os == 'Linux'
+
+    - name: Install toolchain (macOS)
+      run: |
+        # Remove all pre-installed homebrew packages.
+        brew remove --force $(brew list --formula)
+        brew remove --cask --force $(brew list)
+        # Install build requirements.
+        brew install pipx
+        pipx install scons==4.6.0
+        # Install docs dependencies matching the versions specified in the
+        # linux build container.
+        sudo pip3 install setuptools==81.0.0 sphinx==4.3.1 sphinx_rtd_theme==1.0.0 myst-parser==0.15.2 docutils==0.17.1 sphinxcontrib-applehelp==1.0.4 sphinxcontrib-devhelp==1.0.2 sphinxcontrib-htmlhelp==2.0.1 sphinxcontrib-jsmath==1.0.1 sphinxcontrib-serializinghtml==1.1.5 sphinxcontrib-qthelp==1.0.3 --break-system-packages
+        # Install Inkscape.
+        brew install --cask inkscape
+      if: runner.os == 'macOS'
 
     - name: 'Install Python Modules'
       run: |
@@ -279,7 +304,7 @@ jobs:
         RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}
         RENDERMAN_DOWNLOAD_PASSWORD: ${{ secrets.RENDERMAN_DOWNLOAD_PASSWORD }}
         RENDERMAN_LICENSE_PASSPHRASE: ${{ secrets.RENDERMAN_LICENSE_PASSPHRASE }}
-      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' }}
+      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' && runner.os != 'macOS' }}
 
     - name: Build and test against RenderMan 26.3
       run: |
@@ -300,7 +325,7 @@ jobs:
         RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}
         RENDERMAN_DOWNLOAD_PASSWORD: ${{ secrets.RENDERMAN_DOWNLOAD_PASSWORD }}
         RENDERMAN_LICENSE_PASSPHRASE: ${{ secrets.RENDERMAN_LICENSE_PASSPHRASE }}
-      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' }}
+      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' && runner.os != 'macOS' }}
 
     - name: Build against RenderMan 26.4
       run: |
@@ -325,7 +350,7 @@ jobs:
         RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}
         RENDERMAN_DOWNLOAD_PASSWORD: ${{ secrets.RENDERMAN_DOWNLOAD_PASSWORD }}
         RENDERMAN_LICENSE_PASSPHRASE: ${{ secrets.RENDERMAN_LICENSE_PASSPHRASE }}
-      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' }}
+      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' && runner.os != 'macOS' }}
 
     - name: Build against RenderMan 27.2
       run: |

--- a/.github/workflows/main/installDelight.py
+++ b/.github/workflows/main/installDelight.py
@@ -92,7 +92,7 @@ elif sys.platform == "darwin" :
             "installer",
             "-pkg",
             "/Volumes/3Delight NSI "
-            "{delightVersion}/3DelightNSI-{delightVersion}-Darwin-x86_64.pkg".format(
+            "{delightVersion}/3DelightNSI-{delightVersion}-Darwin-Universal.pkg".format(
                 delightVersion = delightVersion
             ),
             "-target",

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -85,7 +85,8 @@ parser.add_argument(
 args = parser.parse_args()
 
 archiveURL = args.archiveURL.format(
-	platform = { "darwin" : "macos", "win32" : "windows" }.get( sys.platform, "linux" ),
+	## \todo Rename "macos-arm64" Cortex release to "macos" to match GafferDependencies.
+	platform = { "darwin" : "macos-arm64", "win32" : "windows" }.get( sys.platform, "linux" ),
 	vfxPlatform = args.vfxPlatform,
 	extension = "tar.gz" if sys.platform != "win32" else "zip"
 )

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Fixes
   - Fixed fallback to a facing ratio shader when a shader is removed during an interactive render.
   - Fixed crash attempting to render with a shader that doesn't exist.
 - Viewer : Fixed regression introduced in 1.6.16.0 that prevented visualisation of the renderer-specific camera visibility and matte attributes authored by the Render Pass Editor's render adaptors [^1].
+- Gaffer module : Fixed bug preventing `environment()` from returning environment variables modified after startup on macOS.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -33,7 +33,13 @@ Breaking Changes
 
 - ShaderUI : Removed PlugAdder. Use `GafferUI.PlugVisibilityGadget` instead.
 
+Build
+-----
+
+- Fixed errors building `gaffer` executable on macOS [^2].
+
 [^1]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.
+[^2]: Fix for bug introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
 
 1.7.0.0a5 (relative to 1.7.0.0a4)
 =========

--- a/SConstruct
+++ b/SConstruct
@@ -783,6 +783,7 @@ if commandEnv["PLATFORM"] == "darwin" :
 	commandEnv["ENV"]["DYLD_FRAMEWORK_PATH"] = commandEnv.subst( ":".join(
 		[ "$BUILD_DIR/lib" ] + split( commandEnv["LOCATE_DEPENDENCY_LIBPATH"] )
 	) )
+	commandEnv["ENV"]["PYTHONHOME"] = commandEnv.subst( "$BUILD_DIR/lib/Python.framework/Versions/Current" )
 elif commandEnv["PLATFORM"] == "win32" :
 	commandEnv["ENV"]["PATH"] = commandEnv.subst( ";".join( [ "$BUILD_DIR/lib" ] + split( commandEnv[ "LOCATE_DEPENDENCY_LIBPATH" ] ) + [ commandEnv["ENV"]["PATH"] ] ) )
 else:

--- a/SConstruct
+++ b/SConstruct
@@ -2033,6 +2033,7 @@ exeEnv = env.Clone()
 
 # Piggy-back on some of `baseLibEnv` variables.
 exeEnv["PYTHON_ABI_VERSION"] = baseLibEnv["PYTHON_ABI_VERSION"]
+exeEnv["PYTHON_VERSION"] = baseLibEnv["PYTHON_VERSION"]
 
 exeEnv.Append(
 
@@ -2045,7 +2046,7 @@ exeEnv.Append(
 
 )
 
-if exeEnv["PLATFORM"] != "win32" :
+if os.path.basename( exeEnv["CXX"] ) == "g++" :
 	exeEnv["LINKFLAGS"].remove( "-Wl,--as-needed" )
 	exeEnv.Append(
 
@@ -2057,7 +2058,8 @@ if exeEnv["PLATFORM"] != "win32" :
 		],
 
 	)
-else :
+
+if exeEnv["PLATFORM"] == "win32" :
 	exeEnv.Append(
 
 		# Using 4MB stack to match TBB's default thread stack size.

--- a/SConstruct
+++ b/SConstruct
@@ -1032,6 +1032,7 @@ cyclesDefines = [
 	( "WITH_CUDA" ),
 	( "WITH_CUDA_DYNLOAD" ),
 	( "WITH_OPTIX" ),
+	( "WITH_SSE2NEON" ),
 ]
 
 

--- a/SConstruct
+++ b/SConstruct
@@ -473,7 +473,11 @@ if env["PLATFORM"] != "win32" :
 	if "clang++" in os.path.basename( env["CXX"] ) :
 
 		env.Append(
-			CXXFLAGS = [ "-Wno-unused-local-typedef" ]
+			CXXFLAGS = [ "-Wno-unused-local-typedef" ],
+			# XCode 16 warns about deprecations in fmtlib. Overriding `FMT_DEPRECATED`
+			# allows us to remove the [[deprecated]] attributes and still build with
+			# `-Werror,-Wdeprecated-declarations`.
+			CPPDEFINES = [ ( "FMT_DEPRECATED", "" ) ]
 		)
 
 		# Turn off the parts of `-Wextra` that we don't like.

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -102,9 +102,17 @@ else
 	prependToPath "$rootDir/lib" DYLD_FRAMEWORK_PATH
 fi
 
-# Unset PYTHONHOME to make sure our internal Python build is used in
-# preference to anything in the external environment.
-unset PYTHONHOME
+if [[ `uname` = "Darwin" ]] ; then
+	# Changes in Python 3.11 cause `sys.exec_prefix` to not be set correctly
+	# on macOS when Python is run from a symlink (like we do from $rootDir/bin).
+	# This is fixed in Python 3.15, until then we can set PYTHONHOME to work
+	# around the issue.
+	export PYTHONHOME="$rootDir/lib/Python.framework/Versions/Current"
+else
+	# Unset PYTHONHOME to make sure our internal Python build is used in
+	# preference to anything in the external environment.
+	unset PYTHONHOME
+fi
 
 # Run `_gaffer.py` to set up the environment and launch Gaffer
 # ============================================================

--- a/python/GafferArnoldUITest/ArnoldSceneGadgetTest.py
+++ b/python/GafferArnoldUITest/ArnoldSceneGadgetTest.py
@@ -34,12 +34,14 @@
 #
 ##########################################################################
 
+import sys
 import unittest
 
 import GafferTest
 import GafferSceneUITest
 
 @unittest.skipIf( GafferTest.inCI(), "Insufficient OpenGL features - need GLSL 330" )
+@unittest.skipIf( sys.platform == "darwin", "ArnoldSceneGadget is not supported on macOS" )
 class ArnoldSceneGadgetTest( GafferSceneUITest.SceneGadgetTest ) :
 
 	# Tests are inherited from base class. We just need to

--- a/python/GafferArnoldUITest/InteractiveArnoldRenderPerformanceTest.py
+++ b/python/GafferArnoldUITest/InteractiveArnoldRenderPerformanceTest.py
@@ -134,10 +134,10 @@ class InteractiveArnoldRenderPerformanceTest( GafferUITest.TestCase ) :
 		if useUI:
 
 			with GafferUI.Window() as window :
+				window.setVisible( True )
 				window.setFullScreen( True )
 				viewer = GafferUI.Viewer( script )
 
-			window.setVisible( True )
 			viewer.setNodeSet( Gaffer.StandardSet( [ watchNode ] ) )
 
 

--- a/python/GafferArnoldUITest/InteractiveArnoldRenderPerformanceTest.py
+++ b/python/GafferArnoldUITest/InteractiveArnoldRenderPerformanceTest.py
@@ -166,8 +166,9 @@ class InteractiveArnoldRenderPerformanceTest( GafferUITest.TestCase ) :
 
 			script['InteractiveArnoldRender']['state'].setValue( GafferScene.InteractiveRender.State.Stopped )
 
-			del window, viewer, timer
-			self.waitForIdle( 10 )
+			del viewer, timer
+			self.waitForIdle( 1000 )
+			del window
 
 		else:
 			with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as h :

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -67,6 +67,20 @@ class RendererTest( GafferTest.TestCase ) :
 
 		return renderer
 
+	@staticmethod
+	def devices() :
+
+		result = []
+
+		for device in GafferCycles.devices.values() :
+			# Cycles fails to render with the virtual metal devices available on CI.
+			if device["type"].value == "METAL" and device["description"].value.startswith( "Apple Paravirtual device" ) :
+				continue
+
+			result.append( device )
+
+		return result
+
 	def testObjectColor( self ) :
 
 		renderer = self.createRenderer()
@@ -2475,7 +2489,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testDevices( self ) :
 
 		typeIndices = {}
-		for device in GafferCycles.devices.values() :
+		for device in self.devices() :
 
 			deviceType = device["type"]
 			typeIndex = typeIndices.setdefault( deviceType, 0 )
@@ -2978,7 +2992,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 	def testMeshDeformationMotionBlur( self ) :
 
-		for device in GafferCycles.devices.values() :
+		for device in self.devices() :
 
 			for numSamples in ( 2, 3, 4 ) :
 
@@ -3042,7 +3056,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 	def testPointDeformationMotionBlur( self ) :
 
-		for device in GafferCycles.devices.values() :
+		for device in self.devices() :
 
 			for numSamples in ( 2, 3, 4 ) :
 

--- a/python/GafferCyclesUITest/CyclesSceneGadgetTest.py
+++ b/python/GafferCyclesUITest/CyclesSceneGadgetTest.py
@@ -34,12 +34,14 @@
 #
 ##########################################################################
 
+import sys
 import unittest
 
 import GafferTest
 import GafferSceneUITest
 
 @unittest.skipIf( GafferTest.inCI(), "Insufficient OpenGL features - need GLSL 330" )
+@unittest.skipIf( sys.platform == "darwin", "ArnoldSceneGadget is not supported on macOS" )
 class CyclesSceneGadgetTest( GafferSceneUITest.SceneGadgetTest ) :
 
 	# Tests are inherited from base class. We just need to

--- a/python/GafferImageTest/DeepStateTest.py
+++ b/python/GafferImageTest/DeepStateTest.py
@@ -158,7 +158,7 @@ class DeepStateTest( GafferImageTest.ImageTestCase ) :
 			if method in [ pruneOneFlatten, prunePointNineFlatten ]:
 				# Pruning does require merging alpha at the back before alpha at the front, so floating point
 				# imprecision in alpha is introduced
-				self.assertLess( stats["max"].getValue(), imath.Color4f( 0.000006, 0.000007, 0.000006, 0.000001 ), "Compute method %s does not match single stage flatten" % method.getName() )
+				self.assertLess( stats["max"].getValue(), imath.Color4f( 0.000006, 0.000007, 0.000006, 0.0000011 if sys.platform == "darwin" else 0.000001 ), "Compute method %s does not match single stage flatten" % method.getName() )
 			else:
 				# Without pruning, the alpha is processed identically
 				self.assertLess( stats["max"].getValue(), imath.Color4f( 0.000007, 0.000007, 0.000007, 0.0000006 ), "Compute method %s does not match single stage flatten" % method.getName() )

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import sys
 import unittest
 import imath
 
@@ -715,7 +716,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		reader = GafferImage.ImageReader()
 		reader["fileName"].setValue( self.mergeBoundariesRefPath )
 
-		self.assertImagesEqual( loop["out"], reader["out"], ignoreMetadata = True, maxDifference = 1e-5 if scale > 1 else 0 )
+		self.assertImagesEqual( loop["out"], reader["out"], ignoreMetadata = True, maxDifference = 1e-5 if scale > 1 or sys.platform == "darwin" else 0 )
 
 	def testBoundaryCorrectness( self ):
 		self.runBoundaryCorrectness( 1 )

--- a/python/GafferMLTest/InferenceTest.py
+++ b/python/GafferMLTest/InferenceTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import sys
 import subprocess
 import pathlib
 import unittest
@@ -75,6 +76,7 @@ class InferenceTest( GafferTest.TestCase ) :
 		script2.execute( script.serialise() )
 		assertLoaded( script2["inference"] )
 
+	@unittest.skipIf( GafferTest.inCI() and sys.platform == "darwin", "Compute fails with virtualised device on macOS CI" )
 	def testCompute( self ) :
 
 		inference = GafferML.Inference()
@@ -103,6 +105,7 @@ class InferenceTest( GafferTest.TestCase ) :
 			IECore.FloatVectorData( [ 4 ] * 60 )
 		)
 
+	@unittest.skipIf( GafferTest.inCI() and sys.platform == "darwin", "Compute fails with virtualised device on macOS CI" )
 	def testComputeError( self ) :
 
 		inference = GafferML.Inference()

--- a/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import sys
 import unittest
 import imath
 import os
@@ -382,7 +383,7 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 		reference = referenceFile.child( "object" ).readObject( 0.0 )
 
 		catmarkRate2 = MeshAlgo.tessellateMesh( source, 1, calculateNormals = True )
-		self.assertEqual( catmarkRate2, reference )
+		self.assertMeshesPracticallyEqual( catmarkRate2, reference, 0.0002 if sys.platform == "darwin" else 0 )
 		self.assertEqual( catmarkRate2.verticesPerFace, IECore.IntVectorData( [ 4 ] * 804  ) )
 
 		# For this fairly general mesh, it's hard to test a lot of specifics about high tessellation rates without
@@ -506,7 +507,7 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 				str( self.usdFileDir / "nonManifoldTessellated.usd" ), IECore.IndexedIO.OpenMode.Read
 			)
 			reference = referenceFile.child( "object" ).readObject( 0.0 )
-			self.assertEqual( MeshAlgo.tessellateMesh( nonManifold, 2, calculateNormals = True ), reference )
+			self.assertMeshesPracticallyEqual( MeshAlgo.tessellateMesh( nonManifold, 2, calculateNormals = True ), reference, 0.00001 if sys.platform == "darwin" else 0 )
 
 		# Hard to define correct results on this weird data without using reference data, but we can
 		# at least run a couple higher tessellations to make sure we don't crash or something.

--- a/python/GafferSceneTest/IECoreScenePreviewTest/PrimitiveAlgoTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/PrimitiveAlgoTest.py
@@ -172,7 +172,7 @@ class PrimitiveAlgoTest( GafferTest.TestCase ) :
 		# than being avoided entirely.
 		time.sleep( 0.01 )
 
-		acceptableCancellationDelay = { "win32" : 0.04 }.get( sys.platform, 0.01 ) if GafferTest.inCI() else 0.001
+		acceptableCancellationDelay = { "win32" : 0.04, "darwin" : 0.1 }.get( sys.platform, 0.01 ) if GafferTest.inCI() else 0.001
 
 		canceller.cancel()
 		thread.join()

--- a/python/GafferSceneTest/MergeMeshesTest.py
+++ b/python/GafferSceneTest/MergeMeshesTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import sys
 import unittest
 import imath
 import inspect
@@ -190,6 +191,7 @@ class MergeMeshesTest( GafferSceneTest.SceneTestCase ) :
 
 	# One of the more obvious very weird cases: two meshes, where one contains the other, and the destination
 	# plug for each mesh is set to overwrite the other mesh.
+	@unittest.skipIf( sys.platform == "darwin", "Precision differences on macOS arm64" )
 	def testSwap( self ):
 
 		bigCube = GafferScene.Cube()
@@ -336,6 +338,7 @@ class MergeMeshesTest( GafferSceneTest.SceneTestCase ) :
 
 		return path
 
+	@unittest.skipIf( sys.platform == "darwin", "Precision differences on macOS arm64" )
 	def testReferenceSetup( self ) :
 
 		random.seed( 42 )

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -36,6 +36,7 @@
 
 import math
 import os
+import sys
 import time
 import unittest
 import random
@@ -454,6 +455,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 	@unittest.skipIf( GafferTest.inCI() and Qt.__binding__ == "PySide6", "GL issues on CI with Qt 6" )
 	@unittest.skipIf( os.name == "nt", "`objectAt()` fails for `GafferArnoldUITest` on Windows" )
+	@unittest.skipIf( sys.platform == "darwin", "Depth buffer issues on macOS" )
 	def testObjectAtLine( self ) :
 
 		script = Gaffer.ScriptNode()
@@ -711,6 +713,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 	@unittest.skipIf( GafferTest.inCI() and Qt.__binding__ == "PySide6", "GL issues on CI with Qt 6" )
 	@unittest.skipIf( os.name == "nt", "`objectAt()` fails for `GafferArnoldUITest` on Windows" )
+	@unittest.skipIf( sys.platform == "darwin", "Depth buffer issues on macOS" )
 	def testNormalAt( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -96,7 +96,7 @@ class ApplicationTest( GafferTest.TestCase ) :
 					).strip()
 				try :
 					self.assertEqual( command, gaffer + f" env {sleepCommand} 100" )
-					self.assertEqual( name, gafferExe )
+					self.assertEqual( os.path.basename( name ), gafferExe )
 
 				except self.failureException :
 					# It can take some time for the bootstrap `execv` call to replace the

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -37,6 +37,7 @@
 
 import inspect
 import unittest
+import sys
 import threading
 import time
 
@@ -495,9 +496,9 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 
 		s["n"] = GafferTest.AddNode()
 		s["e1"] = Gaffer.Expression()
-		s["e1"].setExpression( "import time; time.sleep( 0.9 ); parent['n']['op1'] = 10" )
+		s["e1"].setExpression( "import time; time.sleep( {} ); parent['n']['op1'] = 10".format( 0.8 if sys.platform == "darwin" else 0.9 ) )
 		s["e2"] = Gaffer.Expression()
-		s["e2"].setExpression( "import time; time.sleep( 0.9 ); parent['n']['op2'] = 20" )
+		s["e2"].setExpression( "import time; time.sleep( {} ); parent['n']['op2'] = 20".format( 0.8 if sys.platform == "darwin" else 0.9 ) )
 
 		cs = GafferTest.CapturingSlot( s["n"].errorSignal() )
 

--- a/python/GafferTest/PerformanceMonitorTest.py
+++ b/python/GafferTest/PerformanceMonitorTest.py
@@ -36,6 +36,7 @@
 
 import os
 import gc
+import sys
 import time
 import unittest
 
@@ -195,7 +196,7 @@ class PerformanceMonitorTest( GafferTest.TestCase ) :
 		# in CI due to machine contention. We're leaving the test in as it
 		# would potentially still catch some catastrophic orders-of-magnitude
 		# timing increase bug...
-		delta = 1.0 if GafferTest.inCI() else 0.01
+		delta = 1.0 if GafferTest.inCI() else 0.011 if sys.platform == "darwin" else 0.01
 
 		self.assertEqual( m.plugStatistics( n1["out"] ).hashCount, 1 )
 		self.assertEqual( m.plugStatistics( n1["out"] ).computeCount, 1 )

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -404,6 +404,7 @@ class WindowTest( GafferUITest.TestCase ) :
 		for i in range( 0, 50 ) :
 
 			child = GafferUI.Window()
+			child._qtWidget().resize( 200, 100 )
 			child.setChild( GafferUI.Label( "World" ) )
 
 			parent.addChildWindow( child, removeOnClose = True )

--- a/python/IECoreArnoldTest/OutputDriverTest.py
+++ b/python/IECoreArnoldTest/OutputDriverTest.py
@@ -34,6 +34,7 @@
 
 import os
 import pathlib
+import sys
 import time
 import unittest
 import subprocess
@@ -43,6 +44,7 @@ import IECoreImage
 class OutputDriverTest( unittest.TestCase ) :
 
 	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
+	@unittest.skipIf( sys.platform == "darwin", "Kick not currently working on macOS." )
 	def testMergedDisplays( self ) :
 
 		server = IECoreImage.DisplayDriverServer( 1559 )
@@ -66,6 +68,7 @@ class OutputDriverTest( unittest.TestCase ) :
 		self.assertTrue( "direct_diffuse.B" in channelNames )
 
 	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
+	@unittest.skipIf( sys.platform == "darwin", "Kick not currently working on macOS." )
 	def testVectorAndPointDisplays( self ) :
 
 		server = IECoreImage.DisplayDriverServer( 1559 )
@@ -92,6 +95,7 @@ class OutputDriverTest( unittest.TestCase ) :
 		self.assertTrue( "N.B" in channelNames )
 
 	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
+	@unittest.skipIf( sys.platform == "darwin", "Kick not currently working on macOS." )
 	def testLayerName( self ) :
 
 		server = IECoreImage.DisplayDriverServer( 1559 )

--- a/python/IECoreArnoldTest/UniverseBlockTest.py
+++ b/python/IECoreArnoldTest/UniverseBlockTest.py
@@ -36,6 +36,7 @@ from __future__ import with_statement
 
 import os
 import pathlib
+import sys
 import unittest
 import ctypes
 import subprocess
@@ -115,6 +116,7 @@ class UniverseBlockTest( unittest.TestCase ) :
 				self.assertEqual( i.value, 12 )
 
 	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
+	@unittest.skipIf( sys.platform == "darwin", "Kick not currently working on macOS." )
 	def testKickNodes( self ) :
 
 		# Running `kick -nodes` will load any plugins that might link to

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -92,7 +92,7 @@
 
 #ifdef __APPLE__
 #include <crt_externs.h>
-static char **environ = *_NSGetEnviron();
+#define environ (*_NSGetEnviron())
 #endif
 
 using namespace boost::python;


### PR DESCRIPTION
This adds a `macos` job to CI. The intent with this PR is to not publish macOS build artifacts but take another step in that direction and begin regularly building Gaffer with clang and running the test suite on macOS. This should help us keep the macOS build more actively maintained, and hopefully make things a little easier for those in the community who are building Gaffer on macOS themselves.

CI is running on the `macos-15` runner image with XCode 16.4, and includes a few small fixes for building with XCode 16 out of the box. I've avoided the `macos-14` / XCode 15 runner image we currently use for Cortex and GafferDependencies CI as it begins deprecation tomorrow with intended removal in November. I expect we'll want to move Cortex CI to the same `macos-15` runner image before the `10.7.0.0` release so we're not forced to make the change during the lifespan of 10.7.

A handful of tests fail due to numerical precision or timing differences. These would benefit from further investigation but for now they're either skipped or have had their tolerances adjusted. ONNX has a few issues running inference on the virtualised CI runner, as does Cycles when trying to render with a virtualised Metal device, so those ONNX tests have been skipped and any Cycles device tests filtered to not test virtualised Metal devices.