### PR TITLE
InteractiveArnoldRenderTest : Fix intermittent failure on macOS

### DIFF
--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -346,7 +346,9 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		self.assertEventually(
 			lambda : self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 0.58, delta = 0.02 )
 		)
-		self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).g, 0, delta = 0.01 )
+		self.assertEventually(
+			lambda : self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).g, 0, delta = 0.01 )
+		)
 
 		# Edit texture network and make sure the changes take effect
 


### PR DESCRIPTION
When testQuadLightTextureEdits is run on macOS it occasionally fails with:

```
File "/Users/runner/work/gaffer/gaffer/build/arnold/7.4/python/GafferArnoldTest/InteractiveArnoldRenderTest.py", line 349, in testQuadLightTextureEdits
    self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).g, 0, delta = 0.01 )
AssertionError: 0.030833924189209938 != 0 within 0.01 delta (0.030833924189209938 difference)
```

Which looks like the green channel might just need a bit more time to converge, so we now wrap this assert in an assertEventually like the other asserts in this test.