### PR TITLE
CopyObject and PrimitiveQuery improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.7.x.x (relative to 1.7.0.0a6)
 =======
 
+Features
+--------
+
+- CopyObject : Added new node for copying objects from one scene to another.
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,12 +1,18 @@
 1.7.x.x (relative to 1.7.0.0a6)
 =======
 
+Improvements
+------------
+
+- PrimitiveQuery : Added `primitive` output [^2].
+
 Fixes
 -----
 
 - RenderMan : Fixed handling of V3f data with non-geometric interpretation. Common sources include `float3` primvars and attributes loaded from USD files [^1].
 
 [^1]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.
+[^2]: Improvement to a feature introduced in `1.7.0.0a3`, so should be omitted from final `1.7.0.0` release notes.
 
 1.7.0.0a6 (relative to 1.7.0.0a5)
 =========

--- a/include/GafferScene/CopyObject.h
+++ b/include/GafferScene/CopyObject.h
@@ -1,0 +1,83 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/FilteredSceneProcessor.h"
+
+#include "Gaffer/StringPlug.h"
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API CopyObject : public FilteredSceneProcessor
+{
+
+	public :
+
+		explicit CopyObject( const std::string &name=defaultName<CopyObject>() );
+		~CopyObject() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::CopyObject, CopyObjectTypeId, FilteredSceneProcessor );
+
+		GafferScene::ScenePlug *sourcePlug();
+		const GafferScene::ScenePlug *sourcePlug() const;
+
+		Gaffer::StringPlug *sourceLocationPlug();
+		const Gaffer::StringPlug *sourceLocationPlug() const;
+
+		Gaffer::BoolPlug *adjustBoundsPlug();
+		const Gaffer::BoolPlug *adjustBoundsPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+
+		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( CopyObject )
+
+} // namespace GafferScene

--- a/include/GafferScene/PrimitiveQuery.h
+++ b/include/GafferScene/PrimitiveQuery.h
@@ -81,6 +81,9 @@ class GAFFERSCENE_API PrimitiveQuery : public Gaffer::ComputeNode
 		Gaffer::IntPlug *faceVaryingPlug();
 		const Gaffer::IntPlug *faceVaryingPlug() const;
 
+		Gaffer::ObjectPlug *primitivePlug();
+		const Gaffer::ObjectPlug *primitivePlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -201,6 +201,7 @@ enum TypeId
 	CurvesTangentsTypeId = 120156,
 	PrimitiveQueryTypeId = 120157,
 	SceneStatsTypeId = 120158,
+	CopyObjectTypeId = 120159,
 
 	LastTypeId = 120999
 };

--- a/python/GafferSceneTest/CopyObjectTest.py
+++ b/python/GafferSceneTest/CopyObjectTest.py
@@ -1,0 +1,145 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class CopyObjectTest( GafferSceneTest.SceneTestCase ) :
+
+	def testCopy( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["name"].setValue( "object" )
+
+		cube = GafferScene.Cube()
+		cube["name"].setValue( "object" )
+
+		copy = GafferScene.CopyObject()
+		copy["in"].setInput( sphere["out"] )
+		copy["source"].setInput( cube["out"] )
+
+		# Not filtered to anything, so should be a perfect pass through.
+
+		self.assertScenesEqual( copy["out"], sphere["out"]  )
+		self.assertSceneHashesEqual( copy["out"], sphere["out"] )
+
+		# Add a filter, and we should get the object copied.
+
+		objectFilter = GafferScene.PathFilter()
+		objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+		copy["filter"].setInput( objectFilter["out"] )
+
+		self.assertEqual( copy["out"].object( "/object" ), cube["out"].object( "/object" ) )
+		self.assertSceneValid( copy["out"] )
+
+		# Request to copy from a location that doesn't exist, and
+		# we should get a pass-through again.
+
+		copy["sourceLocation"].setValue( "/cube" )
+		self.assertScenesEqual( copy["out"], sphere["out"]  )
+		self.assertSceneHashesEqual( copy["out"], sphere["out"] )
+
+		# Make the path valid, and the object should be copied again.
+
+		cube["name"].setValue( "cube" )
+		self.assertEqual( copy["out"].object( "/object" ), cube["out"].object( "/cube" ) )
+		self.assertSceneValid( copy["out"] )
+
+	def testInputObjectNotComputed( self ) :
+
+		sphere = GafferScene.Sphere()
+		cube = GafferScene.Cube()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		copy = GafferScene.CopyObject()
+		copy["in"].setInput( sphere["out"] )
+		copy["source"].setInput( cube["out"] )
+		copy["filter"].setInput( sphereFilter["out"] )
+		copy["sourceLocation"].setValue( "/cube" )
+
+		with Gaffer.PerformanceMonitor() as pm :
+			copy["out"].object( "/sphere" )
+
+		# The `copy` node will have done a compute, triggering a compute on the
+		# `cube` node.
+
+		self.assertEqual( pm.plugStatistics( copy["out"]["object"] ).hashCount, 1 )
+		self.assertEqual( pm.plugStatistics( copy["out"]["object"] ).computeCount, 1 )
+		self.assertEqual( pm.plugStatistics( cube["out"]["object"] ).hashCount, 1 )
+		self.assertEqual( pm.plugStatistics( cube["out"]["object"] ).computeCount, 1 )
+
+		# But there should be no compute triggered for the input `sphere` scene, since
+		# the object is being replaced completely.
+
+		self.assertEqual( pm.plugStatistics( sphere["out"]["object"] ).hashCount, 0 )
+		self.assertEqual( pm.plugStatistics( sphere["out"]["object"] ).computeCount, 0 )
+
+	def testBoundsUpdate( self ) :
+
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"][0].setInput( sphere["out"] )
+
+		cube = GafferScene.Cube()
+		cube["dimensions"].setValue( imath.V3f( 10, 11, 12 ) )
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/group/sphere" ] ) )
+
+		copy = GafferScene.CopyObject()
+		copy["in"].setInput( group["out"] )
+		copy["source"].setInput( cube["out"] )
+		copy["filter"].setInput( sphereFilter["out"] )
+		copy["sourceLocation"].setValue( "/cube" )
+
+		self.assertEqual( copy["out"].bound( "/" ), copy["in"].bound( "/" ) )
+
+		copy["adjustBounds"].setValue( True )
+		self.assertEqual( copy["out"].bound( "/" ), cube["out"].bound( "/" ) )
+		self.assertEqual( copy["out"].bound( "/group" ), cube["out"].bound( "/" ) )
+		self.assertEqual( copy["out"].bound( "/group/sphere" ), cube["out"].bound( "/" ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/PrimitiveQueryTest.py
+++ b/python/GafferSceneTest/PrimitiveQueryTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 
+import IECore
 import IECoreScene
 
 import GafferScene
@@ -57,6 +58,7 @@ class PrimitiveQueryTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( query["vertex"].getValue(), mesh.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Vertex ) )
 		self.assertEqual( query["varying"].getValue(), mesh.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Varying ) )
 		self.assertEqual( query["faceVarying"].getValue(), mesh.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ) )
+		self.assertEqual( query["primitive"].getValue(), mesh )
 
 		query["enabled"].setValue( False )
 		self.assertEqual( query["type"].getValue(), "" )
@@ -64,6 +66,7 @@ class PrimitiveQueryTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( query["vertex"].getValue(), 0 )
 		self.assertEqual( query["varying"].getValue(), 0 )
 		self.assertEqual( query["faceVarying"].getValue(), 0 )
+		self.assertEqual( query["primitive"].getValue(), IECore.NullObject.defaultNullObject() )
 
 	def testDefaultOutputs( self ) :
 
@@ -75,6 +78,7 @@ class PrimitiveQueryTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( query["vertex"].getValue(), 0 )
 			self.assertEqual( query["varying"].getValue(), 0 )
 			self.assertEqual( query["faceVarying"].getValue(), 0 )
+			self.assertEqual( query["primitive"].getValue(), IECore.NullObject.defaultNullObject() )
 
 		# No scene connected, no location
 		assertDefaults()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -201,6 +201,7 @@ from .CurvesTangentsTest import CurvesTangentsTest
 from .PrimitiveQueryTest import PrimitiveQueryTest
 from .SceneStatsTest import SceneStatsTest
 from .PointInstancerAlgoTest import PointInstancerAlgoTest
+from .CopyObjectTest import CopyObjectTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/CopyAttributesUI.py
+++ b/python/GafferSceneUI/CopyAttributesUI.py
@@ -79,6 +79,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type" : "GafferSceneUI.ScenePathPlugValueWidget",
+			"pathPlugValueWidget:placeholderText" : "${scene:path}",
 			"scenePathPlugValueWidget:scene" : "source",
 
 		},

--- a/python/GafferSceneUI/CopyObjectUI.py
+++ b/python/GafferSceneUI/CopyObjectUI.py
@@ -1,0 +1,93 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.CopyObject,
+
+	"description",
+	"""
+	Copies objects from a source scene, replacing the filtered objects
+	in the input scene. Objects include geometry such as meshes and curves,
+	volumes, cameras etc.
+	""",
+
+	plugs = {
+
+		"source" : {
+
+			"description" :
+			"""
+			The scene from which the object is copied.
+			""",
+
+		},
+
+		"sourceLocation" : {
+
+			"description" :
+			"""
+			The location in the source scene that the copy is copied from.
+			By default, objects are copied from the location equivalent to the one
+			they are being copied to. It is not an error if the location to be copied from
+			does not exist; instead, nothing is copied.
+			""",
+
+			"plugValueWidget:type" : "GafferSceneUI.ScenePathPlugValueWidget",
+			"pathPlugValueWidget:placeholderText" : "${scene:path}",
+			"scenePathPlugValueWidget:scene" : "source",
+
+		},
+
+		"adjustBounds" : {
+
+			"description" :
+			"""
+			Adjusts bounding boxes to account for the copied objects.
+
+			> Caution : Adjusting boundings boxes has a performance penalty.
+			> If you do not need accurate bounds or you know that the bounds
+			> will only change slightly, you may prefer to turn this off.
+			""",
+
+		},
+
+	}
+
+)

--- a/python/GafferSceneUI/CopyPrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/CopyPrimitiveVariablesUI.py
@@ -80,6 +80,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type" : "GafferSceneUI.ScenePathPlugValueWidget",
+			"pathPlugValueWidget:placeholderText" : "${scene:path}",
 			"scenePathPlugValueWidget:scene" : "source",
 
 		},

--- a/python/GafferSceneUI/PrimitiveQueryUI.py
+++ b/python/GafferSceneUI/PrimitiveQueryUI.py
@@ -143,6 +143,18 @@ Gaffer.Metadata.registerNode(
 
 		},
 
+		"primitive" : {
+
+			"description" :
+			"""
+			The complete Primitive from the queried location, or a NullObject
+			if there is no primitive.
+			""",
+
+			"layout:section" : "Settings.Outputs",
+
+		},
+
 	}
 
 )

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -219,6 +219,7 @@ from . import CurvesInterpolationUI
 from . import MeshLightUI
 from . import AttributeProcessorUI
 from . import CurvesTangentsUI
+from . import CopyObjectUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/CopyObject.cpp
+++ b/src/GafferScene/CopyObject.cpp
@@ -1,0 +1,216 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/CopyObject.h"
+
+#include "GafferScene/SceneAlgo.h"
+
+#include "IECore/NullObject.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+GAFFER_NODE_DEFINE_TYPE( GafferScene::CopyObject );
+
+size_t CopyObject::g_firstPlugIndex = 0;
+
+CopyObject::CopyObject( const std::string &name )
+	:	FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ScenePlug( "source" ) );
+	addChild( new StringPlug( "sourceLocation" ) );
+	addChild( new BoolPlug( "adjustBounds", Plug::In, false ) );
+
+	outPlug()->childBoundsPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
+
+	// Fast pass-throughs for things we don't modify
+	outPlug()->childNamesPlug()->setInput( inPlug()->childNamesPlug() );
+	outPlug()->globalsPlug()->setInput( inPlug()->globalsPlug() );
+	outPlug()->setNamesPlug()->setInput( inPlug()->setNamesPlug() );
+	outPlug()->setPlug()->setInput( inPlug()->setPlug() );
+	outPlug()->attributesPlug()->setInput( inPlug()->attributesPlug() );
+	outPlug()->transformPlug()->setInput( inPlug()->transformPlug() );
+}
+
+CopyObject::~CopyObject()
+{
+}
+
+GafferScene::ScenePlug *CopyObject::sourcePlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+const GafferScene::ScenePlug *CopyObject::sourcePlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+Gaffer::StringPlug *CopyObject::sourceLocationPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *CopyObject::sourceLocationPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::BoolPlug *CopyObject::adjustBoundsPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::BoolPlug *CopyObject::adjustBoundsPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+void CopyObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	FilteredSceneProcessor::affects( input, outputs );
+
+	if(
+		input == filterPlug() ||
+		input == inPlug()->objectPlug() ||
+		input == sourcePlug()->objectPlug() ||
+		input == sourcePlug()->existsPlug() ||
+		input == sourceLocationPlug()
+	)
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
+
+	if(
+		input == filterPlug() ||
+		input == adjustBoundsPlug() ||
+		input == inPlug()->boundPlug() ||
+		input == outPlug()->objectPlug() ||
+		input == outPlug()->childBoundsPlug()
+	)
+	{
+		outputs.push_back( outPlug()->boundPlug() );
+	}
+}
+
+void CopyObject::hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	if( !(filterValue( context ) & IECore::PathMatcher::ExactMatch) )
+	{
+		h = inPlug()->objectPlug()->hash();
+		return;
+	}
+
+	std::optional<ScenePath> sourceLocationPath;
+	const string sourceLocation = sourceLocationPlug()->getValue();
+	if( !sourceLocation.empty() )
+	{
+		ScenePlug::stringToPath( sourceLocation, sourceLocationPath.emplace() );
+	}
+
+	if( sourcePlug()->exists( sourceLocationPath ? *sourceLocationPath : path ) )
+	{
+		h = sourcePlug()->objectHash( sourceLocationPath ? *sourceLocationPath : path );
+	}
+	else
+	{
+		h = inPlug()->objectPlug()->hash();
+	}
+}
+
+IECore::ConstObjectPtr CopyObject::computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	if( !(filterValue( context ) & IECore::PathMatcher::ExactMatch) )
+	{
+		return inPlug()->objectPlug()->getValue();
+	}
+
+	std::optional<ScenePath> sourceLocationPath;
+	const string sourceLocation = sourceLocationPlug()->getValue();
+	if( !sourceLocation.empty() )
+	{
+		ScenePlug::stringToPath( sourceLocation, sourceLocationPath.emplace() );
+	}
+
+	if( sourcePlug()->exists( sourceLocationPath ? *sourceLocationPath : path ) )
+	{
+		return sourcePlug()->object( sourceLocationPath ? *sourceLocationPath : path );
+	}
+	else
+	{
+		return inPlug()->objectPlug()->getValue();
+	}
+}
+
+void CopyObject::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	if( adjustBoundsPlug()->getValue() )
+	{
+		const IECore::PathMatcher::Result m = filterValue( context );
+		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
+		{
+			FilteredSceneProcessor::hashBound( path, context, parent, h );
+			outPlug()->childBoundsPlug()->hash( h );
+			outPlug()->objectPlug()->hash( h );
+			return;
+		}
+	}
+	h = inPlug()->boundPlug()->hash();
+}
+
+Imath::Box3f CopyObject::computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	if( adjustBoundsPlug()->getValue() )
+	{
+		const IECore::PathMatcher::Result m = filterValue( context );
+		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::DescendantMatch ) )
+		{
+			Box3f result = outPlug()->childBoundsPlug()->getValue();
+			ConstObjectPtr o = outPlug()->objectPlug()->getValue();
+			if( !runTimeCast<const NullObject>( o.get() ) )
+			{
+				result.extendBy( SceneAlgo::bound( o.get() ) );
+			}
+			return result;
+		}
+	}
+
+	return inPlug()->boundPlug()->getValue();
+}

--- a/src/GafferScene/PrimitiveQuery.cpp
+++ b/src/GafferScene/PrimitiveQuery.cpp
@@ -38,6 +38,8 @@
 
 #include "IECoreScene/Primitive.h"
 
+#include "IECore/NullObject.h"
+
 using namespace Gaffer;
 using namespace GafferScene;
 
@@ -57,6 +59,7 @@ PrimitiveQuery::PrimitiveQuery( const std::string &name )
 	addChild( new Gaffer::IntPlug( "vertex", Gaffer::Plug::Out ) );
 	addChild( new Gaffer::IntPlug( "varying", Gaffer::Plug::Out ) );
 	addChild( new Gaffer::IntPlug( "faceVarying", Gaffer::Plug::Out ) );
+	addChild( new Gaffer::ObjectPlug( "primitive", Gaffer::Plug::Out, IECore::NullObject::defaultNullObject() ) );
 }
 
 PrimitiveQuery::~PrimitiveQuery()
@@ -143,6 +146,16 @@ const Gaffer::IntPlug *PrimitiveQuery::faceVaryingPlug() const
 	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 7 );
 }
 
+Gaffer::ObjectPlug *PrimitiveQuery::primitivePlug()
+{
+	return getChild<Gaffer::ObjectPlug>( g_firstPlugIndex + 8 );
+}
+
+const Gaffer::ObjectPlug *PrimitiveQuery::primitivePlug() const
+{
+	return getChild<Gaffer::ObjectPlug>( g_firstPlugIndex + 8 );
+}
+
 void PrimitiveQuery::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ComputeNode::affects( input, outputs );
@@ -159,6 +172,7 @@ void PrimitiveQuery::affects( const Gaffer::Plug *input, AffectedPlugsContainer 
 		outputs.push_back( vertexPlug() );
 		outputs.push_back( varyingPlug() );
 		outputs.push_back( faceVaryingPlug() );
+		outputs.push_back( primitivePlug() );
 	}
 }
 
@@ -169,7 +183,8 @@ void PrimitiveQuery::hash( const Gaffer::ValuePlug *output, const Gaffer::Contex
 		output == uniformPlug() ||
 		output == vertexPlug() ||
 		output == varyingPlug() ||
-		output == faceVaryingPlug()
+		output == faceVaryingPlug() ||
+		output == primitivePlug()
 	)
 	{
 		ComputeNode::hash( output, context, h );
@@ -200,7 +215,8 @@ void PrimitiveQuery::compute( Gaffer::ValuePlug *output, const Gaffer::Context *
 		output == uniformPlug() ||
 		output == vertexPlug() ||
 		output == varyingPlug() ||
-		output == faceVaryingPlug()
+		output == faceVaryingPlug() ||
+		output == primitivePlug()
 	)
 	{
 		IECoreScene::ConstPrimitivePtr primitive;
@@ -237,6 +253,10 @@ void PrimitiveQuery::compute( Gaffer::ValuePlug *output, const Gaffer::Context *
 		else if( output == faceVaryingPlug() )
 		{
 			static_cast<Gaffer::IntPlug *>( output )->setValue( primitive ? (int)primitive->variableSize( IECoreScene::PrimitiveVariable::FaceVarying ) : 0 );
+		}
+		else if( output == primitivePlug() )
+		{
+			static_cast<Gaffer::ObjectPlug *>( output )->setValue( primitive ? primitive : IECore::ConstObjectPtr( IECore::NullObject::defaultNullObject() ) );
 		}
 	}
 	else

--- a/src/GafferSceneModule/ObjectProcessorBinding.cpp
+++ b/src/GafferSceneModule/ObjectProcessorBinding.cpp
@@ -38,6 +38,7 @@
 
 #include "ObjectProcessorBinding.h"
 
+#include "GafferScene/CopyObject.h"
 #include "GafferScene/CopyPrimitiveVariables.h"
 #include "GafferScene/CurvesInterpolation.h"
 #include "GafferScene/CurvesTangents.h"
@@ -91,6 +92,7 @@ void GafferSceneModule::bindObjectProcessor()
 	GafferBindings::DependencyNodeClass<DeleteObject>();
 	GafferBindings::DependencyNodeClass<UDIMQuery>();
 	GafferBindings::DependencyNodeClass<Wireframe>();
+	GafferBindings::DependencyNodeClass<CopyObject>();
 	GafferBindings::DependencyNodeClass<CopyPrimitiveVariables>();
 	GafferBindings::DependencyNodeClass<MeshNormals>();
 	GafferBindings::DependencyNodeClass<MeshTessellate>();

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -296,6 +296,7 @@ nodeMenu.append( "/Scene/Object/Delete Faces", GafferScene.DeleteFaces, searchTe
 nodeMenu.append( "/Scene/Object/Delete Curves", GafferScene.DeleteCurves, searchText = "DeleteCurves" )
 nodeMenu.append( "/Scene/Object/Delete Points", GafferScene.DeletePoints, searchText = "DeletePoints" )
 nodeMenu.append( "/Scene/Object/Delete Object", GafferScene.DeleteObject, searchText = "DeleteObject" )
+nodeMenu.append( "/Scene/Object/Copy Object", GafferScene.CopyObject, searchText = "CopyObject" )
 nodeMenu.append( "/Scene/Object/Reverse Winding", GafferScene.ReverseWinding, searchText = "ReverseWinding" )
 nodeMenu.append( "/Scene/Object/Mesh Distortion", GafferScene.MeshDistortion, searchText = "MeshDistortion" )
 nodeMenu.append( "/Scene/Object/Mesh Segments", GafferScene.MeshSegments, searchText = "MeshSegments" )


### PR DESCRIPTION
I'm working on a new PointInstancer node to replace the old Instancer node. This time the goal is to build it as a modular graph using ExtensionAlgo and a small PointInstancerCore C++ node rather than as a big monolithic behemoth. To that end this PR adds a couple of new features that will be used by the internal graph of the PointInstancer node.