### PR TITLE
CI : Add build for RenderMan 27.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
       if: ${{ env.RMANTREE != '' }}
 
     - name: Test against RenderMan 26.4
-      # See comments for RenderMan 27.1.
+      # See comments for RenderMan 27.2.
       run: |
         podman run -e CI -e RMANTREE -e GITHUB_WORKSPACE -e GAFFER_BUILD_DIR -v /opt/pixar:/opt/pixar -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --mac-address a4:bb:6d:cf:40:7a --shm-size 4g --entrypoint=sh -w $GITHUB_WORKSPACE rockylinux:9.3-minimal -c .github/workflows/main/testGafferRenderMan.sh
         df -H
@@ -365,6 +365,31 @@ jobs:
       # can't run RenderMan in our Rocky 8 build container, which was carefully
       # chosen to provide a conforming glibc version. So, to test RenderMan 27,
       # we must run in a Rocky 9 container.
+      run: |
+        podman run -e CI -e RMANTREE -e GITHUB_WORKSPACE -e GAFFER_BUILD_DIR -v /opt/pixar:/opt/pixar -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --mac-address a4:bb:6d:cf:40:7a --shm-size 4g --entrypoint=sh -w $GITHUB_WORKSPACE rockylinux:9.3-minimal -c .github/workflows/main/testGafferRenderMan.sh
+        df -H
+      if: ${{ env.RMANTREE != '' && runner.os != 'Windows' }}
+
+    - name: Install RenderMan 27.3
+      run: |
+        rm -r "$RMANTREE" # Free up precious disk space from the previous installation
+        ./.github/workflows/main/installRenderMan.py --version 27.3 --outputFormat "RMANTREE={rmanTree}" >> $GITHUB_ENV
+      shell: bash
+      env:
+        RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}
+        RENDERMAN_DOWNLOAD_PASSWORD: ${{ secrets.RENDERMAN_DOWNLOAD_PASSWORD }}
+        RENDERMAN_LICENSE_PASSPHRASE: ${{ secrets.RENDERMAN_LICENSE_PASSPHRASE }}
+      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' && runner.os != 'macOS' }}
+
+    - name: Build against RenderMan 27.3
+      run: |
+        scons -j ${{ matrix.jobs }} build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions ${{ matrix.extraBuildArguments }}
+      env:
+        PYTHONUTF8: 1
+      if: ${{ env.RMANTREE != '' }}
+
+    - name: Test against RenderMan 27.3
+      # See comments for RenderMan 27.2.
       run: |
         podman run -e CI -e RMANTREE -e GITHUB_WORKSPACE -e GAFFER_BUILD_DIR -v /opt/pixar:/opt/pixar -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --mac-address a4:bb:6d:cf:40:7a --shm-size 4g --entrypoint=sh -w $GITHUB_WORKSPACE rockylinux:9.3-minimal -c .github/workflows/main/testGafferRenderMan.sh
         df -H

--- a/.github/workflows/main/installRenderMan.py
+++ b/.github/workflows/main/installRenderMan.py
@@ -49,7 +49,7 @@ parser.add_argument(
 	"--version",
 	help = "The version of RenderMan to install.",
 	default = "26.3",
-	choices = [ "26.3", "26.4", "27.0", "27.1", "27.2" ],
+	choices = [ "26.3", "26.4", "27.0", "27.1", "27.2", "27.3" ],
 )
 parser.add_argument(
 	"--dailyBuildDate",
@@ -143,6 +143,8 @@ else :
 		"27.1-nt" : ( "12716", "4518"),
 		"27.2-posix" : ( "12773", "4545"),
 		"27.2-nt" : ( "12771", "4545"),
+		"27.3-posix" : ( "12826", "4583"),
+		"27.3-nt" : ( "12828", "4583"),
 	}[f"{args.version}-{os.name}"]
 
 	downloadURL = "https://renderman.pixar.com/forum/download/release"

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.7.x.x (relative to 1.7.0.0a7)
 =======
 
+Features
+--------
 
+- RenderMan : Added support for RenderMan 27.3.
 
 1.7.0.0a7 (relative to 1.7.0.0a6)
 =========


### PR DESCRIPTION
I'd dearly love to remove the one for 27.2 at the same time, but I think it's probably too soon for that?