### PR TITLE
IECoreRenderMan : Handle non-geometric V3f data types

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.20.1)
 =======
 
+Fixes
+-----
 
+RenderMan : Fixed handling of V3f data with non-geometric interpretation. Common sources include `float3` primvars and attributes loaded from USD files.
 
 1.6.20.1 (relative to 1.6.20.0)
 ========

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -1191,6 +1191,118 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( m.level, IECore.Msg.Level.Warning )
 			self.assertIn( "Ignoring unsupported parameter", m.message )
 
+	def testGeometricInterpretation( self ) :
+
+		with IECoreRenderManTest.RileyCapture() as capture :
+
+			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				self.renderer,
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+			)
+
+			mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+			mesh["constantPoint"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Constant,
+				IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Point )
+			)
+			mesh["vertexPoint"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 4, IECore.GeometricData.Interpretation.Point )
+			)
+			mesh["constantVector"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Constant,
+				IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Vector )
+			)
+			mesh["vertexVector"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 4, IECore.GeometricData.Interpretation.Vector )
+			)
+			mesh["constantNormal"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Constant,
+				IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Normal )
+			)
+			mesh["vertexNormal"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 4, IECore.GeometricData.Interpretation.Normal )
+			)
+			mesh["constantFloat3"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Constant,
+				IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Numeric )
+			)
+			mesh["vertexFloat3"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 4, IECore.GeometricData.Interpretation.Numeric )
+			)
+
+			attributes = IECore.CompoundObject( {
+				"user:point" : IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Point ),
+				"user:pointArray" : IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 10, IECore.GeometricData.Interpretation.Point ),
+				"user:vector" : IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Vector ),
+				"user:vectorArray" : IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 12, IECore.GeometricData.Interpretation.Vector ),
+				"user:normal" : IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Normal ),
+				"user:normalArray" : IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 3, IECore.GeometricData.Interpretation.Normal ),
+				"user:float3" : IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Numeric ),
+				"user:float3Array" : IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 5, IECore.GeometricData.Interpretation.Numeric ),
+			} )
+
+			renderer.object(
+				"mesh", mesh, renderer.attributes( attributes )
+			)
+
+			del mesh, renderer
+
+		proto = next(
+			x for x in capture.json if x["method"] == "CreateGeometryPrototype"
+		)
+
+		def assertExpectedParamInfo( paramInfo, dataType, length, isArray ) :
+
+			self.assertEqual( paramInfo["type"], dataType )
+			self.assertEqual( paramInfo["length"], length )
+			self.assertEqual( paramInfo["array"], isArray )
+
+		def assertExpectedPrimVar( name, dataType, length, isArray ) :
+
+			primVar = next( x for x in proto["primvars"]["params"] if x["info"]["name"] == name )
+			assertExpectedParamInfo( primVar["info"], dataType, length, isArray )
+
+		# Matching RtDataType
+		dataTypes = {
+			"integer" : 0,
+			"float" : 1,
+			"color" : 2,
+			"point" : 3,
+			"vector" : 4,
+			"normal" : 5
+		}
+
+		assertExpectedPrimVar( "constantPoint", dataTypes["point"], 1, False )
+		assertExpectedPrimVar( "vertexPoint", dataTypes["point"], 1, False )
+		assertExpectedPrimVar( "constantVector", dataTypes["vector"], 1, False )
+		assertExpectedPrimVar( "vertexVector", dataTypes["vector"], 1, False )
+		assertExpectedPrimVar( "constantNormal", dataTypes["normal"], 1, False )
+		assertExpectedPrimVar( "vertexNormal", dataTypes["normal"], 1, False )
+		assertExpectedPrimVar( "constantFloat3", dataTypes["float"], 3, True )
+		assertExpectedPrimVar( "vertexFloat3", dataTypes["float"], 3, True )
+
+		instance = next(
+			x for x in capture.json if x["method"] == "CreateGeometryInstance"
+		)
+
+		def assertExpectedAttribute( name, dataType, length, isArray ) :
+
+			attribute = next( x for x in instance["attributes"]["params"] if x["info"]["name"] == name )
+			assertExpectedParamInfo( attribute["info"], dataType, length, isArray )
+
+		assertExpectedAttribute( "user:point", dataTypes["point"], 1, False )
+		assertExpectedAttribute( "user:pointArray", dataTypes["point"], 10, True )
+		assertExpectedAttribute( "user:vector", dataTypes["vector"], 1, False )
+		assertExpectedAttribute( "user:vectorArray", dataTypes["vector"], 12, True )
+		assertExpectedAttribute( "user:normal", dataTypes["normal"], 1, False )
+		assertExpectedAttribute( "user:normalArray", dataTypes["normal"], 3, True )
+		assertExpectedAttribute( "user:float3", dataTypes["float"], 3, True )
+		assertExpectedAttribute( "user:float3Array", dataTypes["float"], 15, True )
+
 	def testSubdivInterpolatedBoundary( self ) :
 
 		for interpolateBoundary, expected in [

--- a/src/IECoreRenderMan/GeometryAlgo.cpp
+++ b/src/IECoreRenderMan/GeometryAlgo.cpp
@@ -102,8 +102,10 @@ RtDataType dataType( IECore::GeometricData::Interpretation interpretation )
 			return RtDataType::k_vector;
 		case GeometricData::Normal :
 			return RtDataType::k_normal;
-		default :
+		case GeometricData::Point :
 			return RtDataType::k_point;
+		default :
+			return RtDataType::k_float;
 	}
 }
 
@@ -146,13 +148,14 @@ struct PrimitiveVariableConverter
 
 	void operator()( const V3fData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
 	{
+		const RtDataType type = dataType( data->getInterpretation() );
 		primVarList.SetParam(
 			{
 				name,
-				dataType( data->getInterpretation() ),
+				type,
 				detail( primitiveVariable.interpolation ),
-				/* length = */ 1,
-				/* array = */ false,
+				/* length = */ type == RtDataType::k_float ? 3u : 1u,
+				/* array = */ type == RtDataType::k_float,
 				/* motion = */ sampleIndex > 0,
 				/* deduplicated = */ false
 			},
@@ -238,14 +241,15 @@ struct PrimitiveVariableConverter
 
 	void operator()( const V3fVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
 	{
+		const RtDataType type = dataType( data->getInterpretation() );
 		emit(
 			data,
 			{
 				name,
-				dataType( data->getInterpretation() ),
+				type,
 				detail( primitiveVariable.interpolation ),
-				/* length = */ 1,
-				/* array = */ false,
+				/* length = */ type == RtDataType::k_float ? 3u : 1u,
+				/* array = */ type == RtDataType::k_float,
 				/* motion = */ sampleIndex > 0,
 				/* deduplicated = */ false
 			},

--- a/src/IECoreRenderMan/ParamListAlgo.cpp
+++ b/src/IECoreRenderMan/ParamListAlgo.cpp
@@ -103,8 +103,11 @@ struct ParameterConverter
 			case GeometricData::Normal :
 				paramList.SetNormal( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
 				break;
-			default :
+			case GeometricData::Point :
 				paramList.SetPoint( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
+				break;
+			default :
+				paramList.SetFloatArray( name, data->readable().getValue(), 3 );
 		}
 	}
 
@@ -164,8 +167,11 @@ struct ParameterConverter
 			case GeometricData::Normal :
 				paramList.SetNormalArray( name, reinterpret_cast<const RtVector3 *>( data->readable().data() ), data->readable().size() );
 				break;
-			default :
+			case GeometricData::Point :
 				paramList.SetPointArray( name, reinterpret_cast<const RtVector3 *>( data->readable().data() ), data->readable().size() );
+				break;
+			default :
+				paramList.SetFloatArray( name, data->readable().front().getValue(), 3 * data->readable().size() );
 		}
 	}
 


### PR DESCRIPTION
We use these to represent USD's `float3` type, and need to translate to RenderMan as `k_float` to avoid unwanted transforms being applied.
