### PR TITLE
Plug : Fix bad interaction between `addChild()` and `reorderChildren()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,7 +22,7 @@ Fixes
 - Viewer : Fixed regression introduced in 1.6.16.0 that prevented visualisation of the renderer-specific camera visibility and matte attributes authored by the Render Pass Editor's render adaptors [^1].
 - RenderMan : Fixed `R10043` warning when using PxrDisplace [^1].
 - RenderMan : Fixed automatic creation of required AOVs for PxrStylized filters in XPU [^1].
-- Catalogue : Fixed errors caused by undoing an image deletion.
+- Catalogue : Fixed errors caused by undoing an image deletion or snapshot.
 - Gaffer module : Fixed bug preventing `environment()` from returning environment variables modified after startup on macOS.
 
 API

--- a/python/GafferSceneTest/CatalogueTest.py
+++ b/python/GafferSceneTest/CatalogueTest.py
@@ -1195,6 +1195,39 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 				script.undo()
 				assertPreconditions()
 
+	def testAddImageAndReorder( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["catalogue"] = GafferScene.Catalogue()
+
+		script["catalogue"]["images"].addChild( GafferScene.Catalogue.Image( "image1" ) )
+
+		def assertPreconditions() :
+
+			self.assertEqual( len( script["catalogue"]["images"] ), 1 )
+			self.assertEqual( script["catalogue"]["images"][0].getName(), "image1" )
+
+		assertPreconditions()
+
+		with Gaffer.UndoScope( script ) :
+
+			script["catalogue"]["images"].addChild( GafferScene.Catalogue.Image( "image2" ) )
+			script["catalogue"]["images"].reorderChildren( reversed( script["catalogue"]["images"] ) )
+
+		def assertPostconditions() :
+
+			self.assertEqual( len( script["catalogue"]["images"] ), 2 )
+			self.assertEqual( script["catalogue"]["images"][0].getName(), "image2" )
+			self.assertEqual( script["catalogue"]["images"][1].getName(), "image1" )
+
+		assertPostconditions()
+
+		script.undo()
+		assertPreconditions()
+
+		script.redo()
+		assertPostconditions()
+
 	def testImageNames( self ) :
 
 		def assertImageNames( catalogue ) :

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -1071,6 +1071,63 @@ class PlugTest( GafferTest.TestCase ) :
 			set( Gaffer.Plug.RecursiveRange( node1 ) ) | set( Gaffer.Plug.RecursiveRange( node2 ) )
 		)
 
+	def testAddChildAndReorder( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["node1"] = Gaffer.Node()
+		script["node1"]["user"]["p"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["node1"]["user"]["p"]["c1"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["node1"]["user"]["p"]["c2"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		script["node2"] = Gaffer.Node()
+		script["node2"]["user"]["p"] = script["node1"]["user"]["p"].createCounterpart( "p", Gaffer.Plug.Direction.In )
+		script["node2"]["user"]["p"].setInput( script["node1"]["user"]["p"] )
+
+		def assertPreconditions() :
+
+			self.assertEqual( len( script["node1"]["user"]["p"] ), 2 )
+			self.assertEqual( script["node1"]["user"]["p"][0].getName(), "c1" )
+			self.assertEqual( script["node1"]["user"]["p"][1].getName(), "c2" )
+
+			self.assertEqual( len( script["node2"]["user"]["p"] ), 2 )
+			self.assertEqual( script["node2"]["user"]["p"][0].getName(), "c1" )
+			self.assertEqual( script["node2"]["user"]["p"][1].getName(), "c2" )
+
+			self.assertEqual( script["node2"]["user"]["p"]["c1"].getInput(), script["node1"]["user"]["p"]["c1"] )
+			self.assertEqual( script["node2"]["user"]["p"]["c2"].getInput(), script["node1"]["user"]["p"]["c2"] )
+
+		assertPreconditions()
+
+		with Gaffer.UndoScope( script ) :
+
+			script["node1"]["user"]["p"].addChild( Gaffer.Plug( "c3", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+			script["node1"]["user"]["p"].reorderChildren( reversed( script["node1"]["user"]["p"] ) )
+
+		def assertPostconditions() :
+
+			self.assertEqual( len( script["node1"]["user"]["p"] ), 3 )
+			self.assertEqual( script["node1"]["user"]["p"][0].getName(), "c3" )
+			self.assertEqual( script["node1"]["user"]["p"][1].getName(), "c2" )
+			self.assertEqual( script["node1"]["user"]["p"][2].getName(), "c1" )
+
+			self.assertEqual( len( script["node2"]["user"]["p"] ), 3 )
+			self.assertEqual( script["node2"]["user"]["p"][0].getName(), "c3" )
+			self.assertEqual( script["node2"]["user"]["p"][1].getName(), "c2" )
+			self.assertEqual( script["node2"]["user"]["p"][2].getName(), "c1" )
+
+			self.assertEqual( script["node2"]["user"]["p"]["c1"].getInput(), script["node1"]["user"]["p"]["c1"] )
+			self.assertEqual( script["node2"]["user"]["p"]["c2"].getInput(), script["node1"]["user"]["p"]["c2"] )
+			self.assertEqual( script["node2"]["user"]["p"]["c3"].getInput(), script["node1"]["user"]["p"]["c3"] )
+
+		assertPostconditions()
+
+		script.undo()
+		assertPreconditions()
+
+		script.redo()
+		assertPostconditions()
+
 	def testRemoveOutputsRemovesChildOutputs( self ) :
 
 		p1 = Gaffer.V2iPlug()

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -663,26 +663,30 @@ void Plug::parentChanged( Gaffer::GraphComponent *oldParent )
 
 void Plug::childrenReordered( const std::vector<size_t> &oldIndices )
 {
-	// Reorder the children of our outputs to match our new order. We disable
-	// undo while we do this, because `childrenReordered()` will be called again
-	// when the original action is undone anyway.
-	UndoScope undoDisabler( ancestor<ScriptNode>(), UndoScope::Disabled );
-	for( auto output : m_outputs )
+	// Reorder the children of our outputs to match our new order. We don't
+	// do this during undo or redo, because our reordering will have been
+	// captured the first time around, and will be replayed for us automatically.
+
+	ScriptNode *scriptNode = ancestor<ScriptNode>();
+	if( !scriptNode || ( scriptNode->currentActionStage() != Action::Undo && scriptNode->currentActionStage() != Action::Redo ) )
 	{
-		if( output->children().size() != oldIndices.size() )
+		for( auto output : m_outputs )
 		{
-			IECore::msg(
-				IECore::Msg::Warning, "Plug::childrenReordered",
-				fmt::format( "Not reordering output \"{}\" because its size doesn't match the input", output->fullName() )
-			);
-			continue;
+			if( output->children().size() != oldIndices.size() )
+			{
+				IECore::msg(
+					IECore::Msg::Warning, "Plug::childrenReordered",
+					fmt::format( "Not reordering output \"{}\" because its size doesn't match the input", output->fullName() )
+				);
+				continue;
+			}
+			GraphComponent::ChildContainer children; children.reserve( oldIndices.size() );
+			for( auto i : oldIndices )
+			{
+				children.push_back( output->getChild( i ) );
+			}
+			output->reorderChildren( children );
 		}
-		GraphComponent::ChildContainer children; children.reserve( oldIndices.size() );
-		for( auto i : oldIndices )
-		{
-			children.push_back( output->getChild( i ) );
-		}
-		output->reorderChildren( children );
 	}
 
 	// Propagate dirtiness, because some nodes are sensitive


### PR DESCRIPTION
`Plug::parentChanging()` and `Plug::childrenReordered()` both need to do work to mirror the changes onto their output plugs, so that changes to promoted plugs are reflected on the internal plugs. Likewise, they both need to avoid doubling-up this work during undo/redo, because by default the undo system will have recorded the mirroring and it won't need doing a second time.

`parentChanging()` avoided the doubling by checking `ScriptNode::actionStage()`, which is what we do generally in other spots. But `childrenReordered()` was taking a different approach : using `UndoScope( Disabled )` to prevent the mirroring being recorded in the undo queue, and just doing the work itself every time. I actually think I prefer this latter approach, because it avoids unnecessary bloat in the undo queue. But it was the cause of a bug when adding a child and reordering in the same UndoScope.

The issue was that when `UndoScope( Disabled )` closes, it calls `ScriptNode::popUndoScope()`. When we're in `undo()`, that causes ScriptNode to set `m_actionStage` to `Invalid`, which in turn means that `parentChanging()` will double up on the work. Which leads to _two_ attempts to remove a child, with the second one failing because it has already been removed.

Longer term I think it's worth investigating making `UndoScope( Disabled )` work better for this situation, and moving more code to use it. Or possibly even doing it all magically, by having ScriptNode not record actions that occur while an outer action is running. But for the short term the safest fix is to bring `childrenReordered()` into line with all our other methods that modify the graph in response to signals.
