### PR TITLE
CI : Update build container to 4.0.0a2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,12 +45,12 @@ jobs:
             os: ubuntu-24.04
             buildType: RELEASE
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:3.4.0
+            containerImage: ghcr.io/gafferhq/build/build:4.0.0a2
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
             # test user rather than as root.
-            testRunner: sudo -E -u testUser
+            testRunner: runuser -u testUser --
             sconsCacheMegabytes: 400
             jobs: 4
 
@@ -58,8 +58,8 @@ jobs:
             os: ubuntu-24.04
             buildType: DEBUG
             publish: false
-            containerImage: ghcr.io/gafferhq/build/build:3.4.0
-            testRunner: sudo -E -u testUser
+            containerImage: ghcr.io/gafferhq/build/build:4.0.0a2
+            testRunner: runuser -u testUser --
             testArguments: -excludedCategories performance
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -75,7 +75,7 @@ jobs:
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
             # test user rather than as root.
-            testRunner: sudo -E -u testUser
+            testRunner: runuser -u testUser --
             sconsCacheMegabytes: 400
             jobs: 4
             dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a11/cortex-10.7.0.0a11-linux-platform24.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
         brew remove --cask --force $(brew list)
         # Install build requirements.
         brew install pipx
-        pipx install scons==4.6.0
+        pipx install scons==4.10.1
         # Install docs dependencies matching the versions specified in the
         # linux build container.
         sudo pip3 install setuptools==81.0.0 sphinx==4.3.1 sphinx_rtd_theme==1.0.0 myst-parser==0.15.2 docutils==0.17.1 sphinxcontrib-applehelp==1.0.4 sphinxcontrib-devhelp==1.0.2 sphinxcontrib-htmlhelp==2.0.1 sphinxcontrib-jsmath==1.0.1 sphinxcontrib-serializinghtml==1.1.5 sphinxcontrib-qthelp==1.0.3 --break-system-packages


### PR DESCRIPTION
This updates to the slimmed down container already used to build gafferDependencies-11.x.x-linux-platform25 and cortex-10.7.x.x-linux-platform25 releases. We'll eventually need to make a final `build:4.0.0` container release in preparation of a 1.7 stable release, but that container should be equivalent to what we're updating to here. 

This new container runs into some strange and hard to debug PAM authentication issues while attempting to run `sudo` on CI. The same container run locally has no issues with `sudo`, so rather than dive into that CI rabbit-hole, I've switched to using [runuser](https://www.linux.org/docs/man1/runuser.html) instead of `sudo`. `runuser` lets root run commands under a substitute uid/gid without the additional authentication hoops of `sudo`.