### PR TITLE
StandardAttributes : Add light linking exclusions attributes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 ------------
 
 - PrimitiveQuery : Added `primitive` output [^2].
+- StandardAttributes : Added `linkedLights:exclusions` attribute, specifying lights that never illuminate an object.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,7 @@ Improvements
 ------------
 
 - PrimitiveQuery : Added `primitive` output [^2].
-- StandardAttributes : Added `linkedLights:exclusions` attribute, specifying lights that never illuminate an object.
+- StandardAttributes : Added `linkedLights:exclusions` and `shadowedLights:exclusions` attributes, specifying lights that never illuminate or cast shadows from an object.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,10 @@ Improvements
 ------------
 
 - PrimitiveQuery : Added `primitive` output [^2].
-- StandardAttributes : Added `linkedLights:exclusions` and `shadowedLights:exclusions` attributes, specifying lights that never illuminate or cast shadows from an object.
+- StandardAttributes :
+  - Added `linkedLights:exclusions` and `shadowedLights:exclusions` attributes, specifying lights that never illuminate or cast shadows from an object.
+  - Added `filteredLights:exclusions` attribute, specifying lights that are never filtered by a light filter.
+- LightFilter, ArnoldLightFilter, RenderManLightFilter : Added `filteredLightsExclusions` plug.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - StandardAttributes :
   - Added `linkedLights:exclusions` and `shadowedLights:exclusions` attributes, specifying lights that never illuminate or cast shadows from an object.
   - Added `filteredLights:exclusions` attribute, specifying lights that are never filtered by a light filter.
+  - Moved `filteredLights` and `filteredLights:exclusions` to a new "Light Filters" section in the NodeEditor and AttributeEditor.
 - LightFilter, ArnoldLightFilter, RenderManLightFilter : Added `filteredLightsExclusions` plug.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,11 @@ Fixes
 
 - RenderMan : Fixed handling of V3f data with non-geometric interpretation. Common sources include `float3` primvars and attributes loaded from USD files [^1].
 
+Documentation
+-------------
+
+- Light Linking : Updated to describe use of the `linkedLights:exclusions` attribute.
+
 [^1]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.
 [^2]: Improvement to a feature introduced in `1.7.0.0a3`, so should be omitted from final `1.7.0.0` release notes.
 

--- a/doc/source/WorkingWithScenes/LightLinking/index.md
+++ b/doc/source/WorkingWithScenes/LightLinking/index.md
@@ -1,6 +1,6 @@
 # Light Linking #
 
-When lighting a scene, you will sometimes need to selectively control whether a piece of geometry is illuminated by a particular light, both for artistic purposes and to cut down on rendering time. The relationships that determine whether a light applies to an object are collectively known as **light linking**, and are controlled by the object's `linkedLights` attribute.
+When lighting a scene, you will sometimes need to selectively control whether a piece of geometry is illuminated by a particular light, both for artistic purposes and to cut down on rendering time. The relationships that determine whether a light applies to an object are collectively known as **light linking**, and are controlled by the object's `linkedLights` and `linkedLights:exclusions` attributes.
 
 ![](images/illustrationLightLinking.png "A sphere, a cube, and two lights, but the second light only illuminates the cube")
 
@@ -17,16 +17,22 @@ From the light side of things, by default, each light is a member of a set named
 
 ![](images/interfaceDefaultLightPlug.png "The Default Light plug of a light")
 
-From the object side of things, by default, an object is lit by all lights belonging to the "defaultLights" set. To bring about any other behaviour, such as having the object only lit by one light, a `linkedLights` attribute must be added to the object's location in the hierarchy, and the attribute must specify one or more lights, or sets of lights. The `linkedLights` attribute follows standard [inheritance rules for attributes](../AnatomyOfAScene/index.html#attributes) in the hierarchy, so if the object doesn't have the `linkedLights` attribute, but one of its ancestors does, it will inherit the attribute.
+From the object side of things, by default, an object is lit by all lights belonging to the "defaultLights" set. To bring about any other behaviour, such as having the object only lit by one light, a `linkedLights` attribute must be added to the object's location in the hierarchy, and the attribute must specify one or more lights, or sets of lights.
+
+To prevent an object from being lit by specific lights, a `linkedLights:exclusions` attribute can be added to the object's location in the hierarchy. Like `linkedLights`, it can specify one or more lights, or sets of lights. Lights specified in `linkedLights:exclusions` will **never** illuminate the object, even when that same light is specified in the object's `linkedLights` attribute.
 
 ```{eval-rst}
 .. figure:: images/interfaceLinkedLightsAttribute.png
     :scale: 100%
-    :alt: The linkedLights attribute of an object as it appears in the Scene Inspector.
+    :alt: The linkedLights and linkedLights:exclusions attributes of an object as they appear in the Scene Inspector.
 
-    The linkedLights attribute of an object, as it appears in the Scene Inspector.
+    The linkedLights and linkedLights:exclusions attributes, as they appear in the Scene Inspector.
 ```
 
+The `linkedLights` and `linkedLights:exclusions` attributes follow standard [inheritance rules for attributes](../AnatomyOfAScene/index.html#attributes) in the hierarchy, so if the object doesn't have the attribute, but one of its ancestors does, it will inherit the attribute. As attributes are inherited independently, `linkedLights:exclusions` can be added at a location inheriting a `linkedLights` attribute from an ancestor (or vice-versa). For example, an object at `/group/sphere` with only a `linkedLights:exclusions` attribute will inherit a `linkedLights` attribute authored at `/group`, and will be lit by those lights minus its own exclusions.
+
+> Tip :
+> As objects without a `linkedLights` attribute are lit by all lights in the "defaultLights" set, an object with only a `linkedLights:exclusions` attribute is lit by the default lights, minus its exclusions.
 
 ## Instructions ##
 
@@ -71,6 +77,17 @@ Be aware that if an object belongs to multiple sets with light linking, the obje
 
 ![](images/illustrationLightLinkingMultipleSets.png "A graph where an object belongs to multiple sets, each with different linked lights")
 
+### Excluding lights ###
+
+To exclude lights from illuminating the object, toggle the Linked Lights Exclusions plug and provide a [set expression](../../Reference/ScriptingReference/SetExpressions/index.md) that specifies the lights, or sets of lights to be excluded. This adds the `linkedLights:exclusions` attribute to the object's location. Lights matched by this expression will never illuminate the object, even when they are included by the Linked Lights plug.
+
+![](images/taskLightLinkingExclusionsSetExpression.png "A light linking exclusions set expression with a set")
+
+> Important :
+> Unlike the Linked Lights plug, the Linked Lights Exclusions plug is not an exclusive list. If you toggle the plug and leave the expression blank, no lights are excluded, and illumination is unchanged.
+
+> Tip :
+> The same lights could be excluded with a subtraction in the Linked Lights expression itself, such as `defaultLights - myLights`. The advantage of the Linked Lights Exclusions plug is that it is a separate attribute, so exclusions can be authored further down the hierarchy, or by a downstream node, without redefining the Linked Lights expression.
 
 ## Example scenario ##
 

--- a/doc/source/WorkingWithScenes/LightLinking/index.md
+++ b/doc/source/WorkingWithScenes/LightLinking/index.md
@@ -5,7 +5,7 @@ When lighting a scene, you will sometimes need to selectively control whether a 
 ![](images/illustrationLightLinking.png "A sphere, a cube, and two lights, but the second light only illuminates the cube")
 
 > Note :
-> The only supported renderer that currently implements light linking is Arnold.
+> Light linking is only supported when rendering with Arnold, Cycles, or RenderMan.
 
 > Tip :
 > Maya users will be familiar with the concept of light-centric (light-to-object) and object-centric (object-to-light) light linking. The procedure for linking lights in Gaffer is similar to object-centric linking.

--- a/doc/source/WorkingWithScenes/LightLinking/screengrab.py
+++ b/doc/source/WorkingWithScenes/LightLinking/screengrab.py
@@ -6,6 +6,7 @@
 # BuildTarget: images/interfaceLinkedLightsPlug.png
 # BuildTarget: images/taskLightLinkingSetExpressionLocation.png
 # BuildTarget: images/taskLightLinkingSetExpressionSet.png
+# BuildTarget: images/taskLightLinkingExclusionsSetExpression.png
 
 import imath
 import IECore
@@ -32,7 +33,9 @@ script["StandardAttributes"] = GafferScene.StandardAttributes()
 script["StandardAttributes"]["in"].setInput( script["Group"]["out"] )
 script["StandardAttributes"]["filter"].setInput( script["PathFilter"]["out"] )
 script["StandardAttributes"]["attributes"]["linkedLights"]["enabled"].setValue( True )
-script["StandardAttributes"]["attributes"]["linkedLights"]["value"].setValue( "/group/light" )
+script["StandardAttributes"]["attributes"]["linkedLights"]["value"].setValue( "defaultLights" )
+script["StandardAttributes"]["attributes"]["linkedLights:exclusions"]["enabled"].setValue( True )
+script["StandardAttributes"]["attributes"]["linkedLights:exclusions"]["value"].setValue( "/group/light" )
 script.addChild( script["Sphere"] )
 script.addChild( script["Light"] )
 script.addChild( script["Group"] )
@@ -48,7 +51,7 @@ GafferUI.WidgetAlgo.grab( widget = nodeEditorWindow, imagePath = "images/interfa
 nodeEditorWindow.parent().close()
 del nodeEditorWindow
 
-# Interface: the linkedLights attribute in the Scene Inspector
+# Interface: the linkedLights and linkedLights:exclusions attributes in the Scene Inspector
 script.selection().clear()
 script.selection().add( script["StandardAttributes"] )
 __path = "/group/sphere"
@@ -68,13 +71,16 @@ GafferUI.WidgetAlgo.grab( widget = sceneInspector, imagePath = "images/interface
 
 window.close()
 
+script["StandardAttributes"]["attributes"]["linkedLights:exclusions"]["enabled"].setValue( False )
+script["StandardAttributes"]["attributes"]["linkedLights:exclusions"]["value"].setValue( "" )
+
 # Interface: a StandardAttributes node downstream of an object node
 script.selection().clear()
 graphEditor.frame( script.children( Gaffer.Node ) )
 GafferUI.WidgetAlgo.grab( widget = graphEditor, imagePath = "images/interfaceLightLinkSetupGraphEditor.png" )
 
-# Interface: the empty Linked Lights plug of a StandardAttributes node in the Node Editor
-script["StandardAttributes"]["attributes"]["linkedLights"]["value"].setValue( "" )
+# Interface: the Linked Lights plug of a StandardAttributes node in the Node Editor
+script["StandardAttributes"]["attributes"]["linkedLights"]["value"].setValue( "defaultLights" )
 nodeEditorWindow = GafferUI.NodeEditor.acquire( script["StandardAttributes"], floating = True )
 nodeEditorWindow._qtWidget().setFocus()
 GafferUI.PlugValueWidget.acquire( script["StandardAttributes"]["attributes"]["linkedLights"] )
@@ -114,5 +120,16 @@ script["StandardAttributes"]["attributes"]["linkedLights"]["value"].setValue( "m
 nodeEditorWindow = GafferUI.NodeEditor.acquire( script["StandardAttributes"], floating = True )
 nodeEditorWindow._qtWidget().setFocus()
 GafferUI.WidgetAlgo.grab( widget = nodeEditorWindow, imagePath = "images/taskLightLinkingSetExpressionSet.png" )
+nodeEditorWindow.parent().close()
+del nodeEditorWindow
+
+# Task: the light linking exclusions set expression
+script["StandardAttributes"]["attributes"]["linkedLights"]["enabled"].setValue( False )
+script["StandardAttributes"]["attributes"]["linkedLights"]["value"].setValue( "defaultLights" )
+script["StandardAttributes"]["attributes"]["linkedLights:exclusions"]["enabled"].setValue( True )
+script["StandardAttributes"]["attributes"]["linkedLights:exclusions"]["value"].setValue( "myLights" )
+nodeEditorWindow = GafferUI.NodeEditor.acquire( script["StandardAttributes"], floating = True )
+nodeEditorWindow._qtWidget().setFocus()
+GafferUI.WidgetAlgo.grab( widget = nodeEditorWindow, imagePath = "images/taskLightLinkingExclusionsSetExpression.png" )
 nodeEditorWindow.parent().close()
 del nodeEditorWindow

--- a/include/GafferScene/LightFilter.h
+++ b/include/GafferScene/LightFilter.h
@@ -65,6 +65,9 @@ class GAFFERSCENE_API LightFilter : public ObjectSource
 		Gaffer::StringPlug *filteredLightsPlug();
 		const Gaffer::StringPlug *filteredLightsPlug() const;
 
+		Gaffer::StringPlug *filteredLightsExclusionsPlug();
+		const Gaffer::StringPlug *filteredLightsExclusionsPlug() const;
+
 		Gaffer::Plug *parametersPlug();
 		const Gaffer::Plug *parametersPlug() const;
 

--- a/python/GafferArnoldTest/ArnoldLightFilterTest.py
+++ b/python/GafferArnoldTest/ArnoldLightFilterTest.py
@@ -176,3 +176,23 @@ class ArnoldLightFilterTest( GafferSceneTest.SceneTestCase ) :
 		self.assertNotEqual( h1, h2 )
 
 		self.assertEqual( l["out"].attributes( "/lightFilter" )["filteredLights"], IECore.StringData( "/does/not/exist" ) )
+
+	def testFilteredLightsExclusionsPlug( self ) :
+
+		l = GafferArnold.ArnoldLightFilter()
+		l.loadShader( "light_blocker" )
+
+		self.assertNotIn( "filteredLights:exclusions", l["out"].attributes( "/lightFilter" ) )
+
+		l["filteredLightsExclusions"].setValue( "defaultLights" )
+
+		self.assertIn( "filteredLights:exclusions", l["out"].attributes( "/lightFilter" ) )
+		self.assertEqual( l["out"].attributes( "/lightFilter" )["filteredLights:exclusions"], IECore.StringData( "defaultLights" ) )
+
+		h1 = l["out"].attributesHash( "/lightFilter" )
+		l["filteredLightsExclusions"].setValue( "/does/not/exist" )
+		h2 = l["out"].attributesHash( "/lightFilter" )
+
+		self.assertNotEqual( h1, h2 )
+
+		self.assertEqual( l["out"].attributes( "/lightFilter" )["filteredLights:exclusions"], IECore.StringData( "/does/not/exist" ) )

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -964,6 +964,23 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( linkedFilter ) ), "light_blocker" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( linkedGobo ) ), "gobo" )
 
+		s["attributes"]["attributes"]["filteredLights:exclusions"]["enabled"].setValue( True )
+		s["attributes"]["attributes"]["filteredLights:exclusions"]["value"].setValue( "/group/light" )
+
+		s["render"]["task"].execute()
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, str( self.temporaryDirectory() / "test.ass" ), None )
+
+			light = arnold.AiNodeLookUpByName( universe, "light:/group/light" )
+			linkedFilters = arnold.AiNodeGetArray( light, "filters" )
+			numFilters = arnold.AiArrayGetNumElements( linkedFilters.contents )
+
+			self.assertEqual( numFilters, 1 )
+			linkedGobo = arnold.cast( arnold.AiArrayGetPtr( linkedFilters, 0 ), arnold.POINTER( arnold.AtNode ) )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( linkedGobo ) ), "gobo" )
+
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
 	def testLightFiltersMany( self ) :
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -784,7 +784,7 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			shadows = arnold.AiNodeGetArray( sphere1, "shadow_group" )
 			self.assertEqual( arnold.AiArrayGetNumElements( shadows ), 0 )
 
-	def testLightLinkingExclusions( self ) :
+	def testLightAndShadowLinkingExclusions( self ) :
 
 		sphere1 = GafferScene.Sphere()
 		sphere2 = GafferScene.Sphere()
@@ -816,6 +816,13 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 		attributes["attributes"]["linkedLights:exclusions"]["enabled"].setValue( True )
 		attributes["attributes"]["linkedLights:exclusions"]["value"].setValue( "/group/light" )
 
+		# Shadows
+		attributes["attributes"]["shadowedLights"]["enabled"].setValue( True )
+		attributes["attributes"]["shadowedLights"]["value"].setValue( "defaultLights" )
+
+		attributes["attributes"]["shadowedLights:exclusions"]["enabled"].setValue( True )
+		attributes["attributes"]["shadowedLights:exclusions"]["value"].setValue( "/group/light" )
+
 		render["mode"].setValue( render.Mode.SceneDescriptionMode )
 		render["fileName"].setValue( self.temporaryDirectory() / "test.ass" )
 		render["task"].execute()
@@ -836,6 +843,15 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 				"light:/group/light1"
 			)
 
+			# check shadows
+			self.assertTrue( arnold.AiNodeGetBool( sphere, "use_shadow_group" ) )
+			shadows = arnold.AiNodeGetArray( sphere, "shadow_group" )
+			self.assertEqual( arnold.AiArrayGetNumElements( shadows ), 1 )
+			self.assertEqual(
+				arnold.AiNodeGetName( arnold.AiArrayGetPtr( shadows, 0 ) ),
+				"light:/group/light1"
+			)
+
 			# the second sphere does not have any light linking enabled
 			sphere1 = arnold.AiNodeLookUpByName( universe, "/group/sphere1" )
 
@@ -843,6 +859,11 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			self.assertFalse( arnold.AiNodeGetBool( sphere1, "use_light_group" ) )
 			lights = arnold.AiNodeGetArray( sphere1, "light_group" )
 			self.assertEqual( arnold.AiArrayGetNumElements( lights ), 0 )
+
+			# check shadows
+			self.assertFalse( arnold.AiNodeGetBool( sphere1, "use_shadow_group" ) )
+			shadows = arnold.AiNodeGetArray( sphere1, "shadow_group" )
+			self.assertEqual( arnold.AiArrayGetNumElements( shadows ), 0 )
 
 	def testNoLinkedLightsOnLights( self ) :
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -784,6 +784,66 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			shadows = arnold.AiNodeGetArray( sphere1, "shadow_group" )
 			self.assertEqual( arnold.AiArrayGetNumElements( shadows ), 0 )
 
+	def testLightLinkingExclusions( self ) :
+
+		sphere1 = GafferScene.Sphere()
+		sphere2 = GafferScene.Sphere()
+
+		attributes = GafferScene.StandardAttributes()
+
+		light1 = GafferArnold.ArnoldLight()
+		light1.loadShader( "point_light" )
+
+		light2 = GafferArnold.ArnoldLight()
+		light2.loadShader( "point_light" )
+
+		group = GafferScene.Group()
+
+		render = GafferScene.Render()
+		render["renderer"].setValue( "Arnold" )
+
+		attributes["in"].setInput( sphere1["out"] )
+		group["in"][0].setInput( attributes["out"] )
+		group["in"][1].setInput( light1["out"] )
+		group["in"][2].setInput( light2["out"] )
+		group["in"][3].setInput( sphere2["out"] )
+
+		render["in"].setInput( group["out"] )
+
+		# Illumination
+		attributes["attributes"]["linkedLights"]["enabled"].setValue( True )
+		attributes["attributes"]["linkedLights"]["value"].setValue( "defaultLights" )
+		attributes["attributes"]["linkedLights:exclusions"]["enabled"].setValue( True )
+		attributes["attributes"]["linkedLights:exclusions"]["value"].setValue( "/group/light" )
+
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( self.temporaryDirectory() / "test.ass" )
+		render["task"].execute()
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, str( self.temporaryDirectory() / "test.ass" ), None )
+
+			# the first sphere had linked lights
+			sphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
+
+			# check illumination
+			self.assertTrue( arnold.AiNodeGetBool( sphere, "use_light_group" ) )
+			lights = arnold.AiNodeGetArray( sphere, "light_group" )
+			self.assertEqual( arnold.AiArrayGetNumElements( lights ), 1 )
+			self.assertEqual(
+				arnold.AiNodeGetName( arnold.AiArrayGetPtr( lights, 0 ) ),
+				"light:/group/light1"
+			)
+
+			# the second sphere does not have any light linking enabled
+			sphere1 = arnold.AiNodeLookUpByName( universe, "/group/sphere1" )
+
+			# check illumination
+			self.assertFalse( arnold.AiNodeGetBool( sphere1, "use_light_group" ) )
+			lights = arnold.AiNodeGetArray( sphere1, "light_group" )
+			self.assertEqual( arnold.AiArrayGetNumElements( lights ), 0 )
+
 	def testNoLinkedLightsOnLights( self ) :
 
 		sphere = GafferScene.Sphere()

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -55,6 +55,11 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "No light linking support just yet" )
+	def testLightLinkingWithExclusions( self ) :
+
+		pass
+
 	@unittest.skip( "No shadow linking support just yet" )
 	def testShadowLinking( self ) :
 

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -65,6 +65,11 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "No shadow linking support just yet" )
+	def testShadowLinkingExclusions( self ) :
+
+		pass
+
 	@unittest.skip( "Instance IDs only work with encapsulated instancers. We don't have encapsulation support yet in our 3Delight backend" )
 	def testInstanceIDOutput( self ) :
 

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -3142,6 +3142,22 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 			lambda : self.assertEqual( script["sampler"]["color"].getValue(), imath.Color4f( 0, 0, 0, 1 ) )
 		)
 
+		# Exclude the light, check the plane isn't shadowed.
+
+		script["attributes"]["attributes"].addChild(
+			Gaffer.NameValuePlug( "shadowedLights:exclusions", "/pointLight", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		)
+		self.assertEventually(
+			lambda : self.assertGreater( script["sampler"]["color"]["r"].getValue(), 0.1 )
+		)
+
+		# Exclude a non-existent light, and check plane is shadowed.
+
+		script["attributes"]["attributes"][-1]["value"].setValue( "nonExistent" )
+		self.assertEventually(
+			lambda : self.assertEqual( script["sampler"]["color"].getValue(), imath.Color4f( 0, 0, 0, 1 ) )
+		)
+
 		# Remove light from set, and check plane isn't shadowed.
 
 		script["light"]["defaultLight"].setValue( False )

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -2102,6 +2102,23 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 			lambda : self.assertEqualWithAbsError( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ), imath.Color4f( unfilteredIntensity, unfilteredIntensity, 0, 1 ), error = 0.01 )
 		)
 
+		# Exclude the light from the light filter
+
+		script["attributes"]["attributes"]["filteredLights:exclusions"]["enabled"].setValue( True )
+		script["attributes"]["attributes"]["filteredLights:exclusions"]["value"].setValue( "defaultLights" )
+
+		self.assertEventually(
+			lambda : self.assertEqualWithAbsError( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ), imath.Color4f( unfilteredIntensity * 2.0, unfilteredIntensity * 2.0, 0, 1 ), error = 0.01 )
+		)
+
+		# Remove the exclusion
+
+		script["attributes"]["attributes"]["filteredLights:exclusions"]["enabled"].setValue( False )
+
+		self.assertEventually(
+			lambda : self.assertEqualWithAbsError( self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) ), imath.Color4f( unfilteredIntensity, unfilteredIntensity, 0, 1 ), error = 0.01 )
+		)
+
 		# Reset light and filter
 
 		script["light"]["parameters"]["intensity"].setValue( 1.0 )

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -124,6 +124,11 @@ class OpenGLRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "Shadow linking not supported" )
+	def testShadowLinkingExclusions( self ) :
+
+		pass
+
 	@unittest.skip( "ID output not supported" )
 	def testIDOutput( self ) :
 

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -114,6 +114,11 @@ class OpenGLRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "Light linking not supported" )
+	def testLightLinkingWithExclusions( self ) :
+
+		pass
+
 	@unittest.skip( "Shadow linking not supported" )
 	def testShadowLinking( self ) :
 

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -264,6 +264,26 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( capturedSphere.capturedLinks( "lights" ), { capturedLightB } )
 		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 3 )
 
+		# Likewise if we add exclusions.
+
+		attributes["attributes"]["linkedLights:exclusions"]["enabled"].setValue( True )
+		attributes["attributes"]["linkedLights:exclusions"]["value"].setValue( "B" )
+		controller.update()
+		self.assertEqual( capturedSphere.capturedLinks( "lights" ), set() )
+		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 4 )
+
+		# Or update exclusions.
+
+		attributes["attributes"]["linkedLights:exclusions"]["value"].setValue( "A" )
+		controller.update()
+		self.assertEqual( capturedSphere.capturedLinks( "lights" ), { capturedLightB } )
+		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 5 )
+
+		attributes["attributes"]["linkedLights:exclusions"]["value"].setValue( " " )
+		controller.update()
+		self.assertEqual( capturedSphere.capturedLinks( "lights" ), { capturedLightB } )
+		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 6 )
+
 		# If we change an attribute which has no bearing on light linking,
 		# we don't want links to be emitted again. Attributes change frequently
 		# and light linking can be expensive.
@@ -271,7 +291,7 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		attributes["attributes"]["doubleSided"]["value"].setValue( True )
 		controller.update()
 		self.assertEqual( capturedSphere.capturedLinks( "lights" ), { capturedLightB } )
-		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 3 )
+		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 6 )
 
 		del capturedSphere, capturedLightA, capturedLightB
 

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -356,6 +356,136 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		links = renderer.capturedObject( "/group/spheres/instances/sphere/0" ).capturedLinks( "lights" )
 		self.assertEqual( len( links ), numLights )
 
+	def linkingPerformanceTest( self, lightInclusions = None, lightExclusions = None, shadowInclusions = None, shadowExclusions = None, timeUpdate = False ) :
+
+		numSpheres = 10000
+		numLights = 1000
+
+		# Make a bunch of spheres
+
+		sphere = GafferScene.Sphere()
+
+		spherePlane = GafferScene.Plane()
+		spherePlane["name"].setValue( "spheres" )
+		spherePlane["divisions"].setValue( imath.V2i( 1, numSpheres / 2 - 1 ) )
+
+		sphereInstancer = GafferScene.Instancer()
+		sphereInstancer["in"].setInput( spherePlane["out"] )
+		sphereInstancer["prototypes"].setInput( sphere["out"] )
+		sphereInstancer["parent"].setValue( "/spheres" )
+
+		# Make a bunch of lights
+
+		light = GafferSceneTest.TestLight()
+		light.loadShader( "simpleLight" )
+
+		lightPlane = GafferScene.Plane()
+		lightPlane["name"].setValue( "lights" )
+		lightPlane["divisions"].setValue( imath.V2i( 1, numLights / 2 - 1 ) )
+
+		lightInstancer = GafferScene.Instancer()
+		lightInstancer["in"].setInput( lightPlane["out"] )
+		lightInstancer["prototypes"].setInput( light["out"] )
+		lightInstancer["parent"].setValue( "/lights" )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( sphereInstancer["out"] )
+		group["in"][1].setInput( lightInstancer["out"] )
+
+		groupFilter = GafferScene.PathFilter()
+		groupFilter["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
+
+		attributes = GafferScene.StandardAttributes()
+		attributes["in"].setInput( group["out"] )
+		attributes["filter"].setInput( groupFilter["out"] )
+
+		attributes["attributes"]["linkedLights"]["enabled"].setValue( lightInclusions is not None )
+		attributes["attributes"]["linkedLights"]["value"].setValue( lightInclusions or "" )
+		attributes["attributes"]["linkedLights:exclusions"]["enabled"].setValue( lightExclusions is not None )
+		attributes["attributes"]["linkedLights:exclusions"]["value"].setValue( lightExclusions or "" )
+
+		attributes["attributes"]["shadowedLights"]["enabled"].setValue( shadowInclusions is not None )
+		attributes["attributes"]["shadowedLights"]["value"].setValue( shadowInclusions or "" )
+		attributes["attributes"]["shadowedLights:exclusions"]["enabled"].setValue( shadowExclusions is not None )
+		attributes["attributes"]["shadowedLights:exclusions"]["value"].setValue( shadowExclusions or "" )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( attributes["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 10 )
+
+		# See how quickly we can output those links
+
+		if not timeUpdate :
+			with GafferTest.TestRunner.PerformanceScope() :
+				controller.update()
+		else :
+			controller.update()
+
+		# Sanity check that we did output links as expected.
+
+		capturedSphere = renderer.capturedObject( "/group/spheres/instances/sphere/0" )
+		self.assertEqual( len( capturedSphere.capturedLinks( "lights" ) ), numLights - 1 )
+		if shadowInclusions is not None :
+			self.assertEqual( len( capturedSphere.capturedLinks( "shadowedLights" ) ), numLights - 1 )
+		else :
+			self.assertIsNone( capturedSphere.capturedLinks( "shadowedLights" ) )
+		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 1 )
+		self.assertEqual( capturedSphere.numLinkEdits( "shadowedLights" ), 1 )
+
+		# Update an unrelated attribute and check that no additional linking was performed.
+
+		attributes["attributes"]["doubleSided"]["enabled"].setValue( True )
+
+		if timeUpdate :
+			with GafferTest.TestRunner.PerformanceScope() :
+				controller.update()
+		else :
+			controller.update()
+
+		self.assertEqual( len( capturedSphere.capturedLinks( "lights" ) ), numLights - 1 )
+		self.assertEqual( capturedSphere.numLinkEdits( "lights" ), 1 )
+		self.assertEqual( capturedSphere.numLinkEdits( "shadowedLights" ), 1 )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightLinkOnlyInclusionsPerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights - /group/lights/instances/light/0" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightLinkOnlyInclusionsUpdatePerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights - /group/lights/instances/light/0", timeUpdate = True )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightLinkExclusionsPerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights", "/group/lights/instances/light/0" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightLinkExclusionsUpdatePerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights", "/group/lights/instances/light/0", timeUpdate = True )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightAndShadowLinkOnlyInclusionsPerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights - /group/lights/instances/light/0", shadowInclusions = "__lights - /group/lights/instances/light/1" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightAndShadowLinkOnlyInclusionsUpdatePerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights - /group/lights/instances/light/0", shadowInclusions = "__lights - /group/lights/instances/light/1", timeUpdate = True )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightAndShadowLinkExclusionsPerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights", "/group/lights/instances/light/0", "__lights", "/group/lights/instances/light/1" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testLightAndShadowLinkExclusionsUpdatePerformance( self ) :
+
+		self.linkingPerformanceTest( "defaultLights", "/group/lights/instances/light/0", "__lights", "/group/lights/instances/light/1", timeUpdate = True )
+
 	def testDeformingLight( self ) :
 
 		# Make a deforming mesh light by hand.

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -454,6 +454,85 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertGreater( sampler["color"]["r"].getValue(), 0.02 )
 		self.assertEqual( sampler["color"]["g"].getValue(), 0 )
 
+	def testLightLinkingWithExclusions( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		script["shader"], unused, shaderOut = self._createDiffuseShader()
+
+		for label, excluded, color in (
+			( "red", "green", imath.Color3f( 1, 0, 0 ) ),
+			( "green", "red", imath.Color3f( 0, 1, 0 ) ),
+		) :
+
+			light, colorPlug = self._createPointLight()
+			light["name"].setValue( f"{label}Light" )
+			colorPlug.setValue( color )
+			light["transform"]["translate"]["z"].setValue( 1 )
+			script[f"{label}Light"] = light
+
+			plane = GafferScene.Plane()
+			plane["name"].setValue( f"{label}Plane" )
+			plane["transform"]["translate"].setValue( color )
+			script[f"{label}Plane"] = plane
+
+			assignment = GafferScene.ShaderAssignment()
+			assignment["in"].setInput( plane["out"] )
+			assignment["shader"].setInput( shaderOut )
+			script[f"{label}Assignment"] = assignment
+
+			attributes = GafferScene.StandardAttributes()
+			attributes["attributes"]["linkedLights:exclusions"]["enabled"].setValue( True )
+			attributes["attributes"]["linkedLights:exclusions"]["value"].setValue( f"/{excluded}Light" )
+			attributes["in"].setInput( assignment["out"] )
+			script[f"{label}Attributes"] = attributes
+
+			script["parent"]["children"].next().setInput( light["out"] )
+			script["parent"]["children"].next().setInput( attributes["out"] )
+
+		imagePath = ( self.temporaryDirectory() / "test.exr" )
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba",
+			)
+		)
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["options"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+		script["render"]["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		sampler["pixel"].setValue( imath.V2f( 320, 370 ) )
+		self.assertEqual( sampler["color"]["r"].getValue(), 0 )
+		self.assertGreater( sampler["color"]["g"].getValue(), 0.02 )
+
+		sampler["pixel"].setValue( imath.V2f( 455, 232 ) )
+		self.assertGreater( sampler["color"]["r"].getValue(), 0.02 )
+		self.assertEqual( sampler["color"]["g"].getValue(), 0 )
+
 	def testShadowLinking( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -639,6 +639,112 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 				c.g /= m
 			self.assertEqualWithAbsError( c, expectedColor, 0.001, f"(x == {x})" )
 
+	def testShadowLinkingExclusions( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		script["shader"], unused, shaderOut = self._createDiffuseShader()
+
+		script["plane"] = GafferScene.Plane()
+		script["plane"]["dimensions"].setValue( imath.V2f( 10 ) )
+		script["assignment"] = GafferScene.ShaderAssignment()
+		script["assignment"]["in"].setInput( script["plane"]["out"] )
+		script["assignment"]["shader"].setInput( shaderOut )
+		script["parent"]["children"].next().setInput( script["assignment"]["out"] )
+
+		for label, color in {
+			"red" : imath.Color3f( 1, 0, 0 ),
+			"green" : imath.Color3f( 0, 1, 0 ),
+		}.items() :
+
+			light, colorPlug = self._createDistantLight()
+			light["name"].setValue( f"{label}Light" )
+			colorPlug.setValue( color )
+			light["transform"]["translate"]["z"].setValue( 10 )
+			script[f"{label}Light"] = light
+			script["parent"]["children"].next().setInput( light["out"] )
+
+		for index, shadowedLightsExclusions in enumerate( [ "", " ", "/redLight", "/greenLight", "defaultLights" ] ) :
+
+			sphere = GafferScene.Sphere()
+			sphere["radius"].setValue( 0.5 )
+			sphere["transform"]["translate"]["x"].setValue( index - 2 )
+			sphere["transform"]["translate"]["z"].setValue( 5 )
+			script.addChild( sphere )
+
+			assignment = GafferScene.ShaderAssignment()
+			assignment["in"].setInput( sphere["out"] )
+			assignment["shader"].setInput( shaderOut )
+			script.addChild( assignment )
+
+			attributes = GafferScene.CustomAttributes()
+			attributes["in"].setInput( assignment["out"] )
+			attributes["attributes"].addChild(
+				Gaffer.NameValuePlug( self._cameraVisibilityAttribute(), False, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			)
+
+			attributes["attributes"].addChild(
+				Gaffer.NameValuePlug( "shadowedLights:exclusions", shadowedLightsExclusions, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			)
+
+			script["parent"]["children"].next().setInput( attributes["out"] )
+			script.addChild( attributes )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba",
+			)
+		)
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+		script["render"]["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		for x, expectedColor in {
+			47 : imath.Color4f( 0, 0, 0, 1 ),
+			186 : imath.Color4f( 0, 0, 0, 1 ),
+			320 : imath.Color4f( 1, 0, 0, 1 ),
+			454 : imath.Color4f( 0, 1, 0, 1 ),
+			592 : imath.Color4f( 1, 1, 0, 1 ),
+		}.items() :
+			with self.subTest( x = x, expectedColor = expectedColor ) :
+
+				sampler["pixel"].setValue( imath.V2f( x, 240 ) )
+				c = sampler["color"].getValue()
+				m = max( c.r, c.g )
+				if m :
+					c.r /= m # Normalize so light intensity/falloff is irrelevant
+					c.g /= m
+				self.assertEqualWithAbsError( c, expectedColor, 0.001 )
+
 	def testOutputMetadata( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -2671,6 +2671,84 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 			IECore.PathMatcher( [  "/group/defaultLight", "/group/nonDefaultLight" ] )
 		)
 
+		# Cube relinked to `defaultLights` with "/group/nonDefaultLight" excluded.
+
+		standardAttributes["attributes"]["linkedLights"]["value"].setValue( "defaultLights" )
+		standardAttributes["attributes"]["linkedLights:exclusions"]["enabled"].setValue( True )
+		standardAttributes["attributes"]["linkedLights:exclusions"]["value"].setValue( "/group/nonDefaultLight" )
+
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedObjects( standardAttributes["out"], "/group/defaultLight" ),
+			IECore.PathMatcher( [ "/group", "/group/cube", "/group/sphere" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedObjects( standardAttributes["out"], "/group/nonDefaultLight" ),
+			IECore.PathMatcher( [ "/group", "/group/sphere" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], "/group/cube" ),
+			IECore.PathMatcher( [ "/group/defaultLight" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], "/group/sphere" ),
+			IECore.PathMatcher( [ "/group/defaultLight", "/group/nonDefaultLight" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], IECore.PathMatcher( [ "/group/sphere", "/group/cube" ] ) ),
+			IECore.PathMatcher( [  "/group/defaultLight", "/group/nonDefaultLight" ] )
+		)
+
+		# Cube relinked to "" with "/group/nonDefaultLight" excluded.
+
+		standardAttributes["attributes"]["linkedLights"]["value"].setValue( "" )
+
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedObjects( standardAttributes["out"], "/group/defaultLight" ),
+			IECore.PathMatcher( [ "/group", "/group/sphere" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedObjects( standardAttributes["out"], "/group/nonDefaultLight" ),
+			IECore.PathMatcher( [ "/group", "/group/sphere" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], "/group/cube" ),
+			IECore.PathMatcher()
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], "/group/sphere" ),
+			IECore.PathMatcher( [ "/group/defaultLight", "/group/nonDefaultLight" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], IECore.PathMatcher( [ "/group/sphere", "/group/cube" ] ) ),
+			IECore.PathMatcher( [  "/group/defaultLight", "/group/nonDefaultLight" ] )
+		)
+
+		# Cube relinked to `defaultLights` with "" excluded.
+
+		standardAttributes["attributes"]["linkedLights"]["value"].setValue( "defaultLights" )
+		standardAttributes["attributes"]["linkedLights:exclusions"]["value"].setValue( "" )
+
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedObjects( standardAttributes["out"], "/group/defaultLight" ),
+			IECore.PathMatcher( [ "/group", "/group/cube", "/group/sphere" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedObjects( standardAttributes["out"], "/group/nonDefaultLight" ),
+			IECore.PathMatcher( [ "/group", "/group/cube", "/group/sphere" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], "/group/cube" ),
+			IECore.PathMatcher( [ "/group/defaultLight", "/group/nonDefaultLight" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], "/group/sphere" ),
+			IECore.PathMatcher( [ "/group/defaultLight", "/group/nonDefaultLight" ] )
+		)
+		self.assertEqual(
+			GafferScene.SceneAlgo.linkedLights( standardAttributes["out"], IECore.PathMatcher( [ "/group/sphere", "/group/cube" ] ) ),
+			IECore.PathMatcher( [  "/group/defaultLight", "/group/nonDefaultLight" ] )
+		)
+
 	def testMatchingPathsHash( self ) :
 
 		# /group

--- a/python/GafferSceneTest/StandardAttributesTest.py
+++ b/python/GafferSceneTest/StandardAttributesTest.py
@@ -168,7 +168,7 @@ class StandardAttributesTest( GafferSceneTest.SceneTestCase ) :
 	def testNodeConstructsWithAllAttributes( self ) :
 
 		targets = "attribute:scene:visible attribute:doubleSided attribute:render:* attribute:gaffer:* " \
-			+ "attribute:linkedLights attribute:shadowedLights attribute:filteredLights"
+			+ "attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights attribute:filteredLights"
 
 		node = GafferScene.StandardAttributes()
 		for attribute in Gaffer.Metadata.targetsWithMetadata( targets, "defaultValue" ) :

--- a/python/GafferSceneTest/StandardAttributesTest.py
+++ b/python/GafferSceneTest/StandardAttributesTest.py
@@ -168,7 +168,8 @@ class StandardAttributesTest( GafferSceneTest.SceneTestCase ) :
 	def testNodeConstructsWithAllAttributes( self ) :
 
 		targets = "attribute:scene:visible attribute:doubleSided attribute:render:* attribute:gaffer:* " \
-			+ "attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights attribute:filteredLights"
+			+ "attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights " \
+			+ "attribute:shadowedLights:exclusions attribute:filteredLights"
 
 		node = GafferScene.StandardAttributes()
 		for attribute in Gaffer.Metadata.targetsWithMetadata( targets, "defaultValue" ) :

--- a/python/GafferSceneTest/StandardAttributesTest.py
+++ b/python/GafferSceneTest/StandardAttributesTest.py
@@ -169,7 +169,7 @@ class StandardAttributesTest( GafferSceneTest.SceneTestCase ) :
 
 		targets = "attribute:scene:visible attribute:doubleSided attribute:render:* attribute:gaffer:* " \
 			+ "attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights " \
-			+ "attribute:shadowedLights:exclusions attribute:filteredLights"
+			+ "attribute:shadowedLights:exclusions attribute:filteredLights attribute:filteredLights:exclusions"
 
 		node = GafferScene.StandardAttributes()
 		for attribute in Gaffer.Metadata.targetsWithMetadata( targets, "defaultValue" ) :

--- a/python/GafferSceneUI/LightFilterUI.py
+++ b/python/GafferSceneUI/LightFilterUI.py
@@ -86,9 +86,10 @@ Gaffer.Metadata.registerNode(
 
 			"description" :
 			"""
-			The lights that are being filtered. Accepts a SetExpression. You
-			might want to set it to 'defaultLights' to have the filter affect
-			all lights that haven't been excluded from that set.
+			The lights to be filtered by this light filter. Accepts a
+			set expression or a space separated list of lights. Use
+			\"defaultLights\" to refer to all lights that contribute
+			to illumination by default.
 			""",
 
 			"layout:index" : 1,

--- a/python/GafferSceneUI/LightFilterUI.py
+++ b/python/GafferSceneUI/LightFilterUI.py
@@ -94,6 +94,18 @@ Gaffer.Metadata.registerNode(
 			"layout:index" : 1,
 		},
 
+		"filteredLightsExclusions" : {
+
+			"description" :
+			"""
+			The lights that are never filtered by this light filter, even
+			when they are included by `filteredLights`. Accepts a set
+			expression or a space separated list of lights.
+			""",
+
+			"layout:index" : 2,
+		},
+
 		"sets" : {
 
 			"layout:divider" : True,

--- a/src/GafferScene/LightFilter.cpp
+++ b/src/GafferScene/LightFilter.cpp
@@ -54,6 +54,7 @@ using namespace GafferScene;
 
 static IECore::InternedString g_lightFiltersSetName( "__lightFilters" );
 static IECore::InternedString g_filteredLightsAttributeName( "filteredLights" );
+static IECore::InternedString g_filteredLightsExclusionsAttributeName( "filteredLights:exclusions" );
 
 GAFFER_NODE_DEFINE_TYPE( LightFilter );
 
@@ -67,6 +68,7 @@ LightFilter::LightFilter( GafferScene::ShaderPtr shader, const std::string &name
 	shader->setName( "__shader" );
 	addChild( shader );
 	addChild( new StringPlug( "filteredLights" ) );
+	addChild( new StringPlug( "filteredLightsExclusions" ) );
 	addChild( new Plug( "parameters" ) );
 	addChild( new ShaderPlug( "__shaderIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
 
@@ -114,31 +116,41 @@ const StringPlug *LightFilter::filteredLightsPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 1 );
 }
 
+StringPlug *LightFilter::filteredLightsExclusionsPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const StringPlug *LightFilter::filteredLightsExclusionsPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
 Gaffer::Plug *LightFilter::parametersPlug()
 {
-	return getChild<Plug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 3 );
 }
 
 const Gaffer::Plug *LightFilter::parametersPlug() const
 {
-	return getChild<Plug>( g_firstPlugIndex + 2 );
+	return getChild<Plug>( g_firstPlugIndex + 3 );
 }
 
 ShaderPlug *LightFilter::shaderPlug()
 {
-	return getChild<ShaderPlug>( g_firstPlugIndex + 3 );
+	return getChild<ShaderPlug>( g_firstPlugIndex + 4 );
 }
 
 const ShaderPlug *LightFilter::shaderPlug() const
 {
-	return getChild<ShaderPlug>( g_firstPlugIndex + 3 );
+	return getChild<ShaderPlug>( g_firstPlugIndex + 4 );
 }
 
 void LightFilter::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ObjectSource::affects( input, outputs );
 
-	if( input == shaderPlug() || input == filteredLightsPlug() )
+	if( input == shaderPlug() || input == filteredLightsPlug() || input == filteredLightsExclusionsPlug() )
 	{
 		outputs.push_back( outPlug()->attributesPlug() );
 	}
@@ -164,6 +176,7 @@ void LightFilter::hashAttributes( const SceneNode::ScenePath &path, const Gaffer
 
 	h.append( shaderPlug()->attributesHash() );
 	filteredLightsPlug()->hash( h );
+	filteredLightsExclusionsPlug()->hash( h );
 }
 
 IECore::ConstCompoundObjectPtr LightFilter::computeAttributes( const SceneNode::ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
@@ -176,6 +189,11 @@ IECore::ConstCompoundObjectPtr LightFilter::computeAttributes( const SceneNode::
 	if( !filteredLights.empty() )
 	{
 		result->members()[g_filteredLightsAttributeName] = new IECore::StringData( filteredLights );
+	}
+	const std::string &filteredLightsExclusions = filteredLightsExclusionsPlug()->getValue();
+	if( !filteredLightsExclusions.empty() )
+	{
+		result->members()[g_filteredLightsExclusionsAttributeName] = new IECore::StringData( filteredLightsExclusions );
 	}
 
 	return result;

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1040,6 +1040,7 @@ namespace
 IECore::InternedString g_linkedLightsAttributeName( "linkedLights" );
 IECore::InternedString g_linkedLightsExclusionsAttributeName( "linkedLights:exclusions" );
 IECore::InternedString g_filteredLightsAttributeName( "filteredLights" );
+IECore::InternedString g_filteredLightsExclusionsAttributeName( "filteredLights:exclusions" );
 IECore::InternedString g_defaultLightsSetName( "defaultLights" );
 IECore::InternedString g_shadowedLightsAttributeName( "shadowedLights" );
 IECore::InternedString g_shadowedLightsExclusionsAttributeName( "shadowedLights:exclusions" );
@@ -1233,8 +1234,26 @@ void LightLinks::clearLightLinks()
 
 std::string LightLinks::filteredLightsExpression( const IECore::CompoundObject *attributes ) const
 {
-	const StringData *d = attributes->member<StringData>( g_filteredLightsAttributeName );
-	return d ? d->readable() : "";
+	if( const StringData *d = attributes->member<StringData>( g_filteredLightsAttributeName ) )
+	{
+		const std::string &filteredLights = d->readable();
+		if( isBlank( filteredLights ) )
+		{
+			return "";
+		}
+
+		if( const StringData *e = attributes->member<StringData>( g_filteredLightsExclusionsAttributeName ) )
+		{
+			const std::string &exclusions = e->readable();
+			if( !isBlank( exclusions ) )
+			{
+				return fmt::format( "({}) - ({})", filteredLights, exclusions );
+			}
+		}
+		return filteredLights;
+	}
+
+	return "";
 }
 
 void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::CompoundObject *attributes, IECoreScenePreview::Renderer::ObjectInterface *object, IECore::MurmurHash *hash ) const

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1038,6 +1038,7 @@ namespace
 {
 
 IECore::InternedString g_linkedLightsAttributeName( "linkedLights" );
+IECore::InternedString g_linkedLightsExclusionsAttributeName( "linkedLights:exclusions" );
 IECore::InternedString g_filteredLightsAttributeName( "filteredLights" );
 IECore::InternedString g_defaultLightsSetName( "defaultLights" );
 IECore::InternedString g_shadowedLightsAttributeName( "shadowedLights" );
@@ -1045,6 +1046,24 @@ IECore::InternedString g_shadowGroupAttributeName( "ai:visibility:shadow_group" 
 IECore::InternedString g_lights( "lights" );
 IECore::InternedString g_lightFilters( "lightFilters" );
 const std::string g_shadowedLightsDefaultValue( "__lights" );
+const std::string g_linkedLightsDefaultValue( "defaultLights" );
+const std::string g_emptyString;
+
+bool isBlank( const std::string &s )
+{
+	return s.find_first_not_of( " \t\n\r" ) == std::string::npos;
+}
+
+const std::string &subtractSetExpressions( const std::string &expression, const std::string &exclusions, std::string &storage )
+{
+	if( isBlank( expression ) || isBlank( exclusions ) )
+	{
+		return expression;
+	}
+
+	storage = fmt::format( "({}) - ({})", expression, exclusions );
+	return storage;
+}
 
 } // namespace
 
@@ -1220,18 +1239,22 @@ std::string LightLinks::filteredLightsExpression( const IECore::CompoundObject *
 void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::CompoundObject *attributes, IECoreScenePreview::Renderer::ObjectInterface *object, IECore::MurmurHash *hash ) const
 {
 	const StringData *linkedLightsExpressionData = attributes->member<StringData>( g_linkedLightsAttributeName );
+	const StringData *linkedLightsExclusionsExpressionData = attributes->member<StringData>( g_linkedLightsExclusionsAttributeName );
 	const StringData *shadowedLightsExpressionData = attributes->member<StringData>( g_shadowedLightsAttributeName );
 	if( !shadowedLightsExpressionData && m_shadowedLightsFallbackAttributeName )
 	{
 		shadowedLightsExpressionData = attributes->member<StringData>( *m_shadowedLightsFallbackAttributeName );
 	}
-	const std::string linkedLightsExpression = linkedLightsExpressionData ? linkedLightsExpressionData->readable() : "defaultLights";
+	const std::string &linkedLightsExpression = linkedLightsExpressionData ? linkedLightsExpressionData->readable() : g_linkedLightsDefaultValue;
+	const std::string &linkedLightsExclusions = linkedLightsExclusionsExpressionData ? linkedLightsExclusionsExpressionData->readable() : g_emptyString;
+
 	const std::string &shadowedLightsExpression = shadowedLightsExpressionData ? shadowedLightsExpressionData->readable() : g_shadowedLightsDefaultValue;
 
 	if( hash )
 	{
 		IECore::MurmurHash h;
 		h.append( linkedLightsExpression );
+		h.append( linkedLightsExclusions );
 		h.append( shadowedLightsExpression );
 		if( !m_lightLinksDirty && *hash == h )
 		{
@@ -1245,7 +1268,8 @@ void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::Compoun
 		*hash = h;
 	}
 
-	IECoreScenePreview::Renderer::ConstObjectSetPtr objectSet = linkedLights( linkedLightsExpression, scene );
+	std::string expressionStorage;
+	IECoreScenePreview::Renderer::ConstObjectSetPtr objectSet = linkedLights( subtractSetExpressions( linkedLightsExpression, linkedLightsExclusions, expressionStorage ), scene );
 	object->link( g_lights, objectSet );
 	objectSet = linkedLights( shadowedLightsExpression, scene );
 	object->link( g_shadowedLightsAttributeName, objectSet );

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1042,6 +1042,7 @@ IECore::InternedString g_linkedLightsExclusionsAttributeName( "linkedLights:excl
 IECore::InternedString g_filteredLightsAttributeName( "filteredLights" );
 IECore::InternedString g_defaultLightsSetName( "defaultLights" );
 IECore::InternedString g_shadowedLightsAttributeName( "shadowedLights" );
+IECore::InternedString g_shadowedLightsExclusionsAttributeName( "shadowedLights:exclusions" );
 IECore::InternedString g_shadowGroupAttributeName( "ai:visibility:shadow_group" );
 IECore::InternedString g_lights( "lights" );
 IECore::InternedString g_lightFilters( "lightFilters" );
@@ -1241,6 +1242,7 @@ void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::Compoun
 	const StringData *linkedLightsExpressionData = attributes->member<StringData>( g_linkedLightsAttributeName );
 	const StringData *linkedLightsExclusionsExpressionData = attributes->member<StringData>( g_linkedLightsExclusionsAttributeName );
 	const StringData *shadowedLightsExpressionData = attributes->member<StringData>( g_shadowedLightsAttributeName );
+	const StringData *shadowedLightsExclusionsExpressionData = attributes->member<StringData>( g_shadowedLightsExclusionsAttributeName );
 	if( !shadowedLightsExpressionData && m_shadowedLightsFallbackAttributeName )
 	{
 		shadowedLightsExpressionData = attributes->member<StringData>( *m_shadowedLightsFallbackAttributeName );
@@ -1249,6 +1251,7 @@ void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::Compoun
 	const std::string &linkedLightsExclusions = linkedLightsExclusionsExpressionData ? linkedLightsExclusionsExpressionData->readable() : g_emptyString;
 
 	const std::string &shadowedLightsExpression = shadowedLightsExpressionData ? shadowedLightsExpressionData->readable() : g_shadowedLightsDefaultValue;
+	const std::string &shadowedLightsExclusions = shadowedLightsExclusionsExpressionData ? shadowedLightsExclusionsExpressionData->readable() : g_emptyString;
 
 	if( hash )
 	{
@@ -1256,6 +1259,7 @@ void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::Compoun
 		h.append( linkedLightsExpression );
 		h.append( linkedLightsExclusions );
 		h.append( shadowedLightsExpression );
+		h.append( shadowedLightsExclusions );
 		if( !m_lightLinksDirty && *hash == h )
 		{
 			// We're only being called because the attributes have changed as a whole, but the
@@ -1271,7 +1275,7 @@ void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::Compoun
 	std::string expressionStorage;
 	IECoreScenePreview::Renderer::ConstObjectSetPtr objectSet = linkedLights( subtractSetExpressions( linkedLightsExpression, linkedLightsExclusions, expressionStorage ), scene );
 	object->link( g_lights, objectSet );
-	objectSet = linkedLights( shadowedLightsExpression, scene );
+	objectSet = linkedLights( subtractSetExpressions( shadowedLightsExpression, shadowedLightsExclusions, expressionStorage ), scene );
 	object->link( g_shadowedLightsAttributeName, objectSet );
 }
 

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -1288,6 +1288,9 @@ namespace
 
 InternedString g_lights( "__lights" );
 InternedString g_linkedLights( "linkedLights" );
+InternedString g_linkedLightsExclusions( "linkedLights:exclusions" );
+const std::string g_linkedLightsDefaultValue( "defaultLights" );
+const std::string g_emptyString;
 
 template<typename AttributesPredicate>
 struct AttributesFinder
@@ -1369,6 +1372,25 @@ IECore::PathMatcher findAttributes( const ScenePlug *scene, const AttributesPred
 	return result;
 }
 
+std::string linkedLightsExpression( const CompoundObject *attributes )
+{
+	auto *linkedLightsAttribute = attributes->member<StringData>( g_linkedLights );
+	const string &linkedLights = linkedLightsAttribute ? linkedLightsAttribute->readable() : g_linkedLightsDefaultValue;
+	if( linkedLights.find_first_not_of( " \t\n\r" ) == std::string::npos )
+	{
+		return linkedLights;
+	}
+
+	auto *excludedLightsAttribute = attributes->member<StringData>( g_linkedLightsExclusions );
+	const string &excludedLights = excludedLightsAttribute ? excludedLightsAttribute->readable() : g_emptyString;
+	if( excludedLights.find_first_not_of( " \t\n\r" ) == std::string::npos )
+	{
+		return linkedLights;
+	}
+
+	return fmt::format( "({}) - ({})", linkedLights, excludedLights );
+}
+
 } // namespace
 
 IECore::PathMatcher GafferScene::SceneAlgo::linkedObjects( const ScenePlug *scene, const ScenePlug::ScenePath &light )
@@ -1406,8 +1428,7 @@ GAFFERSCENE_API IECore::PathMatcher GafferScene::SceneAlgo::linkedObjects( const
 	IECore::PathMatcher result = findAttributes(
 		scene,
 		[&queryCache] ( const CompoundObject *fullAttributes ) {
-			auto *linkedLights = fullAttributes->member<StringData>( g_linkedLights );
-			return queryCache.get( linkedLights ? linkedLights->readable() : "defaultLights" );
+			return queryCache.get( linkedLightsExpression( fullAttributes ) );
 		}
 	);
 
@@ -1418,9 +1439,7 @@ GAFFERSCENE_API IECore::PathMatcher GafferScene::SceneAlgo::linkedObjects( const
 IECore::PathMatcher GafferScene::SceneAlgo::linkedLights( const ScenePlug *scene, const ScenePlug::ScenePath &object )
 {
 	IECore::ConstCompoundObjectPtr attributes = scene->fullAttributes( object );
-	auto *linkedLightsAttribute = attributes->member<StringData>( g_linkedLights );
-	const string linkedLights = linkedLightsAttribute ? linkedLightsAttribute->readable() : "defaultLights";
-	IECore::PathMatcher linkedPaths = SetAlgo::evaluateSetExpression( linkedLights, scene );
+	IECore::PathMatcher linkedPaths = SetAlgo::evaluateSetExpression( linkedLightsExpression( attributes.get() ), scene );
 	return linkedPaths.intersection( scene->set( g_lights )->readable() );
 }
 
@@ -1432,8 +1451,7 @@ IECore::PathMatcher GafferScene::SceneAlgo::linkedLights( const ScenePlug *scene
 
 	auto functor = [&resultMutex, &result, &processed] ( const ScenePlug *scene, const ScenePlug::ScenePath &path ) {
 		IECore::ConstCompoundObjectPtr attributes = scene->fullAttributes( path );
-		auto *linkedLightsAttribute = attributes->member<StringData>( g_linkedLights );
-		const string linkedLights = linkedLightsAttribute ? linkedLightsAttribute->readable() : "defaultLights";
+		const string linkedLights = linkedLightsExpression( attributes.get() );
 		if( processed.insert( linkedLights ).second )
 		{
 			ScenePlug::GlobalScope globalScope( Context::current() );

--- a/src/GafferScene/StandardAttributes.cpp
+++ b/src/GafferScene/StandardAttributes.cpp
@@ -48,7 +48,8 @@ namespace
 const IECore::InternedString g_defaultValue( "defaultValue" );
 const std::string g_metadataTargets(
 	"attribute:scene:visible attribute:doubleSided attribute:render:* attribute:gaffer:* " \
-	"attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights attribute:shadowedLights:exclusions attribute:filteredLights"
+	"attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights attribute:shadowedLights:exclusions " \
+	"attribute:filteredLights attribute:filteredLights:exclusions"
 );
 
 } // namespace

--- a/src/GafferScene/StandardAttributes.cpp
+++ b/src/GafferScene/StandardAttributes.cpp
@@ -48,7 +48,7 @@ namespace
 const IECore::InternedString g_defaultValue( "defaultValue" );
 const std::string g_metadataTargets(
 	"attribute:scene:visible attribute:doubleSided attribute:render:* attribute:gaffer:* " \
-	"attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights attribute:filteredLights"
+	"attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights attribute:shadowedLights:exclusions attribute:filteredLights"
 );
 
 } // namespace

--- a/src/GafferScene/StandardAttributes.cpp
+++ b/src/GafferScene/StandardAttributes.cpp
@@ -48,7 +48,7 @@ namespace
 const IECore::InternedString g_defaultValue( "defaultValue" );
 const std::string g_metadataTargets(
 	"attribute:scene:visible attribute:doubleSided attribute:render:* attribute:gaffer:* " \
-	"attribute:linkedLights attribute:shadowedLights attribute:filteredLights"
+	"attribute:linkedLights attribute:linkedLights:exclusions attribute:shadowedLights attribute:filteredLights"
 );
 
 } // namespace

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -198,6 +198,7 @@ Gaffer::ValuePlugPtr attributePlug( const Gaffer::CompoundDataPlug *parentPlug, 
 
 static InternedString g_lightMuteAttributeName( "light:mute" );
 static InternedString g_filteredLightsAttributeName( "filteredLights");
+static InternedString g_filteredLightsExclusionsAttributeName( "filteredLights:exclusions");
 
 IE_CORE_DEFINERUNTIMETYPED( AttributeInspector )
 
@@ -295,6 +296,10 @@ Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::H
 		if( m_attribute == g_filteredLightsAttributeName )
 		{
 			return lightFilter->filteredLightsPlug();
+		}
+		if( m_attribute == g_filteredLightsExclusionsAttributeName )
+		{
+			return lightFilter->filteredLightsExclusionsPlug();
 		}
 		return nullptr;
 	}

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -281,6 +281,25 @@ Gaffer.Metadata.registerValues( {
 
 	},
 
+	"attribute:filteredLights:exclusions" : {
+
+		"defaultValue" : "",
+		"description" :
+		"""
+		The lights that are never filtered by this light filter, even when they
+		are included by the `filteredLights` attribute. Accepts a set expression
+		or a space separated list of lights. Has no effect unless `filteredLights`
+		specifies lights to be filtered.
+		""",
+		"category" : "Standard",
+		"label" : "Filtered Lights Exclusions",
+		"layout:section" : "Light Linking",
+
+		"plugValueWidget:type" : "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression" : True,
+
+	},
+
 	"attribute:gaffer:automaticInstancing" : {
 
 		"defaultValue" : True,

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -274,7 +274,7 @@ Gaffer.Metadata.registerValues( {
 		""",
 		"category" : "Standard",
 		"label" : "Filtered Lights",
-		"layout:section" : "Light Linking",
+		"layout:section" : "Light Filters",
 
 		"plugValueWidget:type" : "GafferSceneUI.SetExpressionPlugValueWidget",
 		"ui:scene:acceptsSetExpression" : True,
@@ -293,7 +293,7 @@ Gaffer.Metadata.registerValues( {
 		""",
 		"category" : "Standard",
 		"label" : "Filtered Lights Exclusions",
-		"layout:section" : "Light Linking",
+		"layout:section" : "Light Filters",
 
 		"plugValueWidget:type" : "GafferSceneUI.SetExpressionPlugValueWidget",
 		"ui:scene:acceptsSetExpression" : True,

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -201,6 +201,28 @@ Gaffer.Metadata.registerValues( {
 
 	},
 
+	"attribute:linkedLights:exclusions" : {
+
+		"defaultValue" : "",
+		"description" :
+		"""
+		The lights never to be linked to this object, even when they are
+		included by the `linkedLights` attribute. Accepts a set expression
+		or a space separated list of lights.
+
+		> Tip : Since `linkedLights` defaults to \"defaultLights\",
+		> exclusions take effect even when no `linkedLights`
+		> attribute has been created.
+		""",
+		"category" : "Standard",
+		"label" : "Linked Lights Exclusions",
+		"layout:section" : "Light Linking",
+
+		"plugValueWidget:type" : "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression" : True
+
+	},
+
 	"attribute:shadowedLights" : {
 
 		"defaultValue" : "__lights",

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -240,6 +240,28 @@ Gaffer.Metadata.registerValues( {
 
 	},
 
+	"attribute:shadowedLights:exclusions" : {
+
+		"defaultValue" : "",
+		"description" :
+		"""
+		The lights that never cast shadows from this object, even when they are
+		included by the `shadowedLights` attribute. Accepts a set expression or
+		a space separated list of lights.
+
+		> Tip : Since `shadowedLights` defaults to \"__lights\", exclusions
+		> take effect even when no `shadowedLights` attribute has been
+		> created.
+		""",
+		"category" : "Standard",
+		"label" : "Shadowed Lights Exclusions",
+		"layout:section" : "Light Linking",
+
+		"plugValueWidget:type" : "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression" : True,
+
+	},
+
 	"attribute:filteredLights" : {
 
 		"defaultValue" : "",

--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -208,6 +208,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	GafferSceneUI.LightEditor.registerShaderParameter( "ai:light", "axis", "ai:lightFilter:filter", "Blocker", "Falloff Axis" )
 	GafferSceneUI.LightEditor.registerShaderParameter( "ai:light", "shader", "ai:lightFilter:filter", "Blocker" )
 	GafferSceneUI.LightEditor.registerAttribute( "ai:light", "filteredLights", "Blocker" )
+	GafferSceneUI.LightEditor.registerAttribute( "ai:light", "filteredLights:exclusions", "Blocker" )
 
 	GafferSceneUI.LightEditor.registerShaderParameter( "ai:light", "use_near_atten", "ai:lightFilter:light_decay", "Decay", "Near Enable" )
 	GafferSceneUI.LightEditor.registerShaderParameter( "ai:light", "use_far_atten", "ai:lightFilter:light_decay", "Decay", "Far Enable" )


### PR DESCRIPTION
This PR adds new ":exclusions" counterparts to the `linkedLights`, `shadowedLights` and `filteredLights` attributes. These give users additional flexibility to manage exclusions independently of inclusions, like we do for the `render:inclusions`/`render:exclusions` options, etc. These attributes will be presented as columns in an upcoming Light Linking Editor.