### PR TITLE
PlugCreationWidget : Fix typo

### DIFF
--- a/python/Gaffer/Application.py
+++ b/python/Gaffer/Application.py
@@ -190,7 +190,7 @@ class Application( IECore.Parameterised ) :
 				IECore.formatParameterHelp( p, formatter )
 			formatter.unindent()
 
-IECore.registerRunTimeTyped( Application, typeName = "Gaffer::Application" )
+IECore.registerRunTimeTyped( Application, "Gaffer::Application" )
 
 # Various parts of the UI try to store their state as attributes on
 # the root object, and therefore require it's identity in python to

--- a/python/Gaffer/DictPath.py
+++ b/python/Gaffer/DictPath.py
@@ -109,4 +109,4 @@ class DictPath( Gaffer.Path ) :
 
 		return e
 
-IECore.registerRunTimeTyped( DictPath, typeName = "Gaffer::DictPath" )
+IECore.registerRunTimeTyped( DictPath, "Gaffer::DictPath" )

--- a/python/Gaffer/ExtensionAlgo.py
+++ b/python/Gaffer/ExtensionAlgo.py
@@ -179,7 +179,7 @@ class {name}( Gaffer.DependencyNode ) :
 				for plug in Gaffer.Plug.RecursiveRange( plug ) :
 					plug.setFlags( Gaffer.Plug.Flags.Dynamic, False )
 
-IECore.registerRunTimeTyped( {name}, typeName = "{moduleName}::{name}" )
+IECore.registerRunTimeTyped( {name}, "{moduleName}::{name}" )
 """
 
 def __nodeDefinition( box, moduleName ) :

--- a/python/Gaffer/FileNamePathFilter.py
+++ b/python/Gaffer/FileNamePathFilter.py
@@ -84,4 +84,4 @@ class FileNamePathFilter( Gaffer.PathFilter ) :
 
 		return result
 
-IECore.registerRunTimeTyped( FileNamePathFilter, typeName = "Gaffer::FileNamePathFilter" )
+IECore.registerRunTimeTyped( FileNamePathFilter, "Gaffer::FileNamePathFilter" )

--- a/python/Gaffer/GraphComponentPath.py
+++ b/python/Gaffer/GraphComponentPath.py
@@ -117,4 +117,4 @@ class GraphComponentPath( Gaffer.Path ) :
 
 		return e
 
-IECore.registerRunTimeTyped( GraphComponentPath, typeName = "Gaffer::GraphComponentPath" )
+IECore.registerRunTimeTyped( GraphComponentPath, "Gaffer::GraphComponentPath" )

--- a/python/Gaffer/InfoPathFilter.py
+++ b/python/Gaffer/InfoPathFilter.py
@@ -81,4 +81,4 @@ class InfoPathFilter( Gaffer.PathFilter ) :
 
 		return result
 
-IECore.registerRunTimeTyped( InfoPathFilter, typeName = "Gaffer::InfoPathFilter" )
+IECore.registerRunTimeTyped( InfoPathFilter, "Gaffer::InfoPathFilter" )

--- a/python/Gaffer/SequencePath.py
+++ b/python/Gaffer/SequencePath.py
@@ -174,4 +174,4 @@ class SequencePath( Gaffer.Path ) :
 
 		return False
 
-IECore.registerRunTimeTyped( SequencePath, typeName = "Gaffer::SequencePath" )
+IECore.registerRunTimeTyped( SequencePath, "Gaffer::SequencePath" )

--- a/python/GafferArnold/ArnoldShaderBall.py
+++ b/python/GafferArnold/ArnoldShaderBall.py
@@ -75,4 +75,4 @@ class ArnoldShaderBall( GafferScene.ShaderBall ) :
 
 		self._outPlug().setInput( self["__arnoldOptions"]["out"] )
 
-IECore.registerRunTimeTyped( ArnoldShaderBall, typeName = "GafferArnold::ArnoldShaderBall" )
+IECore.registerRunTimeTyped( ArnoldShaderBall, "GafferArnold::ArnoldShaderBall" )

--- a/python/GafferArnold/ArnoldTextureBake.py
+++ b/python/GafferArnold/ArnoldTextureBake.py
@@ -622,4 +622,4 @@ class ArnoldTextureBake( GafferDispatch.TaskNode ) :
 
 
 
-IECore.registerRunTimeTyped( ArnoldTextureBake, typeName = "GafferArnold::ArnoldTextureBake" )
+IECore.registerRunTimeTyped( ArnoldTextureBake, "GafferArnold::ArnoldTextureBake" )

--- a/python/GafferCycles/CyclesShaderBall.py
+++ b/python/GafferCycles/CyclesShaderBall.py
@@ -93,4 +93,4 @@ class CyclesShaderBall( GafferScene.ShaderBall ) :
 
 		self._outPlug().setInput( self["__cyclesOptions"]["out"] )
 
-IECore.registerRunTimeTyped( CyclesShaderBall, typeName = "GafferCycles::CyclesShaderBall" )
+IECore.registerRunTimeTyped( CyclesShaderBall, "GafferCycles::CyclesShaderBall" )

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -518,7 +518,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 		self.__jobPool.addJob( job )
 		job._execute()
 
-IECore.registerRunTimeTyped( LocalDispatcher, typeName = "GafferDispatch::LocalDispatcher" )
+IECore.registerRunTimeTyped( LocalDispatcher, "GafferDispatch::LocalDispatcher" )
 GafferDispatch.Dispatcher.registerDispatcher( "Local", LocalDispatcher )
 
 ## \todo Should this be a shared component implemented in C++ in `Messages.h`?

--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -268,6 +268,6 @@ def __codeObjectCacheGetter( expression ) :
 
 _codeObjectCache = IECore.LRUCache( __codeObjectCacheGetter, 10000 )
 
-IECore.registerRunTimeTyped( PythonCommand, typeName = "GafferDispatch::PythonCommand" )
+IECore.registerRunTimeTyped( PythonCommand, "GafferDispatch::PythonCommand" )
 
 Gaffer.Metadata.registerValue( PythonCommand, "dispatcher:allowIsolation", True )

--- a/python/GafferDispatch/SystemCommand.py
+++ b/python/GafferDispatch/SystemCommand.py
@@ -90,6 +90,6 @@ class SystemCommand( GafferDispatch.TaskNode ) :
 
 		subprocess.check_call( command, shell = useShell, env = env )
 
-IECore.registerRunTimeTyped( SystemCommand, typeName = "GafferDispatch::SystemCommand" )
+IECore.registerRunTimeTyped( SystemCommand, "GafferDispatch::SystemCommand" )
 
 Gaffer.Metadata.registerValue( SystemCommand, "dispatcher:allowIsolation", True )

--- a/python/GafferDispatch/TaskContextProcessor.py
+++ b/python/GafferDispatch/TaskContextProcessor.py
@@ -78,4 +78,4 @@ class TaskContextProcessor( GafferDispatch.TaskNode ) :
 
 		raise NotImplementedError
 
-IECore.registerRunTimeTyped( TaskContextProcessor, typeName = "GafferDispatch::TaskContextProcessor" )
+IECore.registerRunTimeTyped( TaskContextProcessor, "GafferDispatch::TaskContextProcessor" )

--- a/python/GafferDispatch/TaskContextVariables.py
+++ b/python/GafferDispatch/TaskContextVariables.py
@@ -60,4 +60,4 @@ class TaskContextVariables( GafferDispatch.TaskContextProcessor ) :
 
 		return [ context ]
 
-IECore.registerRunTimeTyped( TaskContextVariables, typeName = "GafferDispatch::TaskContextVariables" )
+IECore.registerRunTimeTyped( TaskContextVariables, "GafferDispatch::TaskContextVariables" )

--- a/python/GafferDispatch/TaskSwitch.py
+++ b/python/GafferDispatch/TaskSwitch.py
@@ -69,4 +69,4 @@ class TaskSwitch( GafferDispatch.TaskNode ) :
 		# node is executed.
 		pass
 
-IECore.registerRunTimeTyped( TaskSwitch, typeName = "GafferDispatch::TaskSwitch" )
+IECore.registerRunTimeTyped( TaskSwitch, "GafferDispatch::TaskSwitch" )

--- a/python/GafferDispatch/Wedge.py
+++ b/python/GafferDispatch/Wedge.py
@@ -164,4 +164,4 @@ class Wedge( GafferDispatch.TaskContextProcessor ) :
 
 		return contexts
 
-IECore.registerRunTimeTyped( Wedge, typeName = "GafferDispatch::Wedge" )
+IECore.registerRunTimeTyped( Wedge, "GafferDispatch::Wedge" )

--- a/python/GafferDispatchTest/ErroringTaskNode.py
+++ b/python/GafferDispatchTest/ErroringTaskNode.py
@@ -68,4 +68,4 @@ class ErroringTaskNode( GafferDispatch.TaskNode ) :
 
 		raise RuntimeError( "Error in postTasks" )
 
-IECore.registerRunTimeTyped( ErroringTaskNode, typeName = "GafferDispatchTest::ErroringTaskNode" )
+IECore.registerRunTimeTyped( ErroringTaskNode, "GafferDispatchTest::ErroringTaskNode" )

--- a/python/GafferDispatchTest/LoggingTaskNode.py
+++ b/python/GafferDispatchTest/LoggingTaskNode.py
@@ -99,4 +99,4 @@ class LoggingTaskNode( GafferDispatch.TaskNode ) :
 
 		return self["requiresSequenceExecution"].getValue()
 
-IECore.registerRunTimeTyped( LoggingTaskNode, typeName = "GafferDispatchTest::LoggingTaskNode" )
+IECore.registerRunTimeTyped( LoggingTaskNode, "GafferDispatchTest::LoggingTaskNode" )

--- a/python/GafferDispatchTest/TaskNodeTest.py
+++ b/python/GafferDispatchTest/TaskNodeTest.py
@@ -427,7 +427,7 @@ class TaskNodeTest( GafferTest.TestCase ) :
 				else :
 					return GafferDispatch.SystemCommand.affectsTask( self, input )
 
-		IECore.registerRunTimeTyped( MySystemCommand, typeName = "GafferDispatchTest::MySystemCommand" )
+		IECore.registerRunTimeTyped( MySystemCommand, "GafferDispatchTest::MySystemCommand" )
 
 		n = MySystemCommand()
 		cs = GafferTest.CapturingSlot( n.plugDirtiedSignal() )

--- a/python/GafferDispatchTest/TextWriter.py
+++ b/python/GafferDispatchTest/TextWriter.py
@@ -113,6 +113,6 @@ class TextWriter( GafferDispatch.TaskNode ) :
 
 		return text
 
-IECore.registerRunTimeTyped( TextWriter, typeName = "GafferDispatchTest::TextWriter" )
+IECore.registerRunTimeTyped( TextWriter, "GafferDispatchTest::TextWriter" )
 
 Gaffer.Metadata.registerValue( TextWriter, "dispatcher:allowIsolation", True )

--- a/python/GafferFlamenco/FlamencoDispatcher.py
+++ b/python/GafferFlamenco/FlamencoDispatcher.py
@@ -220,6 +220,6 @@ class FlamencoDispatcher( GafferDispatch.Dispatcher ) :
 		else :
 			return None
 
-IECore.registerRunTimeTyped( FlamencoDispatcher, typeName = "GafferFlamenco::FlamencoDispatcher" )
+IECore.registerRunTimeTyped( FlamencoDispatcher, "GafferFlamenco::FlamencoDispatcher" )
 
 GafferDispatch.Dispatcher.registerDispatcher( "Flamenco", FlamencoDispatcher, FlamencoDispatcher._setupPlugs )

--- a/python/GafferImage/BleedFill.py
+++ b/python/GafferImage/BleedFill.py
@@ -193,4 +193,4 @@ class BleedFill( GafferImage.ImageProcessor ) :
 		self['out'].setFlags(Gaffer.Plug.Flags.Serialisable, False)
 		self["out"].setInput( self["__disableSwitch"]["out"] )
 
-IECore.registerRunTimeTyped( BleedFill, typeName = "GafferImage::BleedFill" )
+IECore.registerRunTimeTyped( BleedFill, "GafferImage::BleedFill" )

--- a/python/GafferImage/DeepTidy.py
+++ b/python/GafferImage/DeepTidy.py
@@ -56,4 +56,4 @@ class DeepTidy( GafferImage.ImageProcessor ) :
 		Gaffer.PlugAlgo.promote( self['__deepState']['pruneOccluded'] )
 		Gaffer.PlugAlgo.promote( self['__deepState']['occludedThreshold'] )
 
-IECore.registerRunTimeTyped( DeepTidy, typeName = "GafferImage::DeepTidy" )
+IECore.registerRunTimeTyped( DeepTidy, "GafferImage::DeepTidy" )

--- a/python/GafferImageUI/ImageInspector.py
+++ b/python/GafferImageUI/ImageInspector.py
@@ -80,7 +80,7 @@ class ImageInspector( GafferUI.NodeSetEditor ) :
 			self["__sampleStats"]["in"].setInput( self["__sampleCounts"]["out"] )
 			self["__sampleStats"]["areaSource"].setValue( GafferImage.ImageStats.AreaSource.DataWindow )
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferImageUI::ImageInspector::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferImageUI::ImageInspector::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferRenderMan/_InteractiveDenoiserAdaptor.py
+++ b/python/GafferRenderMan/_InteractiveDenoiserAdaptor.py
@@ -147,6 +147,6 @@ class _InteractiveDenoiserAdaptor( GafferScene.SceneProcessor ) :
 
 		return outputGlobals
 
-IECore.registerRunTimeTyped( _InteractiveDenoiserAdaptor, typeName = "GafferRenderMan::_InteractiveDenoiserAdaptor" )
+IECore.registerRunTimeTyped( _InteractiveDenoiserAdaptor, "GafferRenderMan::_InteractiveDenoiserAdaptor" )
 
 GafferScene.SceneAlgo.registerRenderAdaptor( "InteractiveRenderManDenoiserAdaptor", _InteractiveDenoiserAdaptor, "InteractiveRender", "RenderMan*" )

--- a/python/GafferRenderMan/_StylizedAOVAdaptor.py
+++ b/python/GafferRenderMan/_StylizedAOVAdaptor.py
@@ -139,6 +139,6 @@ class _StylizedAOVAdaptor( GafferScene.SceneProcessor ) :
 
 		return outputGlobals
 
-IECore.registerRunTimeTyped( _StylizedAOVAdaptor, typeName = "GafferRenderMan::_StylizedAOVAdaptor" )
+IECore.registerRunTimeTyped( _StylizedAOVAdaptor, "GafferRenderMan::_StylizedAOVAdaptor" )
 
 GafferScene.SceneAlgo.registerRenderAdaptor( "RenderManStylizedAOVAdaptor", _StylizedAOVAdaptor, "*Render", "RenderMan" )

--- a/python/GafferScene/CatalogueSelect.py
+++ b/python/GafferScene/CatalogueSelect.py
@@ -58,4 +58,4 @@ class CatalogueSelect( GafferImage.ImageProcessor ) :
 		self['out'].setFlags(Gaffer.Plug.Flags.Serialisable, False)
 
 
-IECore.registerRunTimeTyped( CatalogueSelect, typeName = "GafferScene::CatalogueSelect" )
+IECore.registerRunTimeTyped( CatalogueSelect, "GafferScene::CatalogueSelect" )

--- a/python/GafferScene/RenderPassTypeAdaptor.py
+++ b/python/GafferScene/RenderPassTypeAdaptor.py
@@ -152,4 +152,4 @@ class RenderPassTypeAdaptor( GafferScene.SceneProcessor ) :
 
 		return type
 
-IECore.registerRunTimeTyped( RenderPassTypeAdaptor, typeName = "GafferScene::RenderPassTypeAdaptor" )
+IECore.registerRunTimeTyped( RenderPassTypeAdaptor, "GafferScene::RenderPassTypeAdaptor" )

--- a/python/GafferScene/RenderPassWedge.py
+++ b/python/GafferScene/RenderPassWedge.py
@@ -95,4 +95,4 @@ class RenderPassWedge( GafferDispatch.TaskContextProcessor ) :
 
 		return contexts
 
-IECore.registerRunTimeTyped( RenderPassWedge, typeName = "GafferScene::RenderPassWedge" )
+IECore.registerRunTimeTyped( RenderPassWedge, "GafferScene::RenderPassWedge" )

--- a/python/GafferScene/ShaderBall.py
+++ b/python/GafferScene/ShaderBall.py
@@ -99,4 +99,4 @@ class ShaderBall( GafferScene.SceneNode ) :
 
 		return self["__enabler"]["in"][1]
 
-IECore.registerRunTimeTyped( ShaderBall, typeName = "GafferScene::ShaderBall" )
+IECore.registerRunTimeTyped( ShaderBall, "GafferScene::ShaderBall" )

--- a/python/GafferSceneUI/AttributeEditor.py
+++ b/python/GafferSceneUI/AttributeEditor.py
@@ -61,7 +61,7 @@ class AttributeEditor( GafferSceneUI.SceneEditor ) :
 			self["section"] = Gaffer.StringPlug( defaultValue = "Attributes" )
 			self["editScope"] = Gaffer.Plug()
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::AttributeEditor::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::AttributeEditor::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -61,7 +61,7 @@ class HierarchyView( GafferSceneUI.SceneEditor ) :
 
 			self["editScope"] = Gaffer.Plug()
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::HierarchyView::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::HierarchyView::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -73,7 +73,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 			self["__filteredIn"] = GafferScene.ScenePlug()
 			self["__filteredIn"].setInput( self["__isolate"]["out"] )
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::LightEditor::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::LightEditor::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -135,7 +135,7 @@ class PrimitiveInspector( GafferSceneUI.SceneEditor ) :
 			GafferSceneUI.SceneEditor.Settings.__init__( self )
 			self["location"] = Gaffer.StringPlug()
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::PrimitiveInspector::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::PrimitiveInspector::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -86,7 +86,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 			self["__filteredIn"] = GafferScene.ScenePlug()
 			self["__filteredIn"].setInput( self["__filter"]["out"] )
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::RenderPassEditor::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::RenderPassEditor::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 
@@ -1180,7 +1180,7 @@ class _Filter( GafferScene.SceneProcessor ) :
 
 		self["out"].setInput( self["__keepEnabledPasses"]["out"] )
 
-IECore.registerRunTimeTyped( _Filter, typeName = "GafferSceneUI::RenderPassEditor::_Filter" )
+IECore.registerRunTimeTyped( _Filter, "GafferSceneUI::RenderPassEditor::_Filter" )
 
 ##########################################################################
 # Widgets
@@ -1402,7 +1402,7 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self["__adaptors"] = GafferSceneUI.RenderPassEditor._createRenderAdaptors()
 			self["__adaptors"]["in"].setInput( self["in"] )
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::RenderPassPlugValueWidget::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::RenderPassPlugValueWidget::Settings" )
 
 	__PassStatus = collections.namedtuple( "__PassStatus", [ "enabled", "adaptedEnabled" ] )
 

--- a/python/GafferSceneUI/SceneEditor.py
+++ b/python/GafferSceneUI/SceneEditor.py
@@ -81,7 +81,7 @@ class SceneEditor( GafferUI.NodeSetEditor ) :
 				Gaffer.PlugAlgo.promote( self["__hierarchyFilter"]["filter"] )
 				Gaffer.PlugAlgo.promote( self["__hierarchyFilter"]["setFilter"] )
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::SceneEditor::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::SceneEditor::Settings" )
 
 	def __init__( self, topLevelWidget, scriptNode, **kw ) :
 
@@ -317,7 +317,7 @@ class _HierarchyFilter( GafferScene.SceneProcessor ) :
 		else :
 			return filterSet or setFilterValue
 
-IECore.registerRunTimeTyped( _HierarchyFilter, typeName = "GafferSceneUI::SceneEditor::_HierarchyFilter" )
+IECore.registerRunTimeTyped( _HierarchyFilter, "GafferSceneUI::SceneEditor::_HierarchyFilter" )
 
 SceneEditor._HierarchyFilter = _HierarchyFilter
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -184,7 +184,7 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 
 			return [ self["compare"][n]["enabled"] for n in [ "scene", "renderPass" ] ]
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::SceneInspector::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::SceneInspector::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -58,7 +58,7 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 			self["hideEmptySets"] = Gaffer.BoolPlug()
 			self["hideEmptySelection"] = Gaffer.BoolPlug()
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::SetEditor::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferSceneUI::SetEditor::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferTest/AddNode.py
+++ b/python/GafferTest/AddNode.py
@@ -105,4 +105,4 @@ class AddNode( Gaffer.ComputeNode ) :
 
 		self.numComputeCalls += 1
 
-IECore.registerRunTimeTyped( AddNode, typeName = "GafferTest::AddNode" )
+IECore.registerRunTimeTyped( AddNode, "GafferTest::AddNode" )

--- a/python/GafferTest/ArrayPlugNode.py
+++ b/python/GafferTest/ArrayPlugNode.py
@@ -52,4 +52,4 @@ class ArrayPlugNode( Gaffer.Node ) :
 			)
 		)
 
-IECore.registerRunTimeTyped( ArrayPlugNode, typeName="GafferTest::ArrayPlugNode" )
+IECore.registerRunTimeTyped( ArrayPlugNode, "GafferTest::ArrayPlugNode" )

--- a/python/GafferTest/BadNode.py
+++ b/python/GafferTest/BadNode.py
@@ -87,4 +87,4 @@ class BadNode( Gaffer.ComputeNode ) :
 			pass
 
 
-IECore.registerRunTimeTyped( BadNode, typeName = "GafferTest::BadNode" )
+IECore.registerRunTimeTyped( BadNode, "GafferTest::BadNode" )

--- a/python/GafferTest/CachingTestNode.py
+++ b/python/GafferTest/CachingTestNode.py
@@ -72,4 +72,4 @@ class CachingTestNode( Gaffer.ComputeNode ) :
 
 		self["out"].setValue( IECore.StringData( self["in"].getValue() ) )
 
-IECore.registerRunTimeTyped( CachingTestNode, typeName = "GafferTest::CachingTestNode" )
+IECore.registerRunTimeTyped( CachingTestNode, "GafferTest::CachingTestNode" )

--- a/python/GafferTest/CompoundNumericNode.py
+++ b/python/GafferTest/CompoundNumericNode.py
@@ -48,4 +48,4 @@ class CompoundNumericNode( Gaffer.Node ) :
 
 		self.addChild( Gaffer.V3fPlug( "p", Gaffer.Plug.Direction.In ) )
 
-IECore.registerRunTimeTyped( CompoundNumericNode, typeName = "GafferTest::CompoundNumericNode" )
+IECore.registerRunTimeTyped( CompoundNumericNode, "GafferTest::CompoundNumericNode" )

--- a/python/GafferTest/CompoundPlugNode.py
+++ b/python/GafferTest/CompoundPlugNode.py
@@ -76,4 +76,4 @@ class CompoundPlugNode( Gaffer.DependencyNode ) :
 
 		return outputs
 
-IECore.registerRunTimeTyped( CompoundPlugNode, typeName = "GafferTest::CompoundPlugNode" )
+IECore.registerRunTimeTyped( CompoundPlugNode, "GafferTest::CompoundPlugNode" )

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -747,7 +747,7 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 
 				return outputs
 
-		IECore.registerRunTimeTyped( ManyToOneDependencyNode, typeName = "GafferTest::ManyToOneDependencyNode" )
+		IECore.registerRunTimeTyped( ManyToOneDependencyNode, "GafferTest::ManyToOneDependencyNode" )
 
 		node = ManyToOneDependencyNode()
 

--- a/python/GafferTest/FrameNode.py
+++ b/python/GafferTest/FrameNode.py
@@ -66,4 +66,4 @@ class FrameNode( Gaffer.ComputeNode ) :
 
 		plug.setValue( context.getFrame() )
 
-IECore.registerRunTimeTyped( FrameNode, typeName = "GafferTest::FrameNode" )
+IECore.registerRunTimeTyped( FrameNode, "GafferTest::FrameNode" )

--- a/python/GafferTest/KeywordPlugNode.py
+++ b/python/GafferTest/KeywordPlugNode.py
@@ -50,4 +50,4 @@ class KeywordPlugNode( Gaffer.Node ) :
 		# format to be able to cope with that
 		self.addChild( Gaffer.IntPlug( "in", Gaffer.Plug.Direction.In ) )
 
-IECore.registerRunTimeTyped( KeywordPlugNode, typeName = "GafferTest::KeywordPlugNode" )
+IECore.registerRunTimeTyped( KeywordPlugNode, "GafferTest::KeywordPlugNode" )

--- a/python/GafferTest/StringInOutNode.py
+++ b/python/GafferTest/StringInOutNode.py
@@ -72,4 +72,4 @@ class StringInOutNode( Gaffer.ComputeNode ) :
 
 		self.numComputeCalls += 1
 
-IECore.registerRunTimeTyped( StringInOutNode, typeName = "GafferTest::StringInOutNode" )
+IECore.registerRunTimeTyped( StringInOutNode, "GafferTest::StringInOutNode" )

--- a/python/GafferTest/TweakPlugTest.py
+++ b/python/GafferTest/TweakPlugTest.py
@@ -526,7 +526,7 @@ class TweakPlugTest( GafferTest.TestCase ) :
 				if plug.isSame( self["out"] ) :
 					plug.setValue( IECore.StringVectorData( [ "a", "b", "c", "d", "e" ] ) )
 
-		IECore.registerRunTimeTyped( UncachedOutNode, typeName = "GafferTest::UncachedOutNode" )
+		IECore.registerRunTimeTyped( UncachedOutNode, "GafferTest::UncachedOutNode" )
 
 		# This exposed a bug whereby TweakPlug could clobber the incoming tweak
 		# data before applying it.

--- a/python/GafferTractor/TractorDispatcher.py
+++ b/python/GafferTractor/TractorDispatcher.py
@@ -244,6 +244,6 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 		parentPlug["tractor"]["service"] = Gaffer.StringPlug()
 		parentPlug["tractor"]["tags"] = Gaffer.StringPlug()
 
-IECore.registerRunTimeTyped( TractorDispatcher, typeName = "GafferTractor::TractorDispatcher" )
+IECore.registerRunTimeTyped( TractorDispatcher, "GafferTractor::TractorDispatcher" )
 
 GafferDispatch.Dispatcher.registerDispatcher( "Tractor", TractorDispatcher, TractorDispatcher._setupPlugs )

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -62,7 +62,7 @@ class CompoundEditor( GafferUI.Editor ) :
 
 			self["editScope"] = Gaffer.Plug()
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferUI::CompoundEditor::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferUI::CompoundEditor::Settings" )
 
 	# The CompoundEditor constructor args are considered 'private', used only
 	# by the persistent layout system.

--- a/python/GafferUI/Editor.py
+++ b/python/GafferUI/Editor.py
@@ -78,7 +78,7 @@ class Editor( GafferUI.Widget ) :
 			# Editor from Node?
 			self["__scriptNode"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default & ~Gaffer.Plug.Flags.Serialisable )
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferUI::Editor::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferUI::Editor::Settings" )
 
 	def __init__( self, topLevelWidget, scriptNode, **kw ) :
 

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -73,7 +73,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			# SceneEditor in NodeSetEditor?
 			self["in"] = Gaffer.Plug()
 
-	IECore.registerRunTimeTyped( Settings, typeName = "GafferUI::Viewer::Settings" )
+	IECore.registerRunTimeTyped( Settings, "GafferUI::Viewer::Settings" )
 
 	def __init__( self, scriptNode, **kw ) :
 

--- a/python/GafferUITest/ToolTest.py
+++ b/python/GafferUITest/ToolTest.py
@@ -52,7 +52,7 @@ class ToolTest( GafferUITest.TestCase ) :
 
 			GafferUI.Tool.__init__( self, view, name )
 
-	IECore.registerRunTimeTyped( TestTool, typeName = "GafferUITest::TestTool" )
+	IECore.registerRunTimeTyped( TestTool, "GafferUITest::TestTool" )
 	GafferUI.Tool.registerTool( "TestTool", GafferUITest.ViewTest.MyView, TestTool )
 
 	def testDerivingInPython( self ) :

--- a/python/GafferUITest/ViewTest.py
+++ b/python/GafferUITest/ViewTest.py
@@ -65,7 +65,7 @@ class ViewTest( GafferUITest.TestCase ) :
 
 			GafferUI.View.__init__( self, "MyView", scriptNode, Gaffer.IntPlug( "in" ) )
 
-	IECore.registerRunTimeTyped( MyView, typeName = "GafferUITest::MyView" )
+	IECore.registerRunTimeTyped( MyView, "GafferUITest::MyView" )
 
 	def testFactory( self ) :
 

--- a/python/GafferUSD/_PointInstancerAdaptor.py
+++ b/python/GafferUSD/_PointInstancerAdaptor.py
@@ -141,4 +141,4 @@ class _PointInstancerAdaptor( GafferScene.SceneProcessor ) :
 
 		self["out"].setInput( self["instancer"]["out"] )
 
-IECore.registerRunTimeTyped( _PointInstancerAdaptor, typeName = "GafferUSD::_PointInstancerAdaptor" )
+IECore.registerRunTimeTyped( _PointInstancerAdaptor, "GafferUSD::_PointInstancerAdaptor" )


### PR DESCRIPTION
I'm a bit confused why this hasn't come up, since it looks like this was added in May, but when I tried to launch `gaffer browser`, it stopped loading with an exception here: "ValueError: invalid literal for int() with base 10: 'GafferUI::PlugCreationGadget'"

Looks like a simple fix, based on all the other calls to registerRunTimeTyped, I assume the intention was to set typeName.