### PR TITLE
DataStore

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ API
 
 - GraphEditor : Added an optional argument to `nodeContextMenuSignal()` to request a signal that will pass a list of nodes to the handler, rather than a single node. This can be used to register menu items that will act on multiple nodes.
 - Spreadsheet : Added support for `spreadsheet:outputRowVisible` metadata, which can be used to hide the output row.
+- TestCase : Added alternateMountTemporaryDirectory() for testing behaviour when moving files between directories on different filesystems.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Breaking Changes
 ----------------
 
 - RenderMan : Changed the default values used for PxrCryptomatte's material output.
+- ScriptNode : Changed preconditions for calling `serialiseToFile`. If the desired behaviour is that the ScriptNode in memory will be now be associated with the new file ( ie. a saveAs operation ), then the caller is responsible for setting `ScriptNode.fileNamePlug()` to the new file name before calling `serialiseToFile`.
 
 1.7.0.0a8 (relative to 1.7.0.0a7)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Fixes
 - ScriptNode :
   - Fixed context updates for `variables` plugs with an input connection.
   - Prevented invalid input connections to `variables` plugs. Connections from node outputs are considered invalid because they could create a circular dependency between context variables.
+- EditMenu : Added popup dialogue when errors occur during "cut" or "copy" operations.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - QuantizePrimitiveVariables : Added new node for quantizing the values of primitive variables.
+- DataStore : Added new node for storing large data alongside a Gaffer script, which is more efficient than storing large data inside the script file. Data is stored on the DataStore node by calling setEntry, instead of setting plug values. This node will be used as a basis of future tools that create data within Gaffer ( such as paint tools ).
 
 Improvements
 ------------

--- a/include/Gaffer/DataStore.h
+++ b/include/Gaffer/DataStore.h
@@ -1,0 +1,169 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Gaffer/ComputeNode.h"
+
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+#include "IECore/MurmurHash.h"
+
+#include "tbb/spin_rw_mutex.h"
+
+#include <unordered_set>
+
+namespace GafferModule
+{
+
+// Forward declaration for friendship declared below.
+// We don't include DataSToreBinding.h because we don't want
+// python involved in any way when building the pure C++
+// modules.
+struct DataStoreWrapperFunctionContainer;
+struct DataStoreSerialisationTracker;
+class DataStoreSerialiser;
+
+} // namespace GafferModule
+
+
+namespace Gaffer
+{
+
+class GAFFER_API DataStore : public ComputeNode
+{
+
+	public :
+
+		explicit DataStore( const std::string &name=defaultName<ComputeNode>() );
+		~DataStore() override;
+
+		GAFFER_NODE_DECLARE_TYPE( Gaffer::DataStore, DataStoreTypeId, ComputeNode );
+
+		StringPlug *selectorPlug();
+		const StringPlug *selectorPlug() const;
+
+		ObjectPlug *outPlug();
+		const ObjectPlug *outPlug() const;
+
+		StringVectorDataPlug *keysPlug();
+		const StringVectorDataPlug *keysPlug() const;
+
+		virtual void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+		// The data is stored as key/value pairs called entries. They can be set, removed, and gotten.
+		void setEntry( const std::string &key, IECore::ConstObjectPtr value );
+		void removeEntry( const std::string &key );
+		IECore::ConstObjectPtr getEntry( const std::string &key, bool throwExceptions = true ) const;
+
+		// Check whether the value for this key is being held in dedicated memory by this DataStore.
+		// If false, it is stored on disk, and only held in memory by the standard ValuePlug cache,
+		// where it can be freed if the memory is needed for other things.
+		bool isLive( const std::string &key ) const;
+
+	protected :
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
+
+		// Used during deserialisation to load all the entries which were previously set
+		friend struct GafferModule::DataStoreWrapperFunctionContainer;
+		void loadEntries( const std::map< std::string, IECore::MurmurHash > &entries, const std::string &loadFrom = "" );
+
+	private :
+
+		class SetEntryAction;
+
+		// This is incremented by setEntry so that the hash cache will pick up the update.
+		IntPlug *refreshCountPlug();
+		const IntPlug *refreshCountPlug() const;
+
+		// Evaluate the entry for a key in the context - used by getEntry, and the output plugs.
+		ObjectPlug *evaluatePlug();
+		const ObjectPlug *evaluatePlug() const;
+
+
+		struct Entry
+		{
+			IECore::MurmurHash m_hash;
+			mutable IECore::ConstObjectPtr m_liveValue;
+		};
+
+		std::unordered_map<std::string, Entry> m_entries;
+
+		// The live values are cleared after being saved, which can be triggered from a background
+		// thread, so we need a mutex to protect them.
+		mutable tbb::spin_rw_mutex m_entriesLiveValueMutex;
+
+		void setEntryInternal( const std::string &key, const std::optional<Entry> &value );
+
+		// The directory manager handles the directory where we can find values for any entries that
+		// aren't live.
+		class DirectoryManager;
+		mutable std::shared_ptr<DirectoryManager> m_sourceDirectory;
+
+		static std::shared_ptr<DirectoryManager> acquireDirectoryManager( const std::filesystem::path &scriptPath );
+
+
+		// DataStoreSerialiser needs access to m_entries and checkSaved()
+		friend class GafferModule::DataStoreSerialiser;
+
+		// If there isn't a data store directory associated with serialisation, then we need to make sure
+		// everything is already saved.
+		void checkSaved() const;
+
+		// DataStoreSerialisationTracker needs access to these private functions
+		friend struct GafferModule::DataStoreSerialisationTracker;
+
+		// Implement the actual saving of all entries for this node, and update usedDataHashes
+		void save( const std::filesystem::path &scriptPath, const GraphComponent *serialisationParent, std::unordered_set< IECore::MurmurHash > &usedDataHashes ) const;
+
+		// When we finish writing a data store directory, we remove files for entries that are no longer used,
+		// either deleting them, or placing them in a recycle bin if they could be needed by an undo in the future.
+		static void finaliseDirectory(
+			const std::filesystem::path &scriptPath, const GraphComponent *serialisationParent,
+			const std::unordered_set< IECore::MurmurHash > &usedDataHashes
+		);
+
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( DataStore );
+
+} // namespace Gaffer

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -199,6 +199,11 @@ class GAFFER_API ScriptNode : public Node
 		/// serialised nodes to those contained in the set.
 		std::string serialise( const Node *parent = nullptr, const Set *filter = nullptr ) const;
 		/// Calls serialise() and saves the result into the specified file.
+		/// Note : If you intend for this to have the effect of a "saveAs", where the open
+		/// script will now correspond to the newly saved file, then you should set
+		/// fileNamePlug() to the new fileName before calling this. Failing to do this can
+		/// result in DataStore nodes still pointing to the old files, and somewhat weird
+		/// corner case behaviour.
 		void serialiseToFile( const std::filesystem::path &fileName, const Node *parent = nullptr, const Set *filter = nullptr ) const;
 		/// Executes a previously generated serialisation. If continueOnError is true, then
 		/// errors are reported via IECore::MessageHandler rather than as exceptions, and

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -342,8 +342,8 @@ class GAFFER_API ScriptNode : public Node
 		// Serialisation and execution
 		// ===========================
 
-		std::string serialiseInternal( const Node *parent, const Set *filter ) const;
-		bool executeInternal( const std::string &serialisation, Node *parent, bool continueOnError, const std::string &context = "" );
+		std::string serialiseInternal( const Node *parent, const Set *filter, const std::filesystem::path *filePath = nullptr ) const;
+		bool executeInternal( const std::string &serialisation, Node *parent, bool continueOnError, const std::filesystem::path *sourceFile = nullptr );
 
 		using SerialiseFunction = std::function<std::string ( const Node *, const Set * )>;
 		using ExecuteFunction = std::function<bool ( ScriptNode *, const std::string &, Node *, bool, const std::string & )>;

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -155,6 +155,8 @@ enum TypeId
 	Box2fVectorDataPlugTypeId = 118109,
 	PatternMatchTypeId = 118110,
 	Int64VectorDataPlugTypeId = 118111,
+	DataStoreTypeId = 118112,
+	DataStoreSetEntryActionTypeId = 118113,
 
 	LastTypeId = 118799
 

--- a/include/GafferBindings/Serialisation.h
+++ b/include/GafferBindings/Serialisation.h
@@ -41,6 +41,7 @@
 
 #include "Gaffer/GraphComponent.h"
 #include "Gaffer/Set.h"
+#include "Gaffer/Signals.h"
 
 #include "IECore/Canceller.h"
 #include "IECore/Object.h"
@@ -98,6 +99,11 @@ class GAFFERBINDINGS_API Serialisation : boost::noncopyable
 		static std::string objectToBase64( const IECore::Object *object );
 		/// Creates an object from a string previously encoded with `objectToBase64()`.
 		static IECore::ObjectPtr objectFromBase64( const std::string &base64 );
+
+		using PostSerialisationSignal = Gaffer::Signals::Signal<void ( const Serialisation *, bool ) >;
+		/// This signal is emitted when Serialisation is finished. The bool argument indicates whether
+		/// the serialisation was successful.
+		PostSerialisationSignal &postSerialisationSignal();
 
 		/// The Serialiser class may be implemented differently for specific types to customise
 		/// their serialisation.
@@ -170,6 +176,8 @@ class GAFFERBINDINGS_API Serialisation : boost::noncopyable
 		std::set<std::string> m_modules;
 
 		void walk( const Gaffer::GraphComponent *parent, const std::string &parentIdentifier, const Serialiser *parentSerialiser, const IECore::Canceller *canceller );
+
+		PostSerialisationSignal m_postSerialisationSignal;
 
 		using SerialiserMap = std::map<IECore::TypeId, SerialiserPtr>;
 		static SerialiserMap &serialiserMap();

--- a/python/GafferDispatchTest/CopyFilesTest.py
+++ b/python/GafferDispatchTest/CopyFilesTest.py
@@ -48,57 +48,13 @@ import GafferTest
 
 class CopyFilesTest( GafferTest.TestCase ) :
 
-	@classmethod
-	def setUpClass( cls ) :
-
-		GafferTest.TestCase.setUpClass()
-
-		if sys.platform == "darwin" :
-			cls.__ramDisk = pathlib.Path( "/Volumes/GafferTest" )
-			assert( not cls.__ramDisk.exists() )
-			image = subprocess.check_output( [ "hdiutil", "attach", "-nomount", "ram://1024" ] ).strip()
-			subprocess.check_call( [ "diskutil", "erasevolume", "HFS+", "GafferTest", image ] )
-		elif sys.platform == "linux" :
-			cls.__ramDisk = pathlib.Path( "/dev/shm/GafferTest" )
-			assert( not cls.__ramDisk.exists() )
-			cls.__ramDisk.mkdir()
-		else :
-			cls.__ramDisk = None
-
-	@classmethod
-	def tearDownClass( cls ) :
-
-		GafferTest.TestCase.tearDownClass()
-
-		if sys.platform == "darwin" :
-			subprocess.check_call( [ "hdiutil", "detach", cls.__ramDisk ] )
-		elif sys.platform == "linux" :
-			shutil.rmtree( cls.__ramDisk )
-
-	def setUp( self ) :
-
-		GafferTest.TestCase.setUp( self )
-
-		if self.__ramDisk is not None :
-			self.__temporaryRAMDirectory = pathlib.Path( self.__ramDisk ) / "copyFilesTest"
-			self.__temporaryRAMDirectory.mkdir()
-		else :
-			self.__temporaryRAMDirectory = None
-
-	def tearDown( self ) :
-
-		GafferTest.TestCase.tearDown( self )
-
-		if self.__temporaryRAMDirectory is not None :
-			shutil.rmtree( self.__temporaryRAMDirectory )
-
 	def __sourceDirectories( self ) :
 
 		# We run every test with two different source directories, with one
-		# of them being on a RAM-based filesystem. This gives us test coverage
+		# of them being on a different mount. This gives us test coverage
 		# for the inability of `filesystem::rename()` to move files between file
 		# systems.
-		return [ self.temporaryDirectory() ] + [ self.__temporaryRAMDirectory ] if self.__temporaryRAMDirectory is not None else []
+		return [ self.temporaryDirectory(), self.alternateMountTemporaryDirectory() ]
 
 	def testMissingDestinationDirectory( self ) :
 
@@ -165,7 +121,7 @@ class CopyFilesTest( GafferTest.TestCase ) :
 
 				self.assertFalse( node["overwrite"].getValue() )
 
-				with self.assertRaisesRegex( RuntimeError, "File exists" ) :
+				with self.assertRaisesRegex( RuntimeError, "[Ff]ile exists" ) :
 					node["task"].execute()
 				self.assertEqual( destinationFile.read_text(), "" )
 
@@ -186,7 +142,19 @@ class CopyFilesTest( GafferTest.TestCase ) :
 				source.write_text( "Test" )
 
 				destinationDir = self.temporaryDirectory() / "destination"
-				destinationDir.mkdir( mode = os.O_RDONLY, exist_ok = True )
+				destinationDir.mkdir( exist_ok = True )
+
+				# Make the directory have no write permissions ( easy on other OSes,
+				# requires a weird incantation on Windows where setting a directory
+				# read only doesn't stop writing to it )
+				if os.name != "nt" :
+					destinationDir.chmod( 444 )
+				else :
+					subprocess.check_call(
+						[ "icacls", destinationDir, "/deny", "Users:(OI)(CI)(W)" ],
+						stdout = subprocess.DEVNULL,
+						stderr = subprocess.STDOUT
+					)
 
 				node = GafferDispatch.CopyFiles()
 				node["files"].setValue( IECore.StringVectorData( [ str( source ) ] ) )
@@ -194,7 +162,7 @@ class CopyFilesTest( GafferTest.TestCase ) :
 				node["overwrite"].setValue( True )
 				node["deleteSource"].setValue( True )
 
-				with self.assertRaisesRegex( RuntimeError, "Permission denied" ) :
+				with self.assertRaisesRegex( RuntimeError, "(Permission|Access is) denied" ) :
 					node["task"].execute()
 
 				self.assertTrue( source.exists() )

--- a/python/GafferTest/BadNode.py
+++ b/python/GafferTest/BadNode.py
@@ -41,9 +41,11 @@ import Gaffer
 
 class BadNode( Gaffer.ComputeNode ) :
 
-	def __init__( self, name="BadNode" ) :
+	def __init__( self, name="BadNode", serialiseThrows = False ) :
 
 		Gaffer.ComputeNode.__init__( self, name )
+
+		self.__serialiseThrows = serialiseThrows
 
 		self.addChild( Gaffer.IntPlug( "in1", Gaffer.Plug.Direction.In ) )
 		self.addChild( Gaffer.IntPlug( "in2", Gaffer.Plug.Direction.In ) )
@@ -86,5 +88,16 @@ class BadNode( Gaffer.ComputeNode ) :
 			# bad - don't do anything
 			pass
 
+	def checkSerialise( self ):
+		if self.__serialiseThrows:
+			raise Exception( "Testing failure during serialise" )
+
 
 IECore.registerRunTimeTyped( BadNode, "GafferTest::BadNode" )
+
+class BadNodeSerialiser( Gaffer.NodeSerialiser ) :
+	def constructor( self, graphComponent, serialisation ) :
+		graphComponent.checkSerialise()
+		return super( BadNodeSerialiser, self ).constructor( graphComponent, serialisation )
+
+Gaffer.Serialisation.registerSerialiser( BadNode, BadNodeSerialiser() )

--- a/python/GafferTest/DataStoreTest.py
+++ b/python/GafferTest/DataStoreTest.py
@@ -1,0 +1,839 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import inspect
+import os
+import pathlib
+import random
+import shutil
+import tempfile
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferDispatch
+import GafferTest
+
+class DataStoreTest( GafferTest.TestCase ) :
+
+	def setupComparison( self, s ) :
+		s["dataStore"] = Gaffer.DataStore()
+		s["compareBox"] = Gaffer.Box()
+		s["compareBox"]["compound"] = Gaffer.CompoundDataPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+	def comparisonSetEntry( self, s, key, value ) :
+		if value is None:
+			s["dataStore"].removeEntry( key )
+			del s["compareBox"]["compound"][key]
+		else:
+			s["dataStore"].setEntry( key, value )
+			s["compareBox"]["compound"].addMembers( IECore.CompoundData( { key : value } ), True )
+
+	def assertComparisonValid( self, s ) :
+		keys = set( s["dataStore"]["keys"].getValue() )
+
+		compoundData = IECore.CompoundData()
+		s["compareBox"]["compound"].fillCompoundData( compoundData )
+
+		self.assertEqual( keys, set( [ k for k in compoundData.keys() ] ) )
+
+		for k in keys:
+			self.assertEqual( s["dataStore"].getEntry( k ), compoundData[ k ] )
+
+	def assertSaved( self, s ) :
+
+		hashes = set()
+
+		for dataStore in Gaffer.DataStore.RecursiveRange( s ):
+
+			keys = set( dataStore["keys"].getValue() )
+			for k in keys:
+				hashes.add( dataStore.getEntry( k ).hash() )
+				self.assertFalse( dataStore.isLive( k ) )
+
+		storeDir = s["fileName"].getValue() + ".dataStore"
+		entryFiles = set()
+		if not os.path.exists( storeDir ):
+			# If the store dir doesn't exist, that is equivalent to having an empty store dir
+			# One is the situation if a script has never had data stores, one is the situation if
+			# all data stores have been deleted, either is fine, if it corresponds to a script with
+			# no data stores.
+			pass
+		else:
+			entryFiles = set( os.listdir( storeDir ) )
+
+		expectedEntryFiles = set( [ "%s.cob" % h.toString() for h in hashes ] )
+		# We can ignore a .recycleBin - it will be deleted when the ScriptNode is freed
+		if ".recycleBin" in entryFiles:
+			entryFiles.remove( ".recycleBin" )
+
+		self.assertEqual( entryFiles, expectedEntryFiles )
+
+	def testBasic( self ):
+
+		s = Gaffer.ScriptNode()
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 7 ) )
+		s["dataStore"].setEntry( "b", IECore.FloatData( 123.456 ) )
+		s["dataStore"].setEntry( "c", IECore.StringData( "Hello world" ) )
+
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( s["dataStore"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+		self.assertEqual( s["dataStore"].getEntry( "c" ), IECore.StringData( "Hello world" ) )
+
+		with self.assertRaisesRegex( IECore.Exception, "Unknown key: d" ) :
+			self.assertEqual( s["dataStore"].getEntry( "d" ), IECore.StringData( "Hello world" ) )
+		self.assertEqual( s["dataStore"].getEntry( "d", throwExceptions = False ), None )
+
+		s["dataStore"]["selector"].setValue( "a")
+		self.assertEqual( s["dataStore"]["out"].getValue(), IECore.IntData( 7 ) )
+		s["dataStore"]["selector"].setValue( "c")
+		self.assertEqual( s["dataStore"]["out"].getValue(), IECore.StringData( "Hello world" ) )
+		s["dataStore"]["selector"].setValue( "${contextVar}")
+
+		c = Gaffer.Context()
+		with c:
+			c["contextVar"] = IECore.StringData( "a" )
+			self.assertEqual( s["dataStore"]["out"].getValue(), IECore.IntData( 7 ) )
+			c["contextVar"] = IECore.StringData( "b" )
+			self.assertEqual( s["dataStore"]["out"].getValue(), IECore.FloatData( 123.456 ) )
+			c["contextVar"] = IECore.StringData( "d" )
+			with self.assertRaisesRegex( Gaffer.ProcessException, "Unknown key: d" ) :
+				s["dataStore"]["out"].getValue()
+
+
+		# After saving, the live values will be cleared, and values will be read from disk
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.save()
+		Gaffer.ValuePlug.clearCache()
+
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( s["dataStore"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+		self.assertEqual( s["dataStore"].getEntry( "c" ), IECore.StringData( "Hello world" ) )
+
+	def testComparison( self ):
+		# Test by comparing against values stored explicitly in the Gaffer script
+		s = Gaffer.ScriptNode()
+		self.setupComparison( s )
+		self.comparisonSetEntry( s, "a", IECore.IntData( 7 ) )
+		self.comparisonSetEntry( s, "b", IECore.FloatData( 123.456 ) )
+		self.comparisonSetEntry( s, "c", IECore.StringData( "Hello world" ) )
+		self.assertComparisonValid( s )
+
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.save()
+		self.assertComparisonValid( s )
+		self.assertSaved( s )
+
+		del s
+
+		self.assertFalse( os.path.exists( self.temporaryDirectory() / "test.gfr.dataStore" / ".recycleBin" ) )
+
+		# Test match after reopening
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.load()
+		self.assertComparisonValid( s )
+		self.assertSaved( s )
+
+		# Modify two entries, check that the old data stores get moved to the recycle bin
+		self.comparisonSetEntry( s, "a", IECore.IntData( 1 ) )
+		self.comparisonSetEntry( s, "b", IECore.FloatData( 2 ) )
+
+		s.save()
+		self.assertComparisonValid( s )
+		self.assertSaved( s )
+
+		self.assertTrue( os.path.exists( self.temporaryDirectory() / "test.gfr.dataStore" ) )
+		self.assertTrue( os.path.exists( self.temporaryDirectory() / "test.gfr.dataStore" / ".recycleBin" ) )
+		self.assertEqual( len( os.listdir( self.temporaryDirectory() / "test.gfr.dataStore" / ".recycleBin" ) ), 2 )
+
+		# Do another save, which moves another entry to the recycle bin
+		self.comparisonSetEntry( s, "a", IECore.IntData( 10000 ) )
+		self.assertComparisonValid( s )
+		s.save()
+		self.assertComparisonValid( s )
+		self.assertSaved( s )
+
+		self.assertEqual( len( os.listdir( self.temporaryDirectory() / "test.gfr.dataStore" / ".recycleBin" ) ), 3 )
+
+		del s
+
+		# Closing the script deletes the recycle bin
+		self.assertFalse( os.path.exists( self.temporaryDirectory() / "test.gfr.dataStore" / ".recycleBin" ) )
+
+		# Everything still loads fine
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.load()
+		self.assertComparisonValid( s )
+		self.assertSaved( s )
+
+	def testComparisonFuzz( self ):
+
+		# At any given time, there are 5 main actions that can be taken that affect DataStores in
+		# the current script:
+		# A) setting a new entry
+		# B) changing an existing entry
+		# C) undoing
+		# D) redoing
+		# E) changing the filename
+		# We can achieve a good mix of A and B just by choosing randomly from a small pool of possible options,
+		# and alternate between the other options by picking randomly.
+		# This allows us to generate a sequence of actions that should theoretically exercise all possibilities,
+		# which we can compare against an implementation that just saves values in the script.
+
+		s = Gaffer.ScriptNode()
+		self.setupComparison( s )
+
+		random.seed( 42 )
+
+		fileNameCount = 0
+		fileName = self.temporaryDirectory() / ( "test%i.gfr" % fileNameCount )
+		s["fileName"].setValue( fileName )
+
+		for i in range( 100 ):
+			if random.random() < 0.05:
+				fileNameCount += 1
+				fileName = self.temporaryDirectory() / ( "test%i.gfr" % fileNameCount )
+				s["fileName"].setValue( fileName )
+			elif s.redoAvailable() and random.random() < 0.7:
+				s.redo()
+			elif s.undoAvailable() and random.random() < 0.3:
+				s.undo()
+			else:
+				with Gaffer.UndoScope( s ) :
+					self.comparisonSetEntry( s, "a%i" % random.randint( 0, 6 ), IECore.IntData( random.randint( 0, 10000 ) ) )
+
+			self.assertComparisonValid( s )
+			s.save()
+			self.assertComparisonValid( s )
+			self.assertSaved( s )
+
+			loadS = Gaffer.ScriptNode()
+			loadS["fileName"].setValue( fileName )
+			loadS.load()
+			self.assertComparisonValid( loadS )
+			del loadS
+
+	def testMovingManyEntriesToRecycleBin( self ):
+		# Just wanted to double check that iterating the data store directory is working properly, by
+		# moving a whole bunch of files at once to the recycle bin
+		s = Gaffer.ScriptNode()
+		self.setupComparison( s )
+
+		for i in range( 1000 ):
+			self.comparisonSetEntry( s, "a%i"%i, IECore.IntData( 7 * i ) )
+
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		self.assertComparisonValid( s )
+		s.save()
+		self.assertComparisonValid( s )
+		self.assertSaved( s )
+
+		for i in range( 1000 ):
+			self.comparisonSetEntry( s, "a%i"%i, None )
+
+		self.comparisonSetEntry( s, "b", IECore.IntData( 4 ) )
+
+		self.assertEqual( s["dataStore"]["keys"].getValue(), IECore.StringVectorData( [ "b" ] ) )
+
+		self.assertComparisonValid( s )
+		s.save()
+		self.assertSaved( s )
+		self.assertEqual( len( os.listdir( self.temporaryDirectory() / "test.gfr.dataStore" / ".recycleBin" ) ), 1000 )
+
+	def testNotFound( self ):
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 77 ) )
+		s.save()
+		del s
+
+		# Test the error we get when the caches are deleted before reloading
+		shutil.rmtree( self.temporaryDirectory() / "test.gfr.dataStore" )
+		Gaffer.ValuePlug.clearCache()
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.load()
+
+		with self.assertRaisesRegex( IECore.Exception, r'Could not locate data store file .* in .*\.' ) :
+			s["dataStore"].getEntry( "a" )
+
+		s["fileName"].setValue( self.temporaryDirectory() / "test2.gfr" )
+
+		with self.assertRaisesRegex( IECore.Exception, 'Unable to save entry "a" on "ScriptNode.dataStore" - no live value, but cannot find on disk in directory ".*".' ) :
+			s.save()
+
+	def testSaveFails( self ):
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 77 ) )
+
+		# Add a node that will fail to serialise. Because it is added after the DataStore,
+		# the DataStore will be serialised before this triggers an exception.
+		s["badSerialise"] = GafferTest.BadNode( "badSerialise", True )
+
+		with self.assertRaisesRegex( IECore.Exception, 'Testing failure during serialise' ) :
+			s.save()
+
+		# We shouldn't write out data stores if serialisation fails
+		self.assertFalse( os.path.exists( self.temporaryDirectory() / "test.gfr.dataStore" ) )
+
+	def testHardLinks( self ):
+
+		# Test that if we hold a data store entry the same through several versions of a file, we
+		# keep a link back to the original instead of duplicating the file.
+		testValue = IECore.IntVectorData( [i for i in range( 100000 ) ] )
+		s = Gaffer.ScriptNode()
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", testValue )
+		s["fileName"].setValue( self.temporaryDirectory() / "file1.gfr" )
+		s.save()
+		s["fileName"].setValue( self.temporaryDirectory() / "file2.gfr" )
+		s.save()
+		del s
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "file2.gfr" )
+		s.load()
+		s["fileName"].setValue( self.temporaryDirectory() / "file3.gfr" )
+		s.save()
+		del s
+
+		self.assertEqual( os.stat( self.temporaryDirectory() / "file1.gfr.dataStore" / "2be6e2024a34d8808b87824ac350c907.cob" ).st_nlink, 3 )
+		self.assertEqual( os.stat( self.temporaryDirectory() / "file2.gfr.dataStore" / "2be6e2024a34d8808b87824ac350c907.cob" ).st_nlink, 3 )
+		self.assertEqual( os.stat( self.temporaryDirectory() / "file3.gfr.dataStore" / "2be6e2024a34d8808b87824ac350c907.cob" ).st_nlink, 3 )
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "file3.gfr" )
+		s.load()
+		self.assertEqual( s["dataStore"].getEntry( "a" ), testValue )
+		del s
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "file1.gfr" )
+		s.load()
+		self.assertEqual( s["dataStore"].getEntry( "a" ), testValue )
+		del s
+
+	def testUndo( self ):
+		s = Gaffer.ScriptNode()
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 7 ) )
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+
+		s["fileName"].setValue( self.temporaryDirectory() / "source.gfr" )
+		s.save()
+		del s
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "source.gfr" )
+		s.load()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+
+		with Gaffer.UndoScope( s ) :
+			s["dataStore"].setEntry( "a", IECore.IntData( 42 ) )
+
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 42 ) )
+
+		s.save()
+
+		s.undo()
+
+		# Test that we can reload the data from disk ( even though it's now coming from
+		# the recycle bin )
+		Gaffer.ValuePlug.clearCache()
+
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+
+		# Now try saving - we want this to get the hard link back out of the recycle bin,
+		# rather than saving a separate copy
+
+		s.save()
+
+		del s
+
+		self.assertEqual( os.stat( self.temporaryDirectory() / "source.gfr.dataStore" / "22b41848d90e4f05d50ab80c68957527.cob" ).st_nlink, 2 )
+		self.assertEqual( os.stat( self.temporaryDirectory() / "test.gfr.dataStore" / "22b41848d90e4f05d50ab80c68957527.cob" ).st_nlink, 2 )
+
+	def testManyRecycleBins( self ):
+
+		s = Gaffer.ScriptNode()
+		s["counter"] = Gaffer.IntPlug()
+		s["dataStore"] = Gaffer.DataStore()
+
+		for i in range( 10 ):
+			# Create a data store entry unique to each script we save as
+			with Gaffer.UndoScope( s ) :
+				s["dataStore"].setEntry( "a%i"%i, IECore.IntData( 1000 + i ) )
+
+			with Gaffer.UndoScope( s ) :
+				s["fileName"].setValue( self.temporaryDirectory() / ( "file%i.gfr" % i ) )
+			s.save()
+
+			# Change the entry so we move the previous value to the recycle bin
+			with Gaffer.UndoScope( s ) :
+				s["dataStore"].setEntry( "a%i"%i, IECore.IntData( 2000 + i ) )
+			s.save()
+
+		for i in range( 10 ):
+			# Each store dir should contain the entries so far, plus a recycle bin
+			self.assertEqual( len( os.listdir( self.temporaryDirectory() / ( "file%i.gfr.dataStore" % i ) ) ), 2 + i )
+			# Each recycle bin should contain one file
+			self.assertEqual( len( os.listdir( self.temporaryDirectory() / ( "file%i.gfr.dataStore" % i ) / ".recycleBin" ) ), 1 )
+
+		# Ensure that we're using the values from disk
+		Gaffer.ValuePlug.clearCache()
+
+		# Check the final values
+		for i in range( 10 ) :
+			self.assertEqual( s["dataStore"].getEntry( "a%i"%i ), IECore.IntData( 2000 + i ) )
+
+		# Run back through the undo stack getting all the values from the recycle bins
+		for i in reversed( range( 0, 10 ) ):
+			s.undo()
+
+			self.assertEqual( s["dataStore"].getEntry( "a%i"%i ), IECore.IntData( 1000 + i ) )
+
+			s.undo()
+			s.undo()
+
+		self.assertEqual( s["dataStore"]["keys"].getValue(), IECore.StringVectorData() )
+
+		# Redo everything
+		for i in range( 30 ):
+			s.redo()
+
+		self.assertEqual( set( s["dataStore"]["keys"].getValue() ), { "a%i"%i for i in range( 10 ) } )
+
+		for i in range( 10 ) :
+			self.assertEqual( s["dataStore"].getEntry( "a%i"%i ), IECore.IntData( 2000 + i ) )
+
+		# Run back through the undo stack getting all the values from the recycle bins, but this
+		# time we'll put new actions on the undo stack, forcing clearing of the undo stack
+
+
+		for i in reversed( range( 0, 10 ) ):
+			s.undo()
+
+			self.assertEqual( s["dataStore"].getEntry( "a%i"%i ), IECore.IntData( 1000 + i ) )
+
+			s.undo()
+
+			self.assertTrue( os.path.exists( self.temporaryDirectory() / ( "file%i.gfr.dataStore/.recycleBin" % i ) ) )
+
+			# Make a new edit, then immediately undo it, just to force the undo stack to be cleared
+			with Gaffer.UndoScope( s ) :
+				s["counter"].setValue( 10 + i )
+			s.undo()
+
+			s.undo()
+			self.assertFalse( os.path.exists( self.temporaryDirectory() / ( "file%i.gfr.dataStore/.recycleBin" % i ) ) )
+
+		self.assertEqual( s["dataStore"]["keys"].getValue(), IECore.StringVectorData() )
+
+	# We now require that you rename the .dataStore directory to match if you rename a script,
+	# so renaming just the script will fail.
+	@unittest.expectedFailure
+	def testRenameA( self ):
+		s = Gaffer.ScriptNode()
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 7 ) )
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.save()
+		del s
+
+		os.rename( self.temporaryDirectory() / "test.gfr", self.temporaryDirectory() / "renameA.gfr" )
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "renameA.gfr" )
+		s.load()
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+
+	def testRenameB( self ):
+		s = Gaffer.ScriptNode()
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 42 ) )
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.save()
+		del s
+
+		os.rename( self.temporaryDirectory() / "test.gfr", self.temporaryDirectory() / "renameB.gfr" )
+		os.rename( self.temporaryDirectory() / "test.gfr.dataStore", self.temporaryDirectory() / "renameB.gfr.dataStore" )
+
+		# If we move a file and its data store together, it should be able to find the new data locations when
+		# we load.
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "renameB.gfr" )
+		s.load()
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 42 ) )
+
+	def testCopyPasteWithin( self ):
+
+		app = Gaffer.ApplicationRoot()
+
+		s = Gaffer.ScriptNode()
+
+		app["scripts"]["s"] = s
+
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 7 ) )
+		s["dataStore"].setEntry( "b", IECore.FloatData( 123.456 ) )
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+
+		with self.assertRaisesRegex( IECore.Exception, 'Cannot copy, DataStore "ApplicationRoot.scripts.s.dataStore" is not saved yet.' ) :
+			s.copy()
+
+		s.save()
+
+		s.copy()
+
+		s.paste()
+
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( s["dataStore"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+		self.assertFalse( s["dataStore"].isLive( "a" ) )
+		self.assertFalse( s["dataStore"].isLive( "b" ) )
+		self.assertEqual( s["dataStore1"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( s["dataStore1"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+		self.assertFalse( s["dataStore1"].isLive( "a" ) )
+		self.assertFalse( s["dataStore1"].isLive( "b" ) )
+
+	def testCopyPasteBetween( self ):
+
+		app = Gaffer.ApplicationRoot()
+
+		s = Gaffer.ScriptNode()
+
+		app["scripts"]["s"] = s
+
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 7 ) )
+		s["dataStore"].setEntry( "b", IECore.FloatData( 123.456 ) )
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+
+		with self.assertRaisesRegex( IECore.Exception, 'Cannot copy, DataStore "ApplicationRoot.scripts.s.dataStore" is not saved yet.' ) :
+			s.copy()
+
+		s.save()
+		s.copy()
+		del s
+
+		t = Gaffer.ScriptNode()
+		app["scripts"]["t"] = t
+		t.paste()
+
+		self.assertEqual( t["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( t["dataStore"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+
+		t["fileName"].setValue( self.temporaryDirectory() / "copied.gfr" )
+		t.save()
+
+		# Check that we find the source files, and link back to them.
+		self.assertEqual( os.stat( self.temporaryDirectory() / "copied.gfr.dataStore" / "5f4ab9972edafa975a49cad56ad69070.cob" ).st_nlink, 2 )
+		self.assertEqual( os.stat( self.temporaryDirectory() / "copied.gfr.dataStore" / "22b41848d90e4f05d50ab80c68957527.cob" ).st_nlink, 2 )
+
+		del t
+
+		shutil.rmtree( self.temporaryDirectory() / "copied.gfr.dataStore" )
+
+		# Try again, but this time we delete the source files after loading. This could happen if the
+		# data stores were managed by another Gaffer session.
+		t = Gaffer.ScriptNode()
+		app["scripts"]["t"] = t
+		t.paste()
+
+		self.assertEqual( t["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( t["dataStore"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+
+		shutil.rmtree( self.temporaryDirectory() / "test.gfr.dataStore" )
+		Gaffer.ValuePlug.clearCache()
+
+		# We force loaded the data stores as soon as the paste happened, so the values are safe.
+		self.assertEqual( t["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( t["dataStore"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+
+		t["fileName"].setValue( self.temporaryDirectory() / "copied.gfr" )
+		t.save()
+
+		# But we can't link any more, since we can't find the sources on disk - but we can still correctly
+		# write from the data that was loaded
+		self.assertEqual( os.stat( self.temporaryDirectory() / "copied.gfr.dataStore" / "5f4ab9972edafa975a49cad56ad69070.cob" ).st_nlink, 1 )
+		self.assertEqual( os.stat( self.temporaryDirectory() / "copied.gfr.dataStore" / "22b41848d90e4f05d50ab80c68957527.cob" ).st_nlink, 1 )
+
+		del t
+
+		# Now that the source data is gone though, trying to paste won't work
+		t = Gaffer.ScriptNode()
+		app["scripts"]["t"] = t
+
+		with self.assertRaisesRegex( IECore.Exception, "Cannot paste - source file uses data stores which are not accessible, or have been modified." ) :
+			t.paste()
+
+	def testReference( self ):
+
+		orig = Gaffer.ScriptNode()
+		orig["b"] = Gaffer.Box()
+		orig["b"]["dataStore"] = Gaffer.DataStore()
+		orig["b"]["dataStore"].setEntry( "a", IECore.StringData( "aa" ) )
+		orig["b"]["dataStore"].setEntry( "b", IECore.StringData( "bb" ) )
+		orig["b"]["dataStore"].setEntry( "c", IECore.StringData( "cc" ) )
+
+		orig["b"].exportForReference( self.temporaryDirectory() / "ref.grf" )
+
+		# Data is stored with reference
+		self.assertEqual( len( os.listdir( self.temporaryDirectory() / "ref.grf.dataStore" ) ), 3 )
+
+		s = Gaffer.ScriptNode()
+		s["r"] = Gaffer.Reference()
+		s["r"].load( self.temporaryDirectory() / "ref.grf" )
+
+		self.assertEqual( s["r"]["dataStore"].getEntry( "a" ), IECore.StringData( "aa" ) )
+		self.assertEqual( s["r"]["dataStore"].getEntry( "b" ), IECore.StringData( "bb" ) )
+		self.assertEqual( s["r"]["dataStore"].getEntry( "c" ), IECore.StringData( "cc" ) )
+
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "d", IECore.StringData( "dd" ) )
+
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.save()
+
+		del s
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.load()
+
+		self.assertEqual( s["r"]["dataStore"].getEntry( "a" ), IECore.StringData( "aa" ) )
+		self.assertEqual( s["r"]["dataStore"].getEntry( "b" ), IECore.StringData( "bb" ) )
+		self.assertEqual( s["r"]["dataStore"].getEntry( "c" ), IECore.StringData( "cc" ) )
+		self.assertEqual( s["dataStore"].getEntry( "d" ), IECore.StringData( "dd" ) )
+
+		# Check that we're still using the data files from the reference, and we only save out
+		# the one data file for the local DataStore
+		self.assertEqual( len( os.listdir( self.temporaryDirectory() / "test.gfr.dataStore" ) ), 1 )
+
+
+		# Delete the reference we exported.
+		( self.temporaryDirectory() / "ref.grf" ).unlink()
+		shutil.rmtree( self.temporaryDirectory() / "ref.grf.dataStore" )
+
+		Gaffer.ValuePlug.clearCache()
+
+		# Check that the original file is still fine - exporting a reference shouldn't have affected it.
+
+		self.assertEqual( orig["b"]["dataStore"].getEntry( "a" ), IECore.StringData( "aa" ) )
+		self.assertEqual( orig["b"]["dataStore"].getEntry( "b" ), IECore.StringData( "bb" ) )
+		self.assertEqual( orig["b"]["dataStore"].getEntry( "c" ), IECore.StringData( "cc" ) )
+
+	def testHardLinkFailure( self ):
+
+		s = Gaffer.ScriptNode()
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 7 ) )
+		s["dataStore"].setEntry( "b", IECore.FloatData( 123.456 ) )
+		s["dataStore"].setEntry( "c", IECore.StringData( "Hello world" ) )
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.save()
+
+		s["fileName"].setValue( self.alternateMountTemporaryDirectory() / "test.gfr" )
+
+		# Saving as a new file on a different mount will mean we can't use hardlinks, so we should get a warning.
+		with IECore.CapturingMessageHandler() as mh :
+			s.save()
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertRegex( mh.messages[0].message, 'During saving, could not create hardlink at ".*" pointing to ".*", falling back to copying file.' )
+
+		del s
+
+		Gaffer.ValuePlug.clearCache()
+
+		# But everything should still work
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.alternateMountTemporaryDirectory() / "test.gfr" )
+		s.load()
+
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 7 ) )
+		self.assertEqual( s["dataStore"].getEntry( "b" ), IECore.FloatData( 123.456 ) )
+		self.assertEqual( s["dataStore"].getEntry( "c" ), IECore.StringData( "Hello world" ) )
+
+	def testDocumentUndoLiveValueWeirdness( self ):
+
+		# Saving flags a value as no longer live, since it can then be read from disk and stored
+		# in the regular ValuePlug cache - we don't need to dedicate special memory to storing it.
+		# But currently, the undo queue still holds the live value, so undoing can cause a value
+		# to become live again, even if that value was previously written to disk.
+		# This may be tolerable in a first release, but doesn't feel right long term.
+		# The solution may be that saving needs to process the undo queue, and discard any live
+		# values that are now found on disk. If we were doing that process, then maybe it would
+		# be correct to save all values from the undo queue to disk? ( Any values that are not
+		# actually used currently would go in a .recycleBin and be deleted when the ScriptNode
+		# is closed ). It could make for a slow save, but in a long paint session, it might be
+		# better to use some extra disk space ( temporarily ), rather than running out of memory?
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+
+		s["dataStore"] = Gaffer.DataStore()
+		with Gaffer.UndoScope( s ) :
+			s["dataStore"].setEntry( "a", IECore.IntData( 77777 ) )
+
+		self.assertTrue( s["dataStore"].isLive( "a" ) )
+		s.save()
+		self.assertFalse( s["dataStore"].isLive( "a" ) )
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 77777 ) )
+
+		with Gaffer.UndoScope( s ) :
+			s["dataStore"].setEntry( "a", IECore.IntData( 77778 ) )
+
+		self.assertTrue( s["dataStore"].isLive( "a" ) )
+		s.save()
+		self.assertFalse( s["dataStore"].isLive( "a" ) )
+
+		s.undo()
+		s.undo()
+		s.redo()
+
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 77777 ) )
+
+		# Ideally, this would probably still be false somehow , since the first save() wrote
+		# this value to disk.
+		self.assertTrue( s["dataStore"].isLive( "a" ) )
+
+	def testSaveAs( self ):
+
+		# Create an entry with no live value by writing a value to disk and reloading.
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.IntData( 77777 ) )
+		s.save()
+		del s
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
+		s.load()
+
+		with Gaffer.UndoScope( s ) :
+			s["dataStore"].setEntry( "a", IECore.IntData( 77778 ) )
+
+		s.save()
+		self.assertFalse( s["dataStore"].isLive( "a" ) )
+
+		# When we save as a new file, we point our data stores to the new data
+		# store directory ( but the undo queue also knows to point back to the
+		# old filename when necessary to retrieve old values )
+		s["fileName"].setValue( self.temporaryDirectory() / "test2.gfr" )
+		s.save()
+
+		Gaffer.ValuePlug.clearCache()
+
+		self.assertFalse( s["dataStore"].isLive( "a" ) )
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 77778 ) )
+
+		s.undo()
+		Gaffer.ValuePlug.clearCache()
+
+		# Retrieve value from original files recycle bin
+		self.assertFalse( s["dataStore"].isLive( "a" ) )
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 77777 ) )
+
+		del s
+
+		# Make sure that the up to date values are all stored with the new script though
+		shutil.rmtree( self.temporaryDirectory() / "test.gfr.dataStore" )
+		Gaffer.ValuePlug.clearCache()
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "test2.gfr" )
+		s.load()
+		self.assertFalse( s["dataStore"].isLive( "a" ) )
+		self.assertEqual( s["dataStore"].getEntry( "a" ), IECore.IntData( 77778 ) )
+
+	def testDispatch( self ):
+
+		# Dispatch a task that will serialise the environment it finds itself running in.
+
+		outputFile = self.temporaryDirectory() / "outputFile.txt"
+
+		s = Gaffer.ScriptNode()
+
+		s["dataStore"] = Gaffer.DataStore()
+		s["dataStore"].setEntry( "a", IECore.StringData( "text from data store" ) )
+		s["dataStore"]["selector"].setValue( "a" )
+
+		s["command"] = GafferDispatch.PythonCommand()
+		s["command"]["variables"].addChild( Gaffer.NameValuePlug( "testVar", Gaffer.StringPlug( "value", defaultValue = '', ), True, "member0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		s["expression"] = Gaffer.Expression()
+		s["expression"].setExpression( 'parent["command"]["variables"]["member0"]["value"] = parent["dataStore"]["out"]' )
+
+		s["command"]["command"].setValue(
+			inspect.cleandoc(
+				f"""
+				with open( r"{outputFile}", "w" ) as f :
+					f.write( variables["testVar"] )
+				"""
+			)
+		)
+
+		s["dispatcher"] = GafferDispatch.LocalDispatcher( jobPool = GafferDispatch.LocalDispatcher.JobPool() )
+		s["dispatcher"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["dispatcher"]["tasks"][0].setInput( s["command"]["task"] )
+		s["dispatcher"]["executeInBackground"].setValue( True )
+		s["dispatcher"]["task"].execute()
+		s["dispatcher"].jobPool().waitForAll()
+
+		# The dispatch saved out the data correctly
+		with open( outputFile, encoding = "utf-8" ) as f :
+			self.assertEqual( f.read(), "text from data store" )
+
+		# But this didn't affect the current script, so it still isn't saved.
+		with self.assertRaisesRegex( IECore.Exception, 'Cannot copy, DataStore "ScriptNode.dataStore" is not saved yet.' ) :
+			s.serialise()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -67,6 +67,7 @@ class TestCase( unittest.TestCase ) :
 	def setUp( self ) :
 
 		self.__temporaryDirectory = None
+		self.__alternateMountTemporaryDirectory = None
 		self.__messagesToIgnore = set()
 
 		# Set up a capturing message handler so that `tearDown()` can assert
@@ -137,12 +138,41 @@ class TestCase( unittest.TestCase ) :
 
 			shutil.rmtree( self.__temporaryDirectory )
 
+		if self.__alternateMountTemporaryDirectory is not None :
+			# For the moment, just do the simple version here. I assume we'd only need to do the
+			# complicated stuff we do for __temporaryDirectory if we were putting non-writable files in it.
+			shutil.rmtree( self.__alternateMountTemporaryDirectory )
+
+
 		IECore.MessageHandler.setDefaultHandler( self.__defaultMessageHandler )
 
 		for message in self.__failureMessageHandler.messages :
 			message = "{} : {} : {}".format( IECore.Msg.levelAsString( message.level ), message.context, message.message )
 			if message not in self.__messagesToIgnore :
 				self.fail( f"Unexpected message : {message}" )
+
+	@classmethod
+	def setUpClass( cls ) :
+
+		unittest.TestCase.setUpClass()
+
+		cls.__alternateMountRootDirectory = None
+
+
+	@classmethod
+	def tearDownClass( cls ) :
+
+		unittest.TestCase.tearDownClass()
+
+		if not cls.__alternateMountRootDirectory is None:
+			if sys.platform == "darwin" :
+				subprocess.check_call( [ "hdiutil", "detach", cls.__alternateMountRootDirectory ] )
+			elif sys.platform == "linux" :
+				shutil.rmtree( cls.__alternateMountRootDirectory )
+			elif sys.platform == "win32" :
+				subprocess.check_call( [ "net", "share", "gafferTestLocalShare", "/delete" ] )
+				shutil.rmtree( cls.__windowsMountSource )
+			cls.__alternateMountRootDirectory = None
 
 	## Registers a message that will be ignored if it is emitted during the
 	# test run, instead of triggering a failure.
@@ -159,6 +189,40 @@ class TestCase( unittest.TestCase ) :
 			self.__temporaryDirectory = pathlib.Path( tempfile.mkdtemp( prefix = "gafferTest" ) )
 
 		return self.__temporaryDirectory
+
+	@classmethod
+	def __alternateMount( cls ) :
+		if cls.__alternateMountRootDirectory is None:
+			if sys.platform == "darwin" :
+				cls.__alternateMountRootDirectory = pathlib.Path( "/Volumes/GafferTest" )
+				assert( not cls.__alternateMountRootDirectory.exists() )
+				image = subprocess.check_output( [ "hdiutil", "attach", "-nomount", "ram://1024" ] ).strip()
+				subprocess.check_call( [ "diskutil", "erasevolume", "HFS+", "GafferTest", image ] )
+			elif sys.platform == "linux" :
+				cls.__alternateMountRootDirectory = pathlib.Path( "/dev/shm/GafferTest" )
+				assert( not cls.__alternateMountRootDirectory.exists() )
+				cls.__alternateMountRootDirectory.mkdir()
+			elif sys.platform == "win32" :
+				cls.__windowsMountSource = pathlib.Path( tempfile.mkdtemp( prefix = "gafferTest" ) )
+				subprocess.check_call( [ "net", "share", "gafferTestLocalShare=" + str( cls.__windowsMountSource ), "/grant:Everyone,FULL" ] )
+				cls.__alternateMountRootDirectory = pathlib.Path( "//localhost/gafferTestLocalShare" )
+			else :
+				raise IECore.Exception( "Unknown platform " + sys.platform )
+
+		return cls.__alternateMountRootDirectory
+
+	## Returns a path to a directory the test may use for temporary
+	# storage. This directory is on a different physical disk than the regular temporaryDirectory(),
+	# allowing for testing situations where we can't rename or hardlink files ( currently achieved
+	# by using a RAM disk on Mac and Linux, and a net share on Windows ).
+	# This will be cleaned up automatically after the test has been run.
+	def alternateMountTemporaryDirectory( self ) :
+
+		if self.__alternateMountTemporaryDirectory is None :
+			if not self.__alternateMount() is None :
+				self.__alternateMountTemporaryDirectory = pathlib.Path( tempfile.mkdtemp( prefix = "gafferTest", dir = self.__alternateMount()  ) )
+
+		return self.__alternateMountTemporaryDirectory
 
 	## Returns a context manager that sets the locale
 	# on enter and restores it on exit.

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -164,6 +164,7 @@ from .CollectTest import CollectTest
 from .ProcessTest import ProcessTest
 from .PatternMatchTest import PatternMatchTest
 from .SetExpressionAlgoTest import SetExpressionAlgoTest
+from .DataStoreTest import DataStoreTest
 
 from .IECorePreviewTest import *
 

--- a/python/GafferUI/DataStoreUI.py
+++ b/python/GafferUI/DataStoreUI.py
@@ -1,0 +1,95 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import imath
+
+import Gaffer
+import GafferUI
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.DataStore,
+
+	"description",
+	"""
+	Stores data that will be saved to disk beside the Gaffer script, instead of stored inside
+	the Gaffer serialisation. The next time the script is opened, the data will be deferred
+	loaded when it is needed.
+
+	Appropriate for any large data associated with a Gaffer script ( for example, if you need
+	to store primitive variable values on large meshes ).
+
+	Values are accessed using the setEntry/getEntry methods, and can also be read using regular
+	plug evaluations.
+	""",
+
+	plugs = {
+
+		"selector" : {
+
+			"description" :
+			"""
+			Chooses the entry to be output.
+			Typically this will refer to a Context Variable using
+			the `${variableName}` syntax.
+			The `keys` plug outputs all valid keys you might want to use here.
+			""",
+			"nodule:type" : "",
+		},
+
+
+		"out" : {
+
+			"description" :
+			"""
+			Outputs the entry corresponding to `selector`.
+			""",
+
+			"plugValueWidget:type" : "",
+		},
+
+		"keys" : {
+
+			"description" :
+			"""
+			Outputs all entry keys.
+			""",
+		},
+	}
+
+)

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -134,7 +134,12 @@ def redo( menu ) :
 def cut( menu ) :
 
 	s = scope( menu )
-	with Gaffer.UndoScope( s.script ) :
+	errorHandler = GafferUI.ErrorDialogue.ErrorHandler(
+		title = "Error Occurred During Cut",
+		closeLabel = "OK",
+		parentWindow = s.scriptWindow
+	)
+	with Gaffer.UndoScope( s.script ), errorHandler :
 		s.script.cut( s.parent, s.script.selection() )
 
 ## A function suitable as the command for an Edit/Copy menu item. It must
@@ -142,7 +147,13 @@ def cut( menu ) :
 def copy( menu ) :
 
 	s = scope( menu )
-	s.script.copy( s.parent, s.script.selection() )
+
+	with GafferUI.ErrorDialogue.ErrorHandler(
+		title = "Error Occurred During Copy",
+		closeLabel = "OK",
+		parentWindow = s.scriptWindow
+	) :
+		s.script.copy( s.parent, s.script.selection() )
 
 ## A function suitable as the command for an Edit/Paste menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -235,6 +235,10 @@ def save( menu ) :
 		# thread, which is problematic for any connected UIs on the main
 		# thread. So instead we use `serialiseToFile()` and manage
 		# `unsavedChanges` ourselves.
+		# \todo : One significant advantage if we were able to actually call script.save() here
+		# is that we could then add a script.saveAs() as well, and use that to enforce that
+		# script["fileName"] needs to be set before saveAs.
+		# Maybe it would be easier to address this if unsavedChanges was metadata rather than a plug?
 		result = dialogue.waitForBackgroundTask( functools.partial( script.serialiseToFile, script["fileName"].getValue() ), parentWindow = scriptWindow )
 		if not isinstance( result, Exception ) :
 			script["unsavedChanges"].setValue( False )
@@ -260,13 +264,18 @@ def saveAs( menu ) :
 		path += ".gfr"
 
 	dialogue = GafferUI.BackgroundTaskDialogue( "Saving File" )
+
+	prevFileName = script["fileName"].getValue()
+	script["fileName"].setValue( path )
 	result = dialogue.waitForBackgroundTask( functools.partial( script.serialiseToFile, path ), parentWindow = scriptWindow )
 
 	if not isinstance( result, Exception ) :
-		script["fileName"].setValue( path )
 		script["unsavedChanges"].setValue( False )
 		application = script.ancestor( Gaffer.ApplicationRoot )
 		addRecentFile( application, path )
+	else:
+		script["fileName"].setValue( prevFileName )
+
 
 ## A function suitable as the command for a File/Revert To Saved menu item. It must be invoked from a menu which
 # has a ScriptWindow in its ancestry.

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -304,6 +304,7 @@ from . import EditScopeUI
 from . import ContextVariableTweaksUI
 from . import CollectUI
 from . import PatternMatchUI
+from . import DataStoreUI
 
 # backwards compatibility
 ## \todo Remove me

--- a/src/Gaffer/DataStore.cpp
+++ b/src/Gaffer/DataStore.cpp
@@ -1,0 +1,874 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/DataStore.h"
+
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/Process.h"
+#include "Gaffer/ValuePlug.h"
+
+#include "IECore/CompoundParameter.h"
+#include "IECore/NullObject.h"
+#include "IECore/FileIndexedIO.h"
+#include "IECore/ObjectWriter.h"
+
+#include "fmt/std.h"
+
+#include "tbb/concurrent_hash_map.h"
+
+#include <regex>
+
+using namespace Gaffer;
+
+namespace
+{
+
+// Must match the definition in ScriptNode.cpp
+const IECore::InternedString g_executionSourceFileContextName( "execution:sourceFile" );
+
+// Check if the current serialisation is a save/saveAs ( so the nodes should now point to their
+// new location on disk ), as opposed to an export ( which shouldn't affect the current nodes )
+bool serialiseIsSave( const std::filesystem::path *scriptPath, const GraphComponent* serialisationParent )
+{
+	const ScriptNode *scriptNode = IECore::runTimeCast<const ScriptNode>( serialisationParent );
+	if( ( !scriptNode ) || ( !scriptPath ) )
+	{
+		return false;
+	}
+
+	return std::filesystem::path( scriptNode->fileNamePlug()->getValue() ) == *scriptPath;
+}
+
+static const IECore::InternedString g_dataStoreEvaluationKeyName( "__dataStoreEvaluationKey" );
+
+std::string dataStoreFileNameFromHash( const IECore::MurmurHash &h )
+{
+	return h.toString() + ".cob";
+}
+
+std::optional<IECore::MurmurHash> dataStoreFileNameToHash( const std::string &fileName )
+{
+	static const std::regex g_dataStoreFileNameRegex( R"(([0-9a-f]{32})\.cob)" );
+
+	std::smatch match;
+	if( std::regex_match( fileName, match, g_dataStoreFileNameRegex ) )
+	{
+		return IECore::MurmurHash::fromString( match.str( 1 ) );
+	}
+
+	return {};
+}
+
+IECore::ConstObjectPtr loadDataFile( const std::filesystem::path &filePath )
+{
+	IECore::FileIndexedIOPtr file = new IECore::FileIndexedIO(
+		filePath.generic_string(), IECore::IndexedIO::rootPath, IECore::IndexedIO::Read
+	);
+
+	return IECore::Object::load( file, "object" );
+}
+
+} // namespace
+
+
+class DataStore::SetEntryAction : public Gaffer::Action
+{
+
+	public :
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::DataStore::SetEntryAction, DataStoreSetEntryActionTypeId, Gaffer::Action );
+
+		SetEntryAction( DataStorePtr node, const std::string &key, IECore::ConstObjectPtr value )
+			: m_node( node ), m_key( key ), m_doValue( value ? std::make_optional<Entry>( {value->hash(), value} ) : std::nullopt )
+		{
+			// The source directory isn't changed by a SetEntry - it's changed by serialisation, which
+			// happens in between SetEntry's. But undo'ing or redo'ing a SetEntry is what could trigger
+			// needing to use a previous or future sourceDirectory, and we can support that by recording
+			// this directory which is valid before or after this operation.
+			m_sourceDirectory = node->m_sourceDirectory;
+
+			auto it = node->m_entries.find( key );
+			if( it != node->m_entries.end() )
+			{
+				m_undoValue = it->second;
+			}
+		}
+
+		~SetEntryAction()
+		{
+		}
+
+	protected :
+
+		GraphComponent *subject() const override
+		{
+			return m_node.get();
+		}
+
+		void doAction() override
+		{
+			Action::doAction();
+			m_node->setEntryInternal( m_key, m_doValue );
+			// Currently, no tests fail if this isn't set, because after a redo, the value is
+			// live. But it is conceptually correct to set the source directory to the value
+			// it had at this point in the sequence of actions, and this could become important
+			// if we start cleaning the live values out of the undo queue at some point.
+			m_node->m_sourceDirectory = m_sourceDirectory;
+		}
+
+		void undoAction() override
+		{
+			Action::undoAction();
+			m_node->setEntryInternal( m_key, m_undoValue );
+			m_node->m_sourceDirectory = m_sourceDirectory;
+		}
+
+		bool canMerge( const Action *other ) const override
+		{
+			if( !Action::canMerge( other ) )
+			{
+				return false;
+			}
+			const SetEntryAction *setEntryAction = IECore::runTimeCast<const SetEntryAction>( other );
+			return setEntryAction &&
+				setEntryAction->m_node == m_node &&
+				setEntryAction->m_key == m_key &&
+				setEntryAction->m_sourceDirectory == m_sourceDirectory;
+		}
+
+		void merge( const Action *other ) override
+		{
+			const SetEntryAction *setEntryAction = static_cast<const SetEntryAction *>( other );
+			m_doValue = setEntryAction->m_doValue;
+		}
+
+	private :
+
+		DataStorePtr m_node;
+		std::string m_key;
+
+		std::shared_ptr<DirectoryManager> m_sourceDirectory;
+
+		// \todo In a long paint session on heavy geo, it's very plausible that a large amount of memory
+		// could be consumed by holding live values in the undo queue. In theory, you could probably
+		// even run out of memory and crash. Since we already need the .recycleBin folder for dealing
+		// with unused files that haven't been loaded ( but could be needed by undo ), it would be possible
+		// to use the .recycleBin folder for dealing with this memory accumulation: when we save, we could
+		// write all live value in the undo queue into the recycle bin, and clear them out of the undo
+		// queue. Kinda seems like a good idea, but maybe not necessary currently.
+		std::optional<Entry> m_doValue;
+		std::optional<Entry> m_undoValue;
+
+};
+
+IE_CORE_DEFINERUNTIMETYPED( DataStore::SetEntryAction );
+
+// The DirectoryManager handles the data store directory and recycle bin directory associated with a given script
+// path. Its lifespan lasts as long as anything might need to access something from these directories. When it
+// is freed, the associated recycle bin can be deleted ( since those values are now inaccessible ).
+class DataStore::DirectoryManager
+{
+public:
+	DirectoryManager( const std::filesystem::path &scriptPath )
+		: m_dataStoreDirectory( scriptPath.parent_path() / ( scriptPath.filename().string() + ".dataStore" ) ),
+		m_recycleBinDirectory( m_dataStoreDirectory / ".recycleBin" ),
+		m_recycleBinAcquired( false )
+	{
+	}
+
+	~DirectoryManager()
+	{
+		if( m_recycleBinAcquired )
+		{
+			// This is a fairly scary looking system call, so this is probably a good place to write
+			// down some justification why this seems like it should be safe:
+			// In order to get here, the path must end in ".recycleBin", and m_recycleBinAcquired must have
+			// been set by acquireRecycleBin, which ensures that it didn't previously exist.
+			// That should ensure that we're not deleting directories we don't own.
+			// In order to be placed in a recycle bin, a file must be found in a ".dataStore" directory
+			// corresponding to a script file that is currently being overwritten, and must look like
+			// a Gaffer data store ( ie. matches the regex "[0-9a-f]{32}.cob", enforced by
+			// dataStoreFileNameToHash ).
+
+			std::filesystem::remove_all( m_recycleBinDirectory );
+		}
+	}
+
+	const std::filesystem::path &dataStoreDirectory()
+	{
+		return m_dataStoreDirectory;
+	}
+
+	const std::filesystem::path &acquireRecycleBin()
+	{
+		if( !m_recycleBinAcquired )
+		{
+			if( std::filesystem::exists( m_recycleBinDirectory ) )
+			{
+				throw IECore::Exception( fmt::format(
+					"Cannot save DataStore, old recycle bin found for this file. There are two possible causes: "
+					"either this file was written by another Gaffer process which is still open ( you should "
+					"close it before trying to save here to avoid possible data loss ), or the previous Gaffer "
+					"to write this file crashed without cleaning up ( In this case, you should "
+					"manually delete the recycle bin folder {} )",
+					m_recycleBinDirectory
+				) );
+			}
+
+			std::filesystem::create_directories( m_recycleBinDirectory );
+			m_recycleBinAcquired = true;
+		}
+
+		return m_recycleBinDirectory;
+	}
+
+	std::optional<std::filesystem::path> getRecycleBinIfExists()
+	{
+		if( m_recycleBinAcquired )
+		{
+			return m_recycleBinDirectory;
+		}
+		else
+		{
+			return {};
+		}
+	}
+
+private:
+
+	const std::filesystem::path m_dataStoreDirectory;
+	const std::filesystem::path m_recycleBinDirectory;
+	bool m_recycleBinAcquired;
+};
+
+std::shared_ptr<DataStore::DirectoryManager> DataStore::acquireDirectoryManager( const std::filesystem::path &scriptPath )
+{
+	// When using a path as a key, we don't want two different representations of the same path to compare
+	// differently.
+	const std::filesystem::path scriptPathCanonical = std::filesystem::weakly_canonical( scriptPath );
+
+	// Directory managers are held in a global map of weak_ptrs, so that they can be shared, and freed
+	// when the last thing stops using them
+
+	struct FilesystemHashCompare
+	{
+		size_t hash( const std::filesystem::path& x ) const
+		{
+			return std::filesystem::hash_value( x );
+		}
+		bool equal( const std::filesystem::path& x, const std::filesystem::path& y ) const
+		{
+			return x==y;
+		}
+	};
+
+	using ConcurrentMap = tbb::concurrent_hash_map< std::filesystem::path, std::weak_ptr<DataStore::DirectoryManager>, FilesystemHashCompare >;
+	static ConcurrentMap directoryManagers;
+
+	std::shared_ptr<DirectoryManager> result;
+
+	ConcurrentMap::accessor access;
+	if( !directoryManagers.insert( access, scriptPathCanonical ) )
+	{
+		result = access->second.lock();
+	}
+
+	if( !result )
+	{
+		result = std::make_shared<DirectoryManager>( scriptPathCanonical );
+		access->second = result;
+	}
+
+	return result;
+}
+
+GAFFER_NODE_DEFINE_TYPE( DataStore );
+
+size_t DataStore::g_firstPlugIndex = 0;
+
+DataStore::DataStore( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "selector", Plug::In ) );
+	addChild( new ObjectPlug( "out", Plug::Out, new IECore::NullObject() ) );
+	addChild( new StringVectorDataPlug( "keys", Plug::Out ) );
+	addChild( new IntPlug( "__refreshCount", Plug::In, 0, Plug::Default & ~Plug::Serialisable ) );
+	addChild( new ObjectPlug( "__evaluate", Plug::Out, new IECore::NullObject() ) );
+}
+
+DataStore::~DataStore()
+{
+}
+
+StringPlug *DataStore::selectorPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 0 );
+}
+
+const StringPlug *DataStore::selectorPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 0 );
+}
+
+ObjectPlug *DataStore::outPlug()
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 1 );
+}
+
+const ObjectPlug *DataStore::outPlug() const
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 1 );
+}
+
+StringVectorDataPlug *DataStore::keysPlug()
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 2 );
+}
+
+const StringVectorDataPlug *DataStore::keysPlug() const
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 2 );
+}
+
+IntPlug *DataStore::refreshCountPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+const IntPlug *DataStore::refreshCountPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+ObjectPlug *DataStore::evaluatePlug()
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 4 );
+}
+
+const ObjectPlug *DataStore::evaluatePlug() const
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 4 );
+}
+
+void DataStore::setEntry( const std::string &key, IECore::ConstObjectPtr value )
+{
+	if( !value )
+	{
+		throw IECore::Exception( "Null value passed to setValue" );
+	}
+
+	// Ignore setEntry calls if it matches the existing value
+	auto it = m_entries.find( key );
+	if( it != m_entries.end() && it->second.m_hash == value->hash() )
+	{
+		return;
+	}
+
+	Action::enact( new SetEntryAction( this, key, value ) );
+}
+
+void DataStore::removeEntry( const std::string &key )
+{
+	// Ignore removeEntry calls if there is no entry
+	auto it = m_entries.find( key );
+	if( it == m_entries.end() )
+	{
+		return;
+	}
+
+	// We have a removeEntry method in order to present a clearer API,
+	// but we internally represent a remove as a SetEntry with a null
+	// value in order to avoid duplicating code for SetEntryAction.
+	Action::enact( new SetEntryAction( this, key, nullptr ) );
+}
+
+void DataStore::setEntryInternal( const std::string &key, const std::optional<Entry> &value )
+{
+	if( value )
+	{
+		m_entries[key] = *value;
+	}
+	else
+	{
+		m_entries.erase( key );
+	}
+
+	refreshCountPlug()->setValue( refreshCountPlug()->getValue() + 1 );
+}
+
+IECore::ConstObjectPtr DataStore::getEntry( const std::string &key, bool throwExceptions ) const
+{
+	try
+	{
+		// We use an evaluation plug to provide the getEntry() functionality - this means we can
+		// use Gaffer's default plug cache to ensure that we don't load a file twice if it is
+		// queried both via getEntry and via an output plug.
+		Context::EditableScope s( Context::current() );
+		s.set( g_dataStoreEvaluationKeyName, &key );
+		return evaluatePlug()->getValue();
+	}
+	catch( ProcessException &e )
+	{
+		if( throwExceptions )
+		{
+			e.rethrowUnwrapped();
+		}
+		else
+		{
+			return nullptr;
+		}
+	}
+}
+
+bool DataStore::isLive( const std::string &key ) const
+{
+	tbb::spin_rw_mutex::scoped_lock liveValueLock( m_entriesLiveValueMutex, /* write = */ false );
+	auto it = m_entries.find( key );
+	if( it == m_entries.end() )
+	{
+		return false;
+	}
+
+	return it->second.m_liveValue != nullptr;
+}
+
+void DataStore::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	if(
+		input == refreshCountPlug() ||
+		input == selectorPlug()
+	)
+	{
+		outputs.push_back( evaluatePlug() );
+	}
+
+	if(
+		input == refreshCountPlug()
+	)
+	{
+		outputs.push_back( keysPlug() );
+	}
+
+	if(
+		input == evaluatePlug()
+	)
+	{
+		outputs.push_back( outPlug() );
+	}
+}
+
+void DataStore::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	if( output == evaluatePlug() )
+	{
+		const std::string &key = context->get<std::string>( g_dataStoreEvaluationKeyName );
+
+		auto it = m_entries.find( key );
+		if( it == m_entries.end() )
+		{
+			throw IECore::Exception( "Unknown key: " + key );
+		}
+
+		h = it->second.m_hash;
+		return;
+	}
+	else if( output == outPlug() )
+	{
+		Context::EditableScope s( context );
+		std::string select = selectorPlug()->getValue();
+		s.set( g_dataStoreEvaluationKeyName, &select );
+
+		h = evaluatePlug()->hash();
+		return;
+	}
+	else if( output == keysPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+
+		for( const auto &[key, entry] : m_entries )
+		{
+			h.append( key );
+		}
+		return;
+	}
+
+
+	ComputeNode::hash( output, context, h );
+}
+
+void DataStore::compute( ValuePlug *output, const Context *context ) const
+{
+	if( output == evaluatePlug() )
+	{
+		IECore::ConstObjectPtr result;
+		const std::string &key = context->get<std::string>( g_dataStoreEvaluationKeyName );
+
+		auto it = m_entries.find( key );
+		if( it == m_entries.end() )
+		{
+			throw IECore::Exception( "Unknown key: " + key );
+		}
+
+		tbb::spin_rw_mutex::scoped_lock liveValueLock( m_entriesLiveValueMutex, /* write = */ false );
+		if( it->second.m_liveValue )
+		{
+			result = it->second.m_liveValue;
+		}
+		else
+		{
+			auto entryIt = m_entries.find( key );
+			if( entryIt != m_entries.end() )
+			{
+				std::string dataStoreFileName = dataStoreFileNameFromHash( entryIt->second.m_hash );
+
+				std::optional<std::filesystem::path> sourcePath;
+				if( m_sourceDirectory )
+				{
+					if( IECore::FileIndexedIO::canRead( ( m_sourceDirectory->dataStoreDirectory() / dataStoreFileName ).generic_string() ) )
+					{
+						sourcePath = m_sourceDirectory->dataStoreDirectory() / dataStoreFileName;
+					}
+					else if( const std::optional<std::filesystem::path> recycleBinDir = m_sourceDirectory ? m_sourceDirectory->getRecycleBinIfExists() : std::nullopt )
+					{
+						std::filesystem::path recycleBinPath = (*recycleBinDir) / dataStoreFileName;
+
+						if( IECore::FileIndexedIO::canRead( recycleBinPath.generic_string() ) )
+						{
+							sourcePath = recycleBinPath;
+						}
+					}
+				}
+
+				if( !sourcePath )
+				{
+					throw IECore::Exception( fmt::format(
+						"Could not locate data store file {} in {}.", dataStoreFileName, m_sourceDirectory->dataStoreDirectory()
+					) );
+				}
+
+				result = loadDataFile( *sourcePath );
+			}
+		}
+
+		if( !result )
+		{
+			throw IECore::Exception( "Unknown key: " + key );
+		}
+
+		static_cast<ObjectPlug *>( output )->setValue( result );
+		return;
+
+	}
+	else if( output == outPlug() )
+	{
+		Context::EditableScope s( context );
+		std::string select = selectorPlug()->getValue();
+		s.set( g_dataStoreEvaluationKeyName, &select );
+
+		static_cast<ObjectPlug *>( output )->setValue( evaluatePlug()->getValue() );
+		return;
+	}
+	else if( output == keysPlug() )
+	{
+		std::vector<std::string> keys;
+
+		for( const auto &[key, entry] : m_entries )
+		{
+			keys.push_back( key );
+		}
+
+		std::sort( keys.begin(), keys.end() );
+
+		static_cast<StringVectorDataPlug *>( output )->setValue(
+			new IECore::StringVectorData( std::move( keys ) )
+		);
+		return;
+	}
+
+	ComputeNode::compute( output, context );
+}
+
+void DataStore::loadEntries( const std::map< std::string, IECore::MurmurHash > &entries, const std::string &loadFrom )
+{
+	bool needsLoad;
+	std::filesystem::path sourceScript;
+	if( loadFrom.empty() )
+	{
+		// By default, the source directory for data stores corresponds to the source file we
+		// are executing.
+		// This will fail if source file context variable isn't set ( ie the serialisation
+		// we're executing didn't come from a file ), but we should never hit that exception,
+		// because loadFrom should always be set in those cases.
+		needsLoad = false;
+		sourceScript = Context::current()->get<std::string>( g_executionSourceFileContextName );
+	}
+	else
+	{
+		// When copy-and-pasting, we aren't executing a file on disk, so we need to know where to
+		// find appropriate data stores. This is set via the "loadFrom" variable.
+		sourceScript = loadFrom;
+
+		const ScriptNode* scriptNode = ancestor<ScriptNode>();
+
+		// When we're pasting a serialised value that references a different scripts data store
+		// directory, we aren't taking ownership of that directory, so we can't guarantee that
+		// the files will stay accessible. To prevent a scenario where everything initially
+		// appears to have been pasted successful, but then breaks later when the source script
+		// is modified, we force all the pasted values to load into memory.
+		//
+		// This isn't needed however, in the common case where we're pasting within the same script,
+		// so we check if the source script matches the current filename.
+		needsLoad = !( scriptNode && scriptNode->fileNamePlug()->getValue() == sourceScript );
+	}
+
+	m_sourceDirectory = acquireDirectoryManager( sourceScript );
+
+	for( const auto &[key, hash] : entries )
+	{
+		if( !needsLoad )
+		{
+			m_entries[ key ] = { hash, nullptr };
+		}
+		else
+		{
+			try
+			{
+				m_entries[ key ] = { hash, loadDataFile( m_sourceDirectory->dataStoreDirectory() / dataStoreFileNameFromHash( hash ) ) };
+			}
+			catch( const IECore::Exception & )
+			{
+				throw IECore::Exception( "Cannot paste - source file uses data stores which are not accessible, or have been modified." );
+			}
+		}
+	}
+}
+
+void DataStore::checkSaved() const
+{
+	// Copy and pasting a DataStore is only supported if it has already been saved to disk somewhere.
+	// This function tests this.
+
+	for( auto &[ key, entry ] : m_entries )
+	{
+		std::string fileName = dataStoreFileNameFromHash( entry.m_hash );
+
+		if( !m_sourceDirectory || !std::filesystem::exists( m_sourceDirectory->dataStoreDirectory() / fileName ) )
+		{
+			throw IECore::Exception( fmt::format( "Cannot copy, DataStore \"{}\" is not saved yet.", fullName() ) );
+		}
+	}
+}
+
+void DataStore::save( const std::filesystem::path &scriptPath, const Gaffer::GraphComponent *serialisationParent, std::unordered_set< IECore::MurmurHash > &usedDataHashes ) const
+{
+	std::shared_ptr<DirectoryManager> targetDirectory = acquireDirectoryManager( scriptPath );
+
+	std::string warning;
+
+	tbb::spin_rw_mutex::scoped_lock liveValueLock( m_entriesLiveValueMutex, /* write = */ false );
+	for( auto &[key, entry] : m_entries )
+	{
+		if( usedDataHashes.empty() )
+		{
+			// If this is the first time we've written something this serialisation, make sure the data store
+			// directory exists
+			std::filesystem::create_directories( targetDirectory->dataStoreDirectory() );
+		}
+
+		if( !usedDataHashes.insert( entry.m_hash ).second )
+		{
+			// This value was already saved during this serialization
+			continue;
+		}
+
+		std::string fileName = dataStoreFileNameFromHash( entry.m_hash );
+
+
+		std::filesystem::path destPath = targetDirectory->dataStoreDirectory() / fileName;
+		if( std::filesystem::exists( destPath ) )
+		{
+			// This value was already saved during a previous serialization
+			continue;
+		}
+
+		std::optional<std::filesystem::path> sourcePath;
+		if( m_sourceDirectory )
+		{
+			std::filesystem::path sourceDirectoryPath = m_sourceDirectory->dataStoreDirectory() / fileName;
+			if( m_sourceDirectory != targetDirectory && std::filesystem::exists( sourceDirectoryPath ) )
+			{
+				sourcePath = sourceDirectoryPath;
+			}
+			else if( m_sourceDirectory->getRecycleBinIfExists() )
+			{
+				std::filesystem::path recycleBinPath = (*m_sourceDirectory->getRecycleBinIfExists() ) / fileName;
+				if( std::filesystem::exists( recycleBinPath ) )
+				{
+					sourcePath = recycleBinPath;
+				}
+			}
+		}
+
+		if( sourcePath )
+		{
+			// This value already exists on disk, but in a different directory.
+			// Try to hardlink to it.
+			std::error_code ec;
+			std::filesystem::create_hard_link( *sourcePath, destPath, ec );
+			if( ec )
+			{
+				if( !warning.size() )
+				{
+					warning = fmt::format( "During saving, could not create hardlink at {} pointing to {}, falling back to copying file.", destPath, *sourcePath );
+				}
+
+				// If that failed, just copy.
+				std::filesystem::copy_file( *sourcePath, destPath );
+			}
+		}
+		else
+		{
+			// This value does not yet exist on disk, and we need to write it.
+			if( !entry.m_liveValue )
+			{
+				throw IECore::Exception( fmt::format( "Unable to save entry \"{}\" on \"{}\" - no live value, but cannot find on disk in directory {}.", key, fullName(), m_sourceDirectory->dataStoreDirectory() ) );
+			}
+
+			// I can't think why the writer would modify the source, I assume this old Cortex stuff just isn't
+			// intended to be const correct.
+			IECore::ObjectPtr liveValueCast = const_cast<IECore::Object*>( entry.m_liveValue.get() );
+
+			IECore::WriterPtr writer = new IECore::ObjectWriter( liveValueCast, destPath.generic_string() );
+			writer->write();
+		}
+	}
+
+	if( serialiseIsSave( &scriptPath, serialisationParent ) )
+	{
+		// All entries now exist in target directory. Update so that we'll now read from disk
+		// instead of needing to hold live values.
+
+		m_sourceDirectory = targetDirectory;
+
+		liveValueLock.upgrade_to_writer();
+		for( auto &[key, entry] : m_entries )
+		{
+			entry.m_liveValue.reset();
+		}
+	}
+
+	if( warning.size() )
+	{
+		IECore::msg( IECore::Msg::Warning, "Serialisation", warning );
+	}
+
+}
+
+void DataStore::finaliseDirectory( const std::filesystem::path &scriptPath, const Gaffer::GraphComponent *serialisationParent, const std::unordered_set< IECore::MurmurHash > &usedDataHashes )
+{
+	std::shared_ptr<DirectoryManager> directoryManager = acquireDirectoryManager( scriptPath );
+	const std::filesystem::path &dataStoreDirectory = directoryManager->dataStoreDirectory();
+
+	bool isSave = serialiseIsSave( &scriptPath, serialisationParent );
+
+	if( !std::filesystem::exists( dataStoreDirectory ) )
+	{
+		// No cleanup needed
+		return;
+	}
+
+	try
+	{
+		for( auto const& directoryEntry : std::filesystem::directory_iterator( dataStoreDirectory ) )
+		{
+			auto entryHash = dataStoreFileNameToHash( directoryEntry.path().filename().generic_string() );
+			if( entryHash )
+			{
+				if( !usedDataHashes.count( *entryHash ) )
+				{
+					if( !isSave )
+					{
+						// If this is an export rather than a save, then the open script won't rely on
+						// the old unused data, so we can go ahead and just remove it.
+						// ( Otherwise we need to put it in a recycle bin in case we need this data
+						// again after an undo. )
+						std::filesystem::remove( directoryEntry.path() );
+						continue;
+					}
+
+					// It's a little bit non-obvious whether it's safe to move this file while we have a
+					// directory iterator, but the docs say about changing directory contents: "it is unspecified
+					// whether the change would be observed through the iterator." Since they don't say
+					// anything about the iterator becoming invalid, I guess this is fine.
+					const std::filesystem::path recycledPath( directoryManager->acquireRecycleBin() / directoryEntry.path().filename() );
+
+					if( std::filesystem::exists( recycledPath ) )
+					{
+						// We've already stored this in the recycle bin, so it's safe to just delete it
+						std::filesystem::remove( directoryEntry.path() );
+					}
+					else
+					{
+						std::filesystem::rename( directoryEntry.path(), recycledPath );
+					}
+				}
+			}
+			else
+			{
+				if( directoryEntry.path().filename() != ".recycleBin" )
+				{
+					IECore::msg(
+						IECore::Msg::Warning, "Serialisation",
+						fmt::format( "Unexpected file {} in data store directory {}.",
+							directoryEntry.path().filename(), dataStoreDirectory
+						)
+					);
+				}
+			}
+		}
+	}
+	catch( IECore::Exception &e )
+	{
+		IECore::msg(
+			IECore::Msg::Warning, "Serialisation",
+			e.what()
+		);
+	}
+}

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -249,6 +249,9 @@ const IECore::InternedString g_frameStart( "frameRange:start" );
 const IECore::InternedString g_frameEnd( "frameRange:end" );
 const IECore::InternedString g_framesPerSecond( "framesPerSecond" );
 
+const IECore::InternedString g_executionSourceFileContextName( "execution:sourceFile" );
+const IECore::InternedString g_serialiserTargetFileContextName( "serialiser:targetFile" );
+
 } // namespace
 
 class ScriptNode::FocusSet : public Gaffer::Set
@@ -844,7 +847,7 @@ std::string ScriptNode::serialise( const Node *parent, const Set *filter ) const
 
 void ScriptNode::serialiseToFile( const std::filesystem::path &fileName, const Node *parent, const Set *filter ) const
 {
-	std::string s = serialiseInternal( parent, filter );
+	std::string s = serialiseInternal( parent, filter, &fileName );
 
 	std::ofstream f( fileName.c_str() );
 	if( !f.good() )
@@ -862,26 +865,26 @@ void ScriptNode::serialiseToFile( const std::filesystem::path &fileName, const N
 
 bool ScriptNode::execute( const std::string &serialisation, Node *parent, bool continueOnError )
 {
-	return executeInternal( serialisation, parent, continueOnError, "" );
+	return executeInternal( serialisation, parent, continueOnError );
 }
 
 bool ScriptNode::executeFile( const std::filesystem::path &fileName, Node *parent, bool continueOnError )
 {
 	const std::string serialisation = readFile( fileName );
-	return executeInternal( serialisation, parent, continueOnError, fileName.generic_string() );
+	return executeInternal( serialisation, parent, continueOnError, &fileName );
 }
 
 bool ScriptNode::load( bool continueOnError)
 {
 	DirtyPropagationScope dirtyScope;
 
-	const std::string fileName = fileNamePlug()->getValue();
+	const std::filesystem::path fileName = fileNamePlug()->getValue();
 	const std::string s = readFile( fileName );
 
 	deleteNodes();
 	variablesPlug()->clearChildren();
 
-	const bool result = executeInternal( s, nullptr, continueOnError, fileName );
+	const bool result = executeInternal( s, nullptr, continueOnError, &fileName );
 
 	UndoScope undoDisabled( this, UndoScope::Disabled );
 	unsavedChangesPlug()->setValue( false );
@@ -917,7 +920,7 @@ bool ScriptNode::importFile( const std::filesystem::path &fileName, Node *parent
 	return result;
 }
 
-std::string ScriptNode::serialiseInternal( const Node *parent, const Set *filter ) const
+std::string ScriptNode::serialiseInternal( const Node *parent, const Set *filter, const std::filesystem::path *filePath ) const
 {
 	if( !g_serialiseFunction )
 	{
@@ -931,10 +934,17 @@ std::string ScriptNode::serialiseInternal( const Node *parent, const Set *filter
 		scope.set( "serialiser:includeParentMetadata", &includeParentMetadata );
 	}
 
+	std::string filePathString;
+	if( filePath )
+	{
+		filePathString = filePath->generic_string();
+		scope.set( g_serialiserTargetFileContextName, &filePathString );
+	}
+
 	return g_serialiseFunction( parent ? parent : this, filter );
 }
 
-bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent, bool continueOnError, const std::string &context )
+bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent, bool continueOnError, const std::filesystem::path *sourceFile )
 {
 	if( !g_executeFunction )
 	{
@@ -944,6 +954,7 @@ bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent
 	bool result = false;
 	bool wasExecuting = m_executing;
 
+
 	// As with `ScriptNodeBinding::serialise()`, we don't want to perform string
 	// substitutions. Removing the current Process from ThreadState ensures
 	// `StringPlug::getValue()` will not perform substitutions.
@@ -951,13 +962,22 @@ bool ScriptNode::executeInternal( const std::string &serialisation, Node *parent
 	const Monitor::MonitorSet &monitors = Monitor::current();
 	const ThreadState defaultThreadState;
 	ThreadState::Scope defaultThreadStateScope( defaultThreadState );
-	Context::Scope contextScope( contextVariables );
+	Context::EditableScope contextScope( contextVariables );
 	Monitor::Scope monitorScope( monitors );
+	std::string sourceFileString;
+	if( sourceFile )
+	{
+		sourceFileString = sourceFile->generic_string();
+		contextScope.set<std::string>( g_executionSourceFileContextName, &sourceFileString );
+	}
 
 	m_executing = true;
 	try
 	{
-		result = g_executeFunction( this, serialisation, parent ? parent : this, continueOnError, context );
+		result = g_executeFunction(
+			this, serialisation, parent ? parent : this, continueOnError,
+			sourceFile ? sourceFile->generic_string() : ""
+		);
 	}
 	catch( ... )
 	{

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -724,7 +724,7 @@ void ScriptNode::copy( const Node *parent, const Set *filter )
 	ApplicationRoot *app = applicationRoot();
 	if( !app )
 	{
-		throw( "ScriptNode has no ApplicationRoot" );
+		throw IECore::Exception( "ScriptNode has no ApplicationRoot" );
 	}
 
 	std::string s = serialise( parent, filter );
@@ -742,7 +742,7 @@ void ScriptNode::paste( Node *parent, bool continueOnError )
 	ApplicationRoot *app = applicationRoot();
 	if( !app )
 	{
-		throw( "ScriptNode has no ApplicationRoot" );
+		throw IECore::Exception( "ScriptNode has no ApplicationRoot" );
 	}
 
 	IECore::ConstStringDataPtr s = IECore::runTimeCast<const IECore::StringData>( app->getClipboardContents() );

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -147,20 +147,32 @@ Serialisation::Serialisation( const Gaffer::GraphComponent *parent, const std::s
 	:	m_parent( parent ), m_parentName( parentName ), m_filter( filter ),
 		m_protectParentNamespace( Context::current()->get<bool>( "serialiser:protectParentNamespace", true ) )
 {
-	IECorePython::ScopedGILLock gilLock;
-	walk( parent, parentName, acquireSerialiser( parent ), Context::current()->canceller() );
-
-	if( Context::current()->get<bool>( "serialiser:includeParentMetadata", false ) )
+	try
 	{
-		if( const Node *node = runTimeCast<const Node>( parent ) )
+		IECorePython::ScopedGILLock gilLock;
+		walk( parent, parentName, acquireSerialiser( parent ), Context::current()->canceller() );
+
+		if( Context::current()->get<bool>( "serialiser:includeParentMetadata", false ) )
 		{
-			m_postScript += metadataSerialisation( node, parentName, *this );
-		}
-		else if( const Plug *plug = runTimeCast<const Plug>( parent ) )
-		{
-			m_postScript += metadataSerialisation( plug, parentName, *this );
+			if( const Node *node = runTimeCast<const Node>( parent ) )
+			{
+				m_postScript += metadataSerialisation( node, parentName, *this );
+			}
+			else if( const Plug *plug = runTimeCast<const Plug>( parent ) )
+			{
+				m_postScript += metadataSerialisation( plug, parentName, *this );
+			}
 		}
 	}
+	catch( ... )
+	{
+		// Signal that serialisation failed
+		m_postSerialisationSignal( this, false );
+		throw;
+	}
+
+	// Signal that serialisation succeeded
+	m_postSerialisationSignal( this, true );
 }
 
 const Gaffer::GraphComponent *Serialisation::parent() const
@@ -510,6 +522,12 @@ IECore::ObjectPtr Serialisation::objectFromBase64( const std::string &base64 )
 	MemoryIndexedIOPtr io = new MemoryIndexedIO( buffer, {}, IECore::IndexedIO::Read );
 	return Object::load( io, "o" );
 }
+
+Serialisation::PostSerialisationSignal &Serialisation::postSerialisationSignal()
+{
+	return m_postSerialisationSignal;
+}
+
 
 //////////////////////////////////////////////////////////////////////////
 // Serialisation::Serialiser

--- a/src/GafferModule/DataStoreBinding.cpp
+++ b/src/GafferModule/DataStoreBinding.cpp
@@ -1,0 +1,253 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "DataStoreBinding.h"
+
+#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferBindings/ValuePlugBinding.h"
+
+#include "Gaffer/DataStore.h"
+#include "Gaffer/ScriptNode.h"
+
+#include "boost/bind/placeholders.hpp"
+
+#include "tbb/concurrent_hash_map.h"
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "fmt/std.h"
+
+using namespace boost::placeholders;
+using namespace boost::python;
+using namespace IECorePython;
+using namespace Gaffer;
+using namespace GafferBindings;
+
+
+namespace
+{
+
+// Must match the definition in ScriptNode.cpp
+const IECore::InternedString g_serialiserTargetFileContextName( "serialiser:targetFile" );
+
+} // namespace
+
+namespace GafferModule
+{
+
+struct DataStoreSerialisationTracker : public Signals::Trackable
+{
+	DataStoreSerialisationTracker( Serialisation &serialisation, const std::filesystem::path &targetPath )
+		: m_scriptPath( targetPath )
+	{
+		// Our handling of the postSerialisation signal is really part of the serialisation finishing.
+		// It must always run ( so that the DataStoreSerialisationTracker instance gets cleaned up ),
+		// and it could potentially fail ( if the user has done something naughty like deleting our
+		// source data stores from disk ), in which case it will throw an exception, and this should
+		// be treated the same as the serialisation being cancelled before we reach the postSerialisation
+		// signal.
+		// We don't yet have anything else using the postSerialisation signal, but if there is something
+		// else, it should come after us, so we use a connectFront.
+		serialisation.postSerialisationSignal().connectFront( boost::bind( &DataStoreSerialisationTracker::finishSerialisation, this, ::_1, ::_2 ) );
+	}
+
+	void finishSerialisation( const Serialisation *serialisation, bool success )
+	{
+		TrackersMap::accessor mapEntry;
+		g_serialisationTrackers.find( mapEntry, serialisation );
+		if( !mapEntry->second )
+		{
+			throw IECore::Exception( "DataStoreSerialisationTracker accounting has gone wrong, this should never happen" );
+		}
+
+		// This tracker should be destructed, now that the corresponding Serialisation is finished.
+		// Take ownership of our own entry in the g_serialisationTrackers map as a local variable,
+		// so that we will be freed as soon as this function exits.
+		std::unique_ptr<DataStoreSerialisationTracker> keepAlive = std::move( mapEntry->second );
+		g_serialisationTrackers.erase( mapEntry );
+
+		if( success )
+		{
+			// A set of data store entry values, identified by their hashes, that have been saved
+			// during this serialisation
+			std::unordered_set< IECore::MurmurHash > usedDataHashes;
+
+			for( auto node : m_nodesToSave )
+			{
+				node->save( m_scriptPath, serialisation->parent(), usedDataHashes );
+			}
+
+			DataStore::finaliseDirectory( m_scriptPath, serialisation->parent(), usedDataHashes );
+		}
+
+	}
+
+	std::filesystem::path m_scriptPath;
+
+	std::set<const DataStore*> m_nodesToSave;
+
+	// We associate a SerialisationTracker with each serialisation that writes any DataStores. It tracks values
+	// that have been written, and triggers cleanup of unused values when the serialisation finishes.
+	using TrackersMap = tbb::concurrent_hash_map< const Serialisation*, std::unique_ptr<DataStoreSerialisationTracker> >;
+	static TrackersMap g_serialisationTrackers;
+
+};
+
+DataStoreSerialisationTracker::TrackersMap DataStoreSerialisationTracker::g_serialisationTrackers;
+
+class DataStoreSerialiser : public NodeSerialiser
+{
+	std::string postConstructor(
+		const Gaffer::GraphComponent *graphComponent, const std::string &identifier, Serialisation &serialisation
+	) const override
+	{
+		const DataStore *node = IECore::runTimeCast<const DataStore>( graphComponent );
+
+		serialisation.addModule( "IECore" );
+
+		// If we are saving to a file, as opposed to just doing a copy-and-paste, we rely on ScriptNode
+		// setting this targetPath context variable
+		const std::string *targetPathString = Context::current()->getIfExists<std::string>( g_serialiserTargetFileContextName );
+		if( targetPathString )
+		{
+			std::filesystem::path targetPath = *targetPathString;
+
+			DataStoreSerialisationTracker::TrackersMap::accessor tracker;
+			if( GafferModule::DataStoreSerialisationTracker::g_serialisationTrackers.emplace(
+				tracker, &serialisation, nullptr
+			) )
+			{
+				tracker->second = std::make_unique<DataStoreSerialisationTracker>( serialisation, targetPath );
+			}
+
+			tracker->second->m_nodesToSave.insert( node );
+		}
+		else
+		{
+			node->checkSaved();
+		}
+
+		std::vector<std::string> entryTokens;
+		for( const auto &it : node->m_entries )
+		{
+			entryTokens.push_back( fmt::format( R"("{}" : IECore.MurmurHash("{}"))", it.first, it.second.m_hash.toString() ) );
+		}
+		std::string entriesRepr = fmt::format( "{{ {} }}", fmt::join( entryTokens, ", " ) );
+
+		std::string mySerial;
+		if( targetPathString )
+		{
+			mySerial = fmt::format(
+				"{}._loadEntries( {} )\n", identifier, entriesRepr
+			);
+		}
+		else
+		{
+			// If we're not saving out data stores with this serialisation, then we need to force a load
+			// from the data store directory where the ScriptNode was last saved.
+			const ScriptNode *scriptNode = graphComponent->ancestor<const ScriptNode>();
+			if( !scriptNode )
+			{
+				throw IECore::Exception( "Cannot copy DataStore that is not part of a ScriptNode" );
+			}
+
+			mySerial = fmt::format(
+				"{}._loadEntries( {}, {} )\n", identifier, entriesRepr,
+				std::filesystem::path( scriptNode->fileNamePlug()->getValue() )
+			);
+		}
+
+		return mySerial;
+	}
+};
+
+struct DataStoreWrapperFunctionContainer
+{
+	static void loadEntriesWrapper(
+		DataStore &dataStore, boost::python::dict pythonEntries, const std::string &loadFrom
+	)
+	{
+		std::map< std::string, IECore::MurmurHash > entries;
+		list items = list( pythonEntries.items() );
+		for( int i = 0; i < len( items ); i++ )
+		{
+			boost::python::tuple entry = boost::python::extract<boost::python::tuple>( items[i] );
+			std::string key = boost::python::extract<std::string>( entry[0] );
+			IECore::MurmurHash hash = boost::python::extract<IECore::MurmurHash>( entry[1] );
+			entries[ key ] = hash;
+		}
+
+		dataStore.loadEntries( entries, loadFrom );
+	}
+};
+
+} // namespace GafferModule
+
+namespace
+{
+
+IECore::ObjectPtr getEntryWrapper( const DataStore &dataStore, const std::string &key, bool throwExceptions )
+{
+	IECore::ConstObjectPtr result = dataStore.getEntry( key, throwExceptions );
+	if( result )
+	{
+		return result->copy();
+	}
+	else
+	{
+		return nullptr;
+	}
+}
+
+} // namespace
+
+void GafferModule::bindDataStore()
+{
+
+	scope s = DependencyNodeClass<DataStore>()
+		.def( init<std::string>( ( arg( "name" )=GraphComponent::defaultName<DataStore>() ) ) )
+		.def( "setEntry", &DataStore::setEntry )
+		.def( "removeEntry", &DataStore::removeEntry )
+		.def( "getEntry", &getEntryWrapper, ( arg_( "key" ), arg_( "throwExceptions" ) = true ) )
+		.def( "isLive", &DataStore::isLive, ( arg_( "key" ) ) )
+		.def( "_loadEntries", &DataStoreWrapperFunctionContainer::loadEntriesWrapper, ( arg( "entries" ), arg( "loadFrom") = "") )
+	;
+
+	Serialisation::registerSerialiser( Gaffer::DataStore::staticTypeId(), new DataStoreSerialiser );
+
+}

--- a/src/GafferModule/DataStoreBinding.h
+++ b/src/GafferModule/DataStoreBinding.h
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace GafferModule
+{
+
+void bindDataStore();
+
+} // namespace GafferModule

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -40,6 +40,7 @@
 #include "ApplicationRootBinding.h"
 #include "ArrayPlugBinding.h"
 #include "BoxPlugBinding.h"
+#include "DataStoreBinding.h"
 #include "CollectBinding.h"
 #include "CompoundDataPlugBinding.h"
 #include "CompoundNumericPlugBinding.h"
@@ -186,6 +187,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindOptionalValuePlug();
 	bindCollect();
 	bindSetExpressionAlgo();
+	bindDataStore();
 
 	NodeClass<Backdrop>();
 	DependencyNodeClass<PatternMatch>();

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -610,6 +610,7 @@ nodeMenu.append( "/Utility/Context Query", Gaffer.ContextQuery, searchText = "Co
 nodeMenu.append( "/Utility/Collect", Gaffer.Collect )
 nodeMenu.append( "/Utility/Pattern Match", Gaffer.PatternMatch, searchText = "PatternMatch" )
 nodeMenu.append( "/Utility/File List", GafferDispatch.FileList, searchText = "FileList" )
+nodeMenu.append( "/Utility/Data Store", Gaffer.DataStore, searchText = "DataStore" )
 
 ## Miscellaneous UI
 ###########################################################################


### PR DESCRIPTION
This replaces https://github.com/GafferHQ/gaffer/pull/6985, and includes the name change we've discussed, as well as a lot refactoring.

As far as I've assessed, the refactoring has addressed or rendered irrelevant all prior comments, the test coverage is now decent, and it should be in a good place for a deeper review.

There are still some TODOs scattered throughout, but they're for things that feel worth discussing.

Significant outstanding issues:

* In order to identify save/saveAs vs export, we've proposed an approach where you must set ScriptNode::fileNamePlug before doing a saveAs, so that we can identify the difference between saveAs and export by whether the target filename is equal to the ScriptNode fileName. You suggested that to enforce this, we should add a saveAs method on ScriptNode, and make people call it. The problem is that currently our own FileMenu can't use ScriptNode::save() because of this comment: https://github.com/GafferHQ/gaffer/blob/main/python/GafferUI/FileMenu.py#L233
It seems we would need to address that somehow before it would be helpful to have a saveAs function on ScriptNode?

* We agreed that it made sense for copy-and-paste to force entries to load as live values ( because we don't control the source script, and those files might become unavailable ), but this is unnecessary in the common case of pasting into the same script you copied from. I'm not yet detecting the case where the script is the same ... in order to implement this, I think I'll need to serialise a separate function call to set the entries, rather than putting the entries in the constructor call ( because the constructor runs before parenting, so we don't yet know what script we're being pasted into )?