### PR TITLE
Docs : Update TutorialUsingTheOSLCodeNode to better support Cycles

### DIFF
--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
@@ -1,7 +1,7 @@
 Tutorial: Using The OSLCode Node
 ================================
 
-Gaffer allows the creation of networks of predefined [OSL][1] shaders to be used in renderering and image and geometry processing, without any coding required. But sometimes the shader you want doesn't exist, or it's easier to express your ideas through a few lines of code. In these situations, the OSLCode node allows OSL source code to be entered directly, to create new shaders on the fly.
+Gaffer allows the creation of networks of predefined [OSL][1] shaders to be used in rendering and image and geometry processing, without any coding required. But sometimes the shader you want doesn't exist, or it's easier to express your ideas through a few lines of code. In these situations, the OSLCode node allows OSL source code to be entered directly, to create new shaders on the fly.
 
 A one line shader
 -----------------

--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
@@ -26,6 +26,8 @@ We can now enter any OSL code we want to generate the output from the input. Sta
 stripes = aastep( 0, sin( P.y * M_PI / width ) )
 ```
 
+![](images/stripesShader.png "Stripes shader")
+
 Now hit <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to update the shader. The Viewer will update to show a shader ball with the shader on it, and adjusting the width parameter will update the render interactively.
 
 ![](images/shaderBallStripes.png "Shader ball")
@@ -50,6 +52,8 @@ float vv = P.y + 0.2 * pnoise( P.x * 3, 4 );
 float m = aastep( 0, sin( vv * M_PI / width ) );
 stripes = mix( color1, color2, m );
 ```
+
+![](images/coloredStripesShader.png "Stripes shader")
 
 And as before, hit <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to update the shader.
 

--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
@@ -69,6 +69,6 @@ OSL resources
 This short tutorial has only scratched the surface of what can be done with Open Shading Language. The following resources are a good place to learn more :
 
 - The [language specification](https://open-shading-language.readthedocs.io)
-- The [OSL mailing list](https://groups.google.com/forum/#!forum/osl-dev)
+- The [OSL mailing list](https://lists.aswf.io/g/osl-dev/)
 
-[1]: https://github.com/imageworks/OpenShadingLanguage
+[1]: https://github.com/AcademySoftwareFoundation/OpenShadingLanguage

--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
@@ -14,7 +14,7 @@ We'll start by adding some parameters (inputs and outputs) for the shader.
 
 - Click on the upper ![](images/plus.png "Plus") and choose "Float" from the menu. This creates an input parameter which takes a floating point number.
 - Double click the "Input1" label that appears, and rename the parameter to `width`.
-- Enter the value `0.025` into the width field.
+- Enter the value `0.1` into the width field.
 - Click on the lower ![](images/plus.png "Plus") and choose "Color" from the menu. This creates an output color parameter.
 - Double click the "Output1" label, and rename the parameter to "stripes".
 
@@ -23,7 +23,7 @@ We'll start by adding some parameters (inputs and outputs) for the shader.
 We can now enter any OSL code we want to generate the output from the input. Start by entering the following :
 
 ```
-stripes = aastep( 0, sin( v * M_PI / width ) )
+stripes = aastep( 0, sin( P.y * M_PI / width ) )
 ```
 
 Now hit <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to update the shader. The Viewer will update to show a shader ball with the shader on it, and adjusting the width parameter will update the render interactively.
@@ -46,7 +46,7 @@ Let's add a bit of color and some wobble to our shader, to demonstrate a few mor
 Now update the code :
 
 ```
-float vv = v + 0.05 * pnoise( u * 20, 4 );
+float vv = P.y + 0.2 * pnoise( P.x * 3, 4 );
 float m = aastep( 0, sin( vv * M_PI / width ) );
 stripes = mix( color1, color2, m );
 ```

--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/screengrab.py
@@ -20,12 +20,12 @@ oslEditor = GafferUI.NodeEditor.acquire( script["OSLCode"], floating=True )
 GafferUI.WidgetAlgo.grab( widget = oslEditor, imagePath = "images/blank.png" )
 
 script["OSLCode"]["parameters"]["width"] = Gaffer.FloatPlug( defaultValue = 0.0 )
-script["OSLCode"]["parameters"]["width"].setValue( 0.025 )
+script["OSLCode"]["parameters"]["width"].setValue( 0.1 )
 script["OSLCode"]["out"]["stripes"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out, defaultValue = imath.Color3f( 0, 0, 0 ) )
 GafferUI.WidgetAlgo.grab( widget = oslEditor, imagePath = "images/parameters.png" )
 oslEditor.parent().setVisible( False )
 
-script["OSLCode"]["code"].setValue( "stripes = aastep( 0, sin( v * M_PI / width ) )" )
+script["OSLCode"]["code"].setValue( "stripes = aastep( 0, sin( P.y * M_PI / width ) )" )
 viewer = scriptWindow.getLayout().editors( GafferUI.Viewer )[0]
 # delay so it can render
 t = time.time() + 3
@@ -37,7 +37,7 @@ script["OSLCode"]["parameters"]["color1"] = Gaffer.Color3fPlug( defaultValue = i
 script["OSLCode"]["parameters"]["color1"].setValue( imath.Color3f( 0.814999998, 0.0401652865, 0 ) )
 script["OSLCode"]["parameters"]["color2"] = Gaffer.Color3fPlug( defaultValue = imath.Color3f( 0, 0, 0 ) )
 script["OSLCode"]["parameters"]["color2"].setValue( imath.Color3f( 0.210374981, 0.581973732, 0.764999986 ) )
-script["OSLCode"]["code"].setValue( "float vv = v + 0.05 * pnoise( u * 20, 4 );\nfloat m = aastep( 0, sin( vv * M_PI / width ) );\nstripes = mix( color1, color2, m );" )
+script["OSLCode"]["code"].setValue( "float vv = P.y + 0.2 * pnoise( P.x * 3, 4 );\nfloat m = aastep( 0, sin( vv * M_PI / width ) );\nstripes = mix( color1, color2, m );" )
 # delay so it can render
 t = time.time() + 3
 while time.time() < t :

--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/screengrab.py
@@ -1,5 +1,7 @@
 # BuildTarget: images/blank.png
 # BuildTarget: images/parameters.png
+# BuildTarget: images/stripesShader.png
+# BuildTarget: images/coloredStripesShader.png
 # BuildTarget: images/shaderBallColoredStripes.png
 # BuildTarget: images/shaderBallStripes.png
 
@@ -26,6 +28,10 @@ GafferUI.WidgetAlgo.grab( widget = oslEditor, imagePath = "images/parameters.png
 oslEditor.parent().setVisible( False )
 
 script["OSLCode"]["code"].setValue( "stripes = aastep( 0, sin( P.y * M_PI / width ) )" )
+oslEditor.parent().setVisible( True )
+GafferUI.WidgetAlgo.grab( widget = oslEditor, imagePath = "images/stripesShader.png" )
+oslEditor.parent().setVisible( False )
+
 viewer = scriptWindow.getLayout().editors( GafferUI.Viewer )[0]
 # delay so it can render
 t = time.time() + 3
@@ -38,6 +44,10 @@ script["OSLCode"]["parameters"]["color1"].setValue( imath.Color3f( 0.814999998, 
 script["OSLCode"]["parameters"]["color2"] = Gaffer.Color3fPlug( defaultValue = imath.Color3f( 0, 0, 0 ) )
 script["OSLCode"]["parameters"]["color2"].setValue( imath.Color3f( 0.210374981, 0.581973732, 0.764999986 ) )
 script["OSLCode"]["code"].setValue( "float vv = P.y + 0.2 * pnoise( P.x * 3, 4 );\nfloat m = aastep( 0, sin( vv * M_PI / width ) );\nstripes = mix( color1, color2, m );" )
+oslEditor.parent().setVisible( True )
+GafferUI.WidgetAlgo.grab( widget = oslEditor, imagePath = "images/coloredStripesShader.png" )
+oslEditor.parent().setVisible( False )
+
 # delay so it can render
 t = time.time() + 3
 while time.time() < t :


### PR DESCRIPTION
Unlike Arnold, Cycles provides per-face parametric uv coordinates for `u` and `v`, so the current tutorial looks quite incorrect when rendered with Cycles. This is misleading for anyone attempting to follow the tutorial without having Arnold available to render the shader ball. This difference also causes the documentation screengrabs of the rendered shader ball to differ significantly when making builds without Arnold available, leading to false-positive reports in our imageDiff checks on CI as those checks always compare against a release or nightly build where the screengrabs have been made from Arnold shader balls.

Changing these tutorial shaders to compute the pattern based on `P` rather than `u` & `v` does make them a little less generally useful, but it seems best to keep this tutorial simple...