### PR TITLE
Hide Disconnected Nodules

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,8 @@ Improvements
 - GraphEditor :
   - Changed node context menu items to operate on multiple nodes where possible (#2783).
   - Added drag & drop from LightEditor and AttributeEditor. Dropping a location navigates to the node that created the location.
+  - Added context menu item and keyboard shortcut, <kbd>/</kbd>, for hiding all of a node's disconnected input plugs.
+
 - RenderMan : Changed PxrCryptomatte's material output to use the name of the terminal shader, rather than a hash of the network. This is stable under animation. As before, the output can be customised by creating a `user:__materialid` attribute.
 
 Fixes

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -156,6 +156,7 @@ Auto-arrange selected nodes          | {kbd}`Ctrl` + {kbd}`L`
 Duplicate outgoing connection        | {kbd}`Shift` + {{leftClick}} and drag connection just before in plug
 Disconnect connections under cursor  | {kbd}`X` + {{leftClick}}
 Disconnect connections under line    | {kbd}`X` + {{leftClick}} and drag to draw a line, then release {{leftClick}}
+Hide disconnected nodules            | {kbd}`/`
 
 ### Focus Node ###
 

--- a/python/GafferUI/_PlugVisibilityGadget.py
+++ b/python/GafferUI/_PlugVisibilityGadget.py
@@ -58,6 +58,29 @@ def __hasVisibilityGadget( plug ) :
 		if parent is None or isinstance( parent, Gaffer.Node ) :
 			return False
 
+def __nodeHasVisibilityGadget( node ) :
+
+	for p in Gaffer.Plug.RecursiveRange( node ) :
+		for key in Gaffer.Metadata.registeredValues( p ) :
+			if key.endswith( ":gadgetType" ) and Gaffer.Metadata.value( p, key ) == "GafferUI.PlugVisibilityGadget" :
+				return True
+	return False
+
+def __hidablePlugs( node ) :
+
+	result = []
+	for plug in Gaffer.Plug.RecursiveRange( node ) :
+		if (
+			not __hasVisibilityGadget( plug ) or
+			not Gaffer.Metadata.value( plug, "plugVisibilityGadget:showable" ) or
+			Gaffer.Metadata.value( plug, "nodule:type" ) == "" or
+			Gaffer.Metadata.value( plug, "noduleLayout:visible" ) == False
+		) :
+			continue
+		result.append( plug )
+
+	return result
+
 def __graphEditorPlugContextMenu( graphEditor, plug, menuDefinition ) :
 
 	if not __hasVisibilityGadget( plug ) or not Gaffer.Metadata.value( plug, "plugVisibilityGadget:showable" ) :
@@ -82,3 +105,78 @@ def __graphEditorPlugContextMenu( graphEditor, plug, menuDefinition ) :
 	)
 
 GafferUI.GraphEditor.plugContextMenuSignal().connect( __graphEditorPlugContextMenu )
+
+##########################################################################
+# GraphEditor context menu
+##########################################################################
+
+def __hideUnconnectedWalk( gadget ) :
+
+	if isinstance( gadget, GafferUI.Nodule ) :
+
+		plug = gadget.plug()
+
+		if ( plug.direction() == plug.Direction.In and plug.getInput() ) or ( plug.direction() == plug.Direction.Out and len( plug.outputs() ) > 0 ) :
+			return True
+
+		if any( __hideUnconnectedWalk( g ) for g in gadget.children() ) :
+			return True
+
+		if (
+			not Gaffer.MetadataAlgo.readOnly( plug ) and
+			__hasVisibilityGadget( plug ) and
+			Gaffer.Metadata.value( plug, "plugVisibilityGadget:showable" ) and
+			Gaffer.Metadata.value( plug, "noduleLayout:visible" ) != False
+		) :
+			Gaffer.Metadata.registerValue( plug, "noduleLayout:visible", False )
+
+		return False
+
+	return sum( __hideUnconnectedWalk( c ) for c in gadget.children() ) > 0
+
+def __hideUnconnected( graphGadget, nodeList ) :
+
+	with Gaffer.UndoScope( graphGadget.getRoot().scriptNode() ) :
+		for node in nodeList :
+			nodeGadget = graphGadget.nodeGadget( node )
+			if nodeGadget is None :
+				continue
+
+			__hideUnconnectedWalk( nodeGadget )
+
+def __canHideUnconnectedPlugs( nodeList ) :
+
+	nodeReadOnly = any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList )
+	hidablePlugs = [ p for n in nodeList for p in __hidablePlugs( n ) ]
+	plugReadOnly = any( Gaffer.MetadataAlgo.readOnly( p ) for p in hidablePlugs )
+
+	return not nodeReadOnly and not plugReadOnly and all( __nodeHasVisibilityGadget( n ) for n in nodeList )
+
+def __editorKeyPress( editor, event ) :
+
+	selection = editor.scriptNode().selection()
+	if event.key == "Slash" and event.modifiers == event.Modifiers.None_ and __canHideUnconnectedPlugs( selection ) :
+		__hideUnconnected( editor.graphGadget(), selection )
+		return True
+
+	return False
+
+def __appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition ) :
+
+	if all( __nodeHasVisibilityGadget( n ) for n in nodeList ) :
+		menuDefinition.append(
+			"/Connections/Hide Unconnected Plugs",
+			{
+				"command" : functools.partial( __hideUnconnected, graphEditor.graphGadget(), nodeList ),
+				"shortCut" : "/",
+				"active" : __canHideUnconnectedPlugs( nodeList ),
+			}
+		)
+		return
+
+def __connectToGraphEditor( editor ) :
+
+	editor.keyPressSignal().connect( __editorKeyPress )
+
+GafferUI.GraphEditor.nodeContextMenuSignal( True ).connect( __appendNodeContextMenuDefinitions )
+GafferUI.GraphEditor.instanceCreatedSignal().connect( __connectToGraphEditor )

--- a/python/GafferUI/_PlugVisibilityGadget.py
+++ b/python/GafferUI/_PlugVisibilityGadget.py
@@ -66,20 +66,43 @@ def __nodeHasVisibilityGadget( node ) :
 				return True
 	return False
 
-def __hidablePlugs( node ) :
+def __hidableGadgetWalk( gadget ) :
 
-	result = []
-	for plug in Gaffer.Plug.RecursiveRange( node ) :
+	if isinstance( gadget, GafferUI.Nodule ) :
+		plug = gadget.plug()
+
+		if ( plug.direction() == plug.Direction.In and plug.getInput() ) or ( plug.direction() == plug.Direction.Out and len( plug.outputs() ) > 0 ) :
+			return ( True, [] )
+
+	hidablePlugs = []
+	descendantHasInput = False
+
+	for c in gadget.children() :
+		childHasInput, childHidablePlugs = __hidableGadgetWalk( c )
+		descendantHasInput = descendantHasInput or childHasInput
+		hidablePlugs.extend( childHidablePlugs )
+
+	if isinstance( gadget, GafferUI.Nodule ) :
+
 		if (
-			not __hasVisibilityGadget( plug ) or
-			not Gaffer.Metadata.value( plug, "plugVisibilityGadget:showable" ) or
-			Gaffer.Metadata.value( plug, "nodule:type" ) == "" or
-			Gaffer.Metadata.value( plug, "noduleLayout:visible" ) == False
+			Gaffer.Metadata.value( plug, "plugVisibilityGadget:showable" ) and
+			Gaffer.Metadata.value( plug, "noduleLayout:visible" ) != False and
+			not descendantHasInput and
+			__hasVisibilityGadget( plug )
 		) :
-			continue
-		result.append( plug )
+			hidablePlugs.append( plug )
 
-	return result
+	return ( descendantHasInput, hidablePlugs )
+
+def __hidablePlugs( graphGadget, node ) :
+
+	nodeGadget = graphGadget.nodeGadget( node )
+	if nodeGadget is None :
+		return []
+
+	_, hidablePlugs = __hidableGadgetWalk( nodeGadget )
+
+	return hidablePlugs
 
 def __graphEditorPlugContextMenu( graphEditor, plug, menuDefinition ) :
 
@@ -110,53 +133,25 @@ GafferUI.GraphEditor.plugContextMenuSignal().connect( __graphEditorPlugContextMe
 # GraphEditor context menu
 ##########################################################################
 
-def __hideUnconnectedWalk( gadget ) :
-
-	if isinstance( gadget, GafferUI.Nodule ) :
-
-		plug = gadget.plug()
-
-		if ( plug.direction() == plug.Direction.In and plug.getInput() ) or ( plug.direction() == plug.Direction.Out and len( plug.outputs() ) > 0 ) :
-			return True
-
-		if any( __hideUnconnectedWalk( g ) for g in gadget.children() ) :
-			return True
-
-		if (
-			not Gaffer.MetadataAlgo.readOnly( plug ) and
-			__hasVisibilityGadget( plug ) and
-			Gaffer.Metadata.value( plug, "plugVisibilityGadget:showable" ) and
-			Gaffer.Metadata.value( plug, "noduleLayout:visible" ) != False
-		) :
-			Gaffer.Metadata.registerValue( plug, "noduleLayout:visible", False )
-
-		return False
-
-	return sum( __hideUnconnectedWalk( c ) for c in gadget.children() ) > 0
-
-def __hideUnconnected( graphGadget, nodeList ) :
+def __hideUnconnectedPlugs( graphGadget, nodeList ) :
 
 	with Gaffer.UndoScope( graphGadget.getRoot().scriptNode() ) :
-		for node in nodeList :
-			nodeGadget = graphGadget.nodeGadget( node )
-			if nodeGadget is None :
-				continue
+		for plug in [ p for n in nodeList for p in __hidablePlugs( graphGadget, n ) if not Gaffer.MetadataAlgo.readOnly( p ) ] :
+			Gaffer.Metadata.registerValue( plug, "noduleLayout:visible", False )
 
-			__hideUnconnectedWalk( nodeGadget )
-
-def __canHideUnconnectedPlugs( nodeList ) :
+def __canHideUnconnectedPlugs( graphGadget, nodeList ) :
 
 	nodeReadOnly = any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList )
-	hidablePlugs = [ p for n in nodeList for p in __hidablePlugs( n ) ]
-	plugReadOnly = any( Gaffer.MetadataAlgo.readOnly( p ) for p in hidablePlugs )
+	plugReadOnly = any( Gaffer.MetadataAlgo.readOnly( p ) for n in nodeList for p in __hidablePlugs( graphGadget, n ) )
 
 	return not nodeReadOnly and not plugReadOnly and all( __nodeHasVisibilityGadget( n ) for n in nodeList )
 
 def __editorKeyPress( editor, event ) :
 
 	selection = editor.scriptNode().selection()
-	if event.key == "Slash" and event.modifiers == event.Modifiers.None_ and __canHideUnconnectedPlugs( selection ) :
-		__hideUnconnected( editor.graphGadget(), selection )
+	assert( isinstance( editor, GafferUI.GraphEditor ) )
+	if event.key == "Slash" and event.modifiers == event.Modifiers.None_ and __canHideUnconnectedPlugs( editor.graphGadget(), selection ) :
+		__hideUnconnectedPlugs( editor.graphGadget(), selection )
 		return True
 
 	return False
@@ -167,9 +162,9 @@ def __appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition ) 
 		menuDefinition.append(
 			"/Connections/Hide Unconnected Plugs",
 			{
-				"command" : functools.partial( __hideUnconnected, graphEditor.graphGadget(), nodeList ),
+				"command" : functools.partial( __hideUnconnectedPlugs, graphEditor.graphGadget(), nodeList ),
 				"shortCut" : "/",
-				"active" : __canHideUnconnectedPlugs( nodeList ),
+				"active" : __canHideUnconnectedPlugs( graphEditor.graphGadget(), nodeList ),
 			}
 		)
 		return

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -114,7 +114,7 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
-GafferUI.GraphEditor.nodeContextMenuSignal( True ).connect( __nodeContextMenu )
+GafferUI.GraphEditor.nodeContextMenuSignal( True ).connectFront( __nodeContextMenu )
 
 def __plugContextMenu( graphEditor, plug, menuDefinition ) :
 


### PR DESCRIPTION
This adds a context menu item to nodes (under `/Connections`) to hide all nodules that do not have a connection. Only plugs that are able to be shown again via a `GafferUI.PlugVisibilityWidget` are considered, along with a few other conditions.

This also adds initial support toward addressing #2783. I'm currently using two signals, one for existing handlers of `nodeContextMenuSignal()` that expect to be given one node to operate on, and a second for handlers that expect a list of nodes. 

Having to gather all the single-node menu items and then multi-node items in sequence isn't great. It makes it a little awkward to interleave the two types of menu items since it requires using the `MenuDefinition.insert*()` methods. Hopefully that won't be too much of a burden on users and it will be resolved when we deprecate the dual signal scheme.

There's also the great shortcut key debate to have. @johnhaddon suggested pipe, which I'm using here. I do find it a little hard to differentiate between `|` and `I`. I debated `Ctrl` + `H` for "hide" but that seems like it could conflict with the same shortcut in a scene viewer that will hide objects in an EditScope. Maybe `\`?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
