### PR TITLE
Context menu multi node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - FocalBlur : Fixed issue with excess alpha near depth discontinuities. This resulted in small bright edges near silhouettes where there is a sharp change in depth.
+- Filter : Fixed bug with `Select affected objects` where only the relevant locations from one scene connected to the filter would be included in the selection instead of from all scenes connected to the filter.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,11 @@ Fixes
 
 - FocalBlur : Fixed issue with excess alpha near depth discontinuities. This resulted in small bright edges near silhouettes where there is a sharp change in depth.
 
+API
+---
+
+- GraphEditor : Added an optional argument to `nodeContextMenuSignal()` to request a signal that will pass a list of nodes to the handler, rather than a single node. This can be used to register menu items that will act on multiple nodes.
+
 1.7.0.0a8 (relative to 1.7.0.0a7)
 =========
 
@@ -75,6 +80,7 @@ Build
 
 [^1]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.
 [^2]: Improvement to a feature introduced in `1.7.0.0a3`, so should be omitted from final `1.7.0.0` release notes.
+
 
 1.7.0.0a6 (relative to 1.7.0.0a5)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - QuantizePrimitiveVariables : Added new node for quantizing the values of primitive variables.
 
+Improvements
+------------
+
+- GraphEditor : Changed node context menu items to operate on multiple nodes where possible (#2783).
+
 Fixes
 -----
 

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -419,31 +419,39 @@ GafferUI.NodeGadget.registerNodeGadget( GafferScene.Cryptomatte, __nodeGadget )
 # GraphEditor context menu
 ##########################################################################
 
-def __selectAffected( node, context ) :
+def __selectAffected( nodeList, context ) :
 
-	if not isinstance( node, GafferScene.Cryptomatte ) :
-		return
+	pathMatcherResult = IECore.PathMatcher()
 
-	scene = node["manifestScene"]
+	for node in nodeList :
 
-	with context :
-		pathMatcher = IECore.PathMatcher()
-		for path in node["matteNames"].getValue() :
-			if path[0] != '<' and path[-1] != '>' :
-				pathMatcher.addPath( path )
+		if not isinstance( node, GafferScene.Cryptomatte ) :
+			continue
 
-		pathMatcherResult = IECore.PathMatcher()
-		GafferScene.SceneAlgo.matchingPaths( pathMatcher, scene, pathMatcherResult )
+		scene = node["manifestScene"]
+
+		with context :
+			pathMatcher = IECore.PathMatcher()
+			for path in node["matteNames"].getValue() :
+				if path[0] != '<' and path[-1] != '>' :
+					pathMatcher.addPath( path )
+
+			nodeMatches = IECore.PathMatcher()
+			GafferScene.SceneAlgo.matchingPaths( pathMatcher, scene, nodeMatches )
+			pathMatcherResult.addPaths( nodeMatches )
 
 	GafferSceneUI.ScriptNodeAlgo.setSelectedPaths( node.scriptNode(), pathMatcherResult )
 
-def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
+def appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition ) :
 
-	if not isinstance( node, GafferScene.Cryptomatte ) :
+	if not any( isinstance( n, GafferScene.Cryptomatte ) for n in nodeList ) :
 		return
 
 	menuDefinition.append( "/CryptomatteDivider", { "divider" : True } )
-	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, graphEditor.context() ) } )
+	menuDefinition.append( "/Select Affected Objects", {
+		"command" : functools.partial( __selectAffected, nodeList, graphEditor.context() ),
+		"active" : all( isinstance( n, GafferScene.Cryptomatte ) for n in nodeList )
+	} )
 
 ##########################################################################
 # NodeEditor tool menu

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -84,31 +84,40 @@ Gaffer.Metadata.registerNode(
 # GraphEditor context menu
 ##########################################################################
 
-def __selectAffected( node ) :
-
-	if isinstance( node, GafferScene.FilteredSceneProcessor ) :
-		filter = node["filter"]
-		scenes = [ node["in"] ]
-	else :
-		filter = node
-		scenes = [ n["in"] for n in GafferScene.SceneAlgo.filteredNodes( filter ) ]
-
-	scenes = [ s[0] if isinstance( s, Gaffer.ArrayPlug ) else s for s in scenes ]
+def __selectAffected( nodeList ) :
 
 	pathMatcher = IECore.PathMatcher()
-	for scene in scenes :
-		with GafferUI.ContextTracker.acquireForFocus( scene ).context( scene ) :
-			GafferScene.SceneAlgo.matchingPaths( filter, scene, pathMatcher )
 
-	GafferSceneUI.ScriptNodeAlgo.setSelectedPaths( node.scriptNode(), pathMatcher )
+	for node in nodeList :
+		if isinstance( node, GafferScene.FilteredSceneProcessor ) :
+			filter = node["filter"]
+			scenes = [ node["in"] ]
+		else :
+			filter = node
+			scenes = [ n["in"] for n in GafferScene.SceneAlgo.filteredNodes( filter ) ]
 
-def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
+		scenes = [ s[0] if isinstance( s, Gaffer.ArrayPlug ) else s for s in scenes ]
 
-	if not isinstance( node, ( GafferScene.FilteredSceneProcessor, GafferScene.Filter ) ) :
+
+		for scene in scenes :
+			sceneMatches = IECore.PathMatcher()
+			with GafferUI.ContextTracker.acquireForFocus( scene ).context( scene ) :
+				GafferScene.SceneAlgo.matchingPaths( filter, scene, sceneMatches )
+
+			pathMatcher.addPaths( sceneMatches )
+
+	GafferSceneUI.ScriptNodeAlgo.setSelectedPaths( nodeList[0].scriptNode(), pathMatcher )
+
+def appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition ) :
+
+	if not any( isinstance( n, ( GafferScene.FilteredSceneProcessor, GafferScene.Filter ) ) for n in nodeList ) :
 		return
 
 	menuDefinition.append( "/FilteredSceneProcessorDivider", { "divider" : True } )
-	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node ) } )
+	menuDefinition.append( "/Select Affected Objects", {
+		"command" : functools.partial( __selectAffected, nodeList ),
+		"active" : all( isinstance( n, ( GafferScene.FilteredSceneProcessor, GafferScene.Filter ) ) for n in nodeList )
+	} )
 
 ##########################################################################
 # NodeEditor tool menu

--- a/python/GafferUI/AnnotationsUI.py
+++ b/python/GafferUI/AnnotationsUI.py
@@ -43,16 +43,17 @@ import IECore
 
 import Gaffer
 import GafferUI
+from GafferUI.PlugValueWidget import sole
 
-def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
+def appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition ) :
 
 	def append( menuPath, name ) :
 
 		menuDefinition.append(
 			menuPath,
 			{
-				"command" : functools.partial( __annotate, node, name ),
-				"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+				"command" : functools.partial( __annotate, nodeList, name ),
+				"active" : not any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList ),
 			}
 		)
 
@@ -68,9 +69,9 @@ def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
 		menuDefinition.append( "/Annotate/Divider", { "divider" : True } )
 		append( "/Annotate/User...", "user" )
 
-def __annotate( node, name, menu ) :
+def __annotate( nodeList, name, menu ) :
 
-	dialogue = __AnnotationsDialogue( node, name )
+	dialogue = __AnnotationsDialogue( nodeList, name )
 	dialogue.wait( parentWindow = menu.ancestor( GafferUI.Window ) )
 
 # A signal emitted when a popup menu for an annotation is about to be shown.
@@ -119,7 +120,7 @@ def __buttonDoubleClick( editorWeakRef, annotationsGadget, event ) :
 
 		node, name = annotation
 
-		__annotate( node, name, editorWeakRef() )
+		__annotate( [node], name, editorWeakRef() )
 
 		return True
 
@@ -260,15 +261,15 @@ class _AnnotationsCompleter( GafferUI.CodeWidget.Completer ) :
 
 class __AnnotationsDialogue( GafferUI.Dialogue ) :
 
-	def __init__( self, node, name ) :
+	def __init__( self, nodeList, name ) :
 
 		GafferUI.Dialogue.__init__( self, "Annotate" )
 
-		self.__node = node
+		self.__nodeList = nodeList
 		self.__name = name
 
 		template = Gaffer.MetadataAlgo.getAnnotationTemplate( name )
-		annotation = Gaffer.MetadataAlgo.getAnnotation( node, name ) or template
+		annotation = Gaffer.MetadataAlgo.getAnnotation( self.__nodeList[-1], self.__name ) or template
 
 		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 ) as layout :
 
@@ -276,8 +277,8 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 				text = annotation.text() if annotation else "",
 				placeholderText = "Tip : Use {plugName} to include plug values",
 			)
-			self.__textWidget.setHighlighter( _AnnotationsHighlighter( node ) )
-			self.__textWidget.setCompleter( _AnnotationsCompleter( node ) )
+			self.__textWidget.setHighlighter( _AnnotationsHighlighter( nodeList[-1] ) )
+			self.__textWidget.setCompleter( _AnnotationsCompleter( nodeList[-1] ) )
 			self.__textWidget.setWrapMode( self.__textWidget.WrapMode.WordOrCharacter )
 			self.__textWidget.textChangedSignal().connect(
 				Gaffer.WeakMethod( self.__updateButtonStatus )
@@ -313,18 +314,20 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 		if button is self.__cancelButton or button is None :
 			return
 
-		with Gaffer.UndoScope( self.__node.scriptNode() ) :
+		with Gaffer.UndoScope( self.__nodeList[0].scriptNode() ) :
 			if button is self.__removeButton :
-				Gaffer.MetadataAlgo.removeAnnotation( self.__node, self.__name )
+				for node in self.__nodeList :
+					Gaffer.MetadataAlgo.removeAnnotation( node, self.__name )
 			else :
-				Gaffer.MetadataAlgo.addAnnotation(
-					self.__node, self.__name,
-					self.__makeAnnotation()
-				)
+				for node in self.__nodeList :
+					Gaffer.MetadataAlgo.addAnnotation(
+						node, self.__name,
+						self.__makeAnnotation()
+					)
 
 	def __updateButtonStatus( self, *unused ) :
 
-		existingAnnotation = Gaffer.MetadataAlgo.getAnnotation( self.__node, self.__name )
+		existingAnnotation = Gaffer.MetadataAlgo.getAnnotation( self.__nodeList[-1], self.__name )
 		newAnnotation = self.__makeAnnotation()
 
 		self.__cancelButton.setEnabled( newAnnotation != existingAnnotation )
@@ -365,7 +368,7 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 				return
 
 			if isinstance( graphComponent, Gaffer.ValuePlug ) and hasattr( graphComponent, "getValue" ) :
-				relativeName = graphComponent.relativeName( self.__node )
+				relativeName = graphComponent.relativeName( self.__nodeList[-1] )
 				menuDefinition.append(
 					"/Insert Plug Value/{}".format( "/".join( menuLabel( n ) for n in relativeName.split( "." ) ) ),
 					{
@@ -376,7 +379,7 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 				for plug in Gaffer.Plug.InputRange( graphComponent ) :
 					walkPlugs( plug )
 
-		walkPlugs( self.__node )
+		walkPlugs( self.__nodeList[-1] )
 
 		if not menuDefinition.size() :
 			menuDefinition.append( "/Insert Plug Value/No plugs available", { "active" : False } )

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -46,7 +46,7 @@ import GafferUI
 # Public methods
 ##########################################################################
 
-def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
+def appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition ) :
 
 	if len( menuDefinition.items() ) :
 		menuDefinition.append( "/GraphBookmarksDivider", { "divider" : True } )
@@ -54,9 +54,9 @@ def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
 	menuDefinition.append(
 		"/Bookmarked",
 		{
-			"checkBox" : Gaffer.MetadataAlgo.getBookmarked( node ),
-			"command" : functools.partial( __setBookmarked, node ),
-			"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+			"checkBox" : all( Gaffer.MetadataAlgo.getBookmarked( n ) for n in nodeList ),
+			"command" : functools.partial( __setBookmarked, nodeList ),
+			"active" : not any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList ),
 		}
 	)
 
@@ -64,18 +64,18 @@ def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
 		menuDefinition.append(
 			"/Numeric Bookmark/%s" % i,
 			{
-				"command" : functools.partial( __assignNumericBookmark, node, i ),
+				"command" : functools.partial( __assignNumericBookmark, nodeList[0], i ),
 				"shortCut" : "Ctrl+%i" % i,
-				"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+				"active" : len( nodeList ) == 1 and not Gaffer.MetadataAlgo.readOnly( nodeList[0] ),
 			}
 		)
 
 	menuDefinition.append(
 		"/Numeric Bookmark/Remove",
 		{
-			"command" : functools.partial( __assignNumericBookmark, node, 0 ),
+			"command" : functools.partial( __clearNumericBookmarks, nodeList ),
 			"shortCut" : "Ctrl+0",
-			"active" : Gaffer.MetadataAlgo.numericBookmark( node )
+			"active" : any( Gaffer.MetadataAlgo.numericBookmark( n ) for n in nodeList )
 		}
 	)
 
@@ -169,10 +169,11 @@ def connectToEditor( editor ) :
 # Internal implementation
 ##########################################################################
 
-def __setBookmarked( node, bookmarked ) :
+def __setBookmarked( nodeList, bookmarked ) :
 
-	with Gaffer.UndoScope( node.scriptNode() ) :
-		Gaffer.MetadataAlgo.setBookmarked( node, bookmarked )
+	with Gaffer.UndoScope( nodeList[0].scriptNode() ) :
+		for node in nodeList :
+			Gaffer.MetadataAlgo.setBookmarked( node, bookmarked )
 
 ## \todo Perhaps this functionality should be provided by the
 # GraphGadget or NodeGadget class?
@@ -280,15 +281,25 @@ def __findBookmark( editor, bookmarks = None ) :
 	editor.__findBookmarksMenu = GafferUI.Menu( menuDefinition, title = "Find Bookmark", searchable = True )
 	editor.__findBookmarksMenu.popup()
 
+def __clearSingleNumericBookmark( node ) :
+
+	current = Gaffer.MetadataAlgo.numericBookmark( node )
+	if current :
+		Gaffer.MetadataAlgo.setNumericBookmark( node.scriptNode(), current, None )
+
 def __assignNumericBookmark( node, numericBookmark ) :
 
 	with Gaffer.UndoScope( node.scriptNode() ) :
 		if numericBookmark == 0 : # Remove the current numeric bookmark from selection
-			current = Gaffer.MetadataAlgo.numericBookmark( node )
-			if current :
-				Gaffer.MetadataAlgo.setNumericBookmark( node.scriptNode(), current, None )
+			__clearSingleNumericBookmark( node )
 		else :
 			Gaffer.MetadataAlgo.setNumericBookmark( node.scriptNode(), numericBookmark, node )
+
+def __clearNumericBookmarks( nodeList ) :
+
+	with Gaffer.UndoScope( nodeList[0].scriptNode() ) :
+		for node in nodeList :
+			__clearSingleNumericBookmark( node )
 
 def __findNumericBookmark( editor, numericBookmark ) :
 
@@ -358,5 +369,3 @@ def __editorKeyPress( editor, event ) :
 				editor.setNodeSet( editor.scriptNode().selection() )
 
 			return True
-
-

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -42,6 +42,7 @@ import IECore
 
 import Gaffer
 import GafferUI
+from GafferUI.PlugValueWidget import sole
 
 class _ViewableChildrenPathFilter( Gaffer.PathFilter ) :
 
@@ -307,17 +308,19 @@ class GraphEditor( GafferUI.Editor ) :
 	## May be used from a slot attached to nodeContextMenuSignal() to install a
 	# standard menu item for modifying the enabled state of a node.
 	@classmethod
-	def appendEnabledPlugMenuDefinitions( cls, graphEditor, node, menuDefinition ) :
+	def appendEnabledPlugMenuDefinitions( cls, graphEditor, nodeList, menuDefinition ) :
 
-		enabledPlug = cls.__enabledPlugForEditing( node )
-		if enabledPlug is not None :
+		enabledPlugs = [ cls.__enabledPlugForEditing( node ) for node in nodeList ]
+		if any( p is not None for p in enabledPlugs ) :
+			value = sole( p.getValue() for p in enabledPlugs if p is not None )
+			active = all( enabledPlugs ) and all( p.settable() and not Gaffer.MetadataAlgo.readOnly( p ) for p in enabledPlugs )
 			menuDefinition.append( "/EnabledDivider", { "divider" : True } )
 			menuDefinition.append(
 				"/Enabled",
 				{
-					"command" : functools.partial( cls.__setValue, enabledPlug ),
-					"checkBox" : enabledPlug.getValue(),
-					"active" : enabledPlug.settable() and not Gaffer.MetadataAlgo.readOnly( enabledPlug )
+					"command" : functools.partial( cls.__setValue, enabledPlugs ),
+					"checkBox" : ( value or False ) and active,
+					"active" : active
 				}
 			)
 
@@ -829,10 +832,11 @@ class GraphEditor( GafferUI.Editor ) :
 			graphGadget.setNodeOutputConnectionsMinimised( node, not value )
 
 	@classmethod
-	def __setValue( cls, plug, value ) :
+	def __setValue( cls, plugs, value ) :
 
-		with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
-			plug.setValue( value )
+		with Gaffer.UndoScope( plugs[0].ancestor( Gaffer.ScriptNode ) ) :
+			for p in plugs :
+				p.setValue( value )
 
 	@staticmethod
 	def __childrenViewable( node ) :

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -244,7 +244,7 @@ class GraphEditor( GafferUI.Editor ) :
 	## May be used from a slot attached to nodeContextMenuSignal() to install some
 	# standard menu items for modifying the connection visibility for a node.
 	@classmethod
-	def appendConnectionVisibilityMenuDefinitions( cls, graphEditor, node, menuDefinition ) :
+	def appendConnectionVisibilityMenuDefinitions( cls, graphEditor, nodeList, menuDefinition ) :
 
 		def plugDirectionsWalk( gadget ) :
 
@@ -257,51 +257,58 @@ class GraphEditor( GafferUI.Editor ) :
 
 			return result
 
-		plugDirections = plugDirectionsWalk( graphEditor.graphGadget().nodeGadget( node ) )
+		nodePlugDirections = [ plugDirectionsWalk( graphEditor.graphGadget().nodeGadget( n ) ) for n in nodeList ]
+		plugDirections = set().union( *nodePlugDirections )
 		if not plugDirections :
 			return
 
-		readOnly = Gaffer.MetadataAlgo.readOnly( node )
+		readOnly = any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList )
+		allNodesHavePlugs = all( len( n ) > 0 for n in nodePlugDirections )
+		active = not readOnly and allNodesHavePlugs
 
 		menuDefinition.append( "/ConnectionVisibilityDivider", { "divider" : True } )
 
 		if Gaffer.Plug.Direction.In in plugDirections :
+			value = sole( cls.__getNodeInputConnectionsVisible( graphEditor.graphGadget(), n ) for n in nodeList )
 			menuDefinition.append(
 				"/Connections/Show Input Connections",
 				{
-					"checkBox" : functools.partial( cls.__getNodeInputConnectionsVisible, graphEditor.graphGadget(), node ),
-					"command" : functools.partial( cls.__setNodeInputConnectionsVisible, graphEditor.graphGadget(), node ),
-					"active" : not readOnly,
+					"checkBox" : ( value or False ) and active,
+					"command" : functools.partial( cls.__setNodeInputConnectionsVisible, graphEditor.graphGadget(), nodeList ),
+					"active" : active,
 				}
 			)
 
 		if Gaffer.Plug.Direction.Out in plugDirections :
+			value = sole( cls.__getNodeOutputConnectionsVisible( graphEditor.graphGadget(), n ) for n in nodeList )
 			menuDefinition.append(
 				"/Connections/Show Output Connections",
 				{
-					"checkBox" : functools.partial( cls.__getNodeOutputConnectionsVisible, graphEditor.graphGadget(), node ),
-					"command" : functools.partial( cls.__setNodeOutputConnectionsVisible, graphEditor.graphGadget(), node ),
-					"active" : not readOnly
+					"checkBox" : ( value or False ) and active,
+					"command" : functools.partial( cls.__setNodeOutputConnectionsVisible, graphEditor.graphGadget(), nodeList ),
+					"active" : active,
 				}
 			)
 
 		if Gaffer.Plug.Direction.In in plugDirections :
+			value = sole( cls.__getNoduleLabelsVisible( n, "input" ) for n in nodeList )
 			menuDefinition.append(
 				"/Connections/Show Input Labels",
 				{
-					"checkBox" : functools.partial( cls.__getNoduleLabelsVisible, node, "input" ),
-					"command" : functools.partial( cls.__setNoduleLabelsVisible, node, "input" ),
-					"active" : not readOnly,
+					"checkBox" : ( value or False ) and active,
+					"command" : functools.partial( cls.__setNoduleLabelsVisible, nodeList, "input" ),
+					"active" : active,
 				}
 			)
 
 		if Gaffer.Plug.Direction.Out in plugDirections :
+			value = sole( cls.__getNoduleLabelsVisible( n, "output" ) for n in nodeList )
 			menuDefinition.append(
 				"/Connections/Show Output Labels",
 				{
-					"checkBox" : functools.partial( cls.__getNoduleLabelsVisible, node, "output" ),
-					"command" : functools.partial( cls.__setNoduleLabelsVisible, node, "output" ),
-					"active" : not readOnly,
+					"checkBox" : ( value or False ) and active,
+					"command" : functools.partial( cls.__setNoduleLabelsVisible, nodeList, "output" ),
+					"active" : active,
 				}
 			)
 
@@ -804,10 +811,11 @@ class GraphEditor( GafferUI.Editor ) :
 		return not graphGadget.getNodeInputConnectionsMinimised( node )
 
 	@classmethod
-	def __setNodeInputConnectionsVisible( cls, graphGadget, node, value ) :
+	def __setNodeInputConnectionsVisible( cls, graphGadget, nodeList, value ) :
 
-		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
-			graphGadget.setNodeInputConnectionsMinimised( node, not value )
+		with Gaffer.UndoScope( nodeList[0].ancestor( Gaffer.ScriptNode ) ) :
+			for node in nodeList :
+				graphGadget.setNodeInputConnectionsMinimised( node, not value )
 
 	@classmethod
 	def __getNoduleLabelsVisible( cls, node, direction ) :
@@ -815,10 +823,11 @@ class GraphEditor( GafferUI.Editor ) :
 		return Gaffer.Metadata.value( node, f"nodeGadget:{direction}NoduleLabelsVisible" ) or False
 
 	@classmethod
-	def __setNoduleLabelsVisible( cls, node, direction, value ) :
+	def __setNoduleLabelsVisible( cls, nodeList, direction, value ) :
 
-		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
-			Gaffer.Metadata.registerValue( node, f"nodeGadget:{direction}NoduleLabelsVisible", value )
+		with Gaffer.UndoScope( nodeList[0].ancestor( Gaffer.ScriptNode ) ) :
+			for node in nodeList :
+				Gaffer.Metadata.registerValue( node, f"nodeGadget:{direction}NoduleLabelsVisible", value )
 
 	@classmethod
 	def __getNodeOutputConnectionsVisible( cls, graphGadget, node ) :
@@ -826,10 +835,11 @@ class GraphEditor( GafferUI.Editor ) :
 		return not graphGadget.getNodeOutputConnectionsMinimised( node )
 
 	@classmethod
-	def __setNodeOutputConnectionsVisible( cls, graphGadget, node, value ) :
+	def __setNodeOutputConnectionsVisible( cls, graphGadget, nodeList, value ) :
 
-		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
-			graphGadget.setNodeOutputConnectionsMinimised( node, not value )
+		with Gaffer.UndoScope( nodeList[0].ancestor( Gaffer.ScriptNode ) ) :
+			for node in nodeList :
+				graphGadget.setNodeOutputConnectionsMinimised( node, not value )
 
 	@classmethod
 	def __setValue( cls, plugs, value ) :

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -221,15 +221,23 @@ class GraphEditor( GafferUI.Editor ) :
 		__append( destinationPlug, "Destination Node" )
 
 	__nodeContextMenuSignal = Gaffer.Signals.Signal3()
+	__multiNodeContextMenuSignal = Gaffer.Signals.Signal3()
 	## Returns a signal which is emitted to create a context menu for a
 	# node in the graph. Slots may connect to this signal to edit the
-	# menu definition on the fly - the signature for the signal is
-	# ( graphEditor, node, menuDefinition ) and the menu definition should just be
-	# edited in place. Typically you would add slots to this signal
-	# as part of a startup script.
-	@classmethod
-	def nodeContextMenuSignal( cls ) :
+	# menu definition on the fly. If `multiNode` is `False`, the signature
+	# for the signal is ( graphEditor, node, menuDefinition ).
+	# Otherwise the signature is ( graphEditor, nodeList, menuDefinition ).
+	# The menu is built by first emitting the multi-node signal then the
+	# single node signal with the same `menuDefinition`.
+	# For both, the menu definition should just be edited in place. Typically
+	# you would add slots to this signal as part of a startup script.
 
+	# \todo Deprecate the single node signal in version `1.8` and remove it in `1.9`.
+	@classmethod
+	def nodeContextMenuSignal( cls, multiNode = False ) :
+
+		if multiNode :
+			return cls.__multiNodeContextMenuSignal
 		return cls.__nodeContextMenuSignal
 
 	## May be used from a slot attached to nodeContextMenuSignal() to install some
@@ -430,8 +438,13 @@ class GraphEditor( GafferUI.Editor ) :
 					if not isinstance( nodeGadget, GafferUI.NodeGadget ) :
 						nodeGadget = nodeGadget.ancestor( GafferUI.NodeGadget )
 					if nodeGadget is not None :
+						selection = self.scriptNode().selection()
+						nodeList = list( selection ) if nodeGadget.node() in selection else [nodeGadget.node()]
+						self.nodeContextMenuSignal( True )( self, nodeList, overrideMenuDefinition )
+
 						self.nodeContextMenuSignal()( self, nodeGadget.node(), overrideMenuDefinition )
-						overrideMenuTitle = nodeGadget.node().getName()
+
+						overrideMenuTitle = ( "{} Nodes".format( len( nodeList ) ) ) if len( nodeList ) > 1 else nodeList[0].getName()
 
 				if len( overrideMenuDefinition.items() ) :
 					menuDefinition = overrideMenuDefinition

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -332,20 +332,23 @@ class GraphEditor( GafferUI.Editor ) :
 			)
 
 	@classmethod
-	def appendContentsMenuDefinitions( cls, graphEditor, node, menuDefinition ) :
+	def appendContentsMenuDefinitions( cls, graphEditor, nodeList, menuDefinition ) :
 
 		menuDefinition.append( "/FocusDivider", { "divider" : True } )
 		menuDefinition.append( "/Focus", {
-			"command" : functools.partial( graphEditor.scriptNode().setFocus, node ),
-			"active" : not node.isSame( graphEditor.scriptNode().getFocus() ),
+			"command" : functools.partial( graphEditor.scriptNode().setFocus, nodeList[0] ),
+			"active" : len( nodeList ) == 1 and not nodeList[0].isSame( graphEditor.scriptNode().getFocus() ),
 			"shortCut" : "Ctrl+`"
 		} )
 
-		if not GraphEditor.__childrenViewable( node ) :
+		if not any( GraphEditor.__childrenViewable( n ) for n in nodeList ) :
 			return
 
 		menuDefinition.append( "/ContentsDivider", { "divider" : True } )
-		menuDefinition.append( "/Show Contents...", { "command" : functools.partial( cls.acquire, node ) } )
+		menuDefinition.append( "/Show Contents...", {
+			"command" : functools.partial( cls.__acquireNodes, nodeList ),
+			"active" : all( GraphEditor.__childrenViewable( n ) for n in nodeList )
+		} )
 
 	__nodeDoubleClickSignal = GafferUI.WidgetEventSignal()
 	## Returns a signal which is emitted whenever a node is double clicked.
@@ -847,6 +850,12 @@ class GraphEditor( GafferUI.Editor ) :
 		with Gaffer.UndoScope( plugs[0].ancestor( Gaffer.ScriptNode ) ) :
 			for p in plugs :
 				p.setValue( value )
+
+	@classmethod
+	def __acquireNodes( cls, nodeList ) :
+
+		for n in nodeList :
+			cls.acquire( n )
 
 	@staticmethod
 	def __childrenViewable( node ) :

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -172,48 +172,49 @@ def _load( node, filePath, parentWindow ) :
 # GraphEditor node context menu
 ##########################################################################
 
-def __duplicateAsBox( graphEditor, node ) :
+def __duplicateAsBox( graphEditor, nodeList ) :
 
-	script = node.scriptNode()
+	script = nodeList[0].scriptNode()
 	with Gaffer.UndoScope( script ) :
 
-		box = Gaffer.Box( node.getName() + "Copy" )
-		# We don't want to parent the box to `script` until it is
-		# fully loaded (we don't want to emit signals in an intermediate
-		# state). But we need a ScriptNode to be able to perform the loading,
-		# so we use a temporary script for that.
-		temporaryScript = Gaffer.ScriptNode()
-		temporaryScript.addChild( box )
-
-		with GafferUI.ErrorDialogue.ErrorHandler(
-			title = "Errors Occurred During Loading",
-			closeLabel = "Oy vey",
-			parentWindow = graphEditor.ancestor( GafferUI.Window ),
-		) :
-			sp = IECore.SearchPath( os.environ.get( "GAFFER_REFERENCE_PATHS", "" ) )
-			temporaryScript.executeFile( sp.find( str( node.fileName() ) ), parent = box, continueOnError = True )
-
-		node.parent().addChild( box )
-
-		graphGadget = graphEditor.graphGadget()
-		graphGadget.getLayout().positionNode(
-			graphGadget, box, fallbackPosition = graphGadget.getNodePosition( node )
-		)
-
 		script.selection().clear()
-		script.selection().add( box )
+		graphGadget = graphEditor.graphGadget()
+		for node in nodeList :
+			box = Gaffer.Box( node.getName() + "Copy" )
+			# We don't want to parent the box to `script` until it is
+			# fully loaded (we don't want to emit signals in an intermediate
+			# state). But we need a ScriptNode to be able to perform the loading,
+			# so we use a temporary script for that.
+			temporaryScript = Gaffer.ScriptNode()
+			temporaryScript.addChild( box )
 
-def __graphEditorNodeContextMenu( graphEditor, node, menuDefinition ) :
+			with GafferUI.ErrorDialogue.ErrorHandler(
+				title = "Errors Occurred During Loading",
+				closeLabel = "Oy vey",
+				parentWindow = graphEditor.ancestor( GafferUI.Window ),
+			) :
+				sp = IECore.SearchPath( os.environ.get( "GAFFER_REFERENCE_PATHS", "" ) )
+				temporaryScript.executeFile( sp.find( str( node.fileName() ) ), parent = box, continueOnError = True )
 
-	if not isinstance( node, Gaffer.Reference ) :
+			node.parent().addChild( box )
+
+			graphGadget.getLayout().positionNode(
+				graphGadget, box, fallbackPosition = graphGadget.getNodePosition( node )
+			)
+
+			script.selection().add( box )
+
+def __graphEditorNodeContextMenu( graphEditor, nodeList, menuDefinition ) :
+
+	if not any( isinstance( n, Gaffer.Reference ) for n in nodeList ) :
 		return
 
 	menuDefinition.append(
 		"/Duplicate as Box",
 		{
-			"command" : functools.partial( __duplicateAsBox, graphEditor, node ),
-			"active" : bool( node.fileName() ),
+			"command" : functools.partial( __duplicateAsBox, graphEditor, nodeList ),
+			"active" : all( isinstance( n, Gaffer.Reference ) and bool( n.fileName() ) for n in nodeList ),
 		}
 	)
 
-GafferUI.GraphEditor.nodeContextMenuSignal().connect( __graphEditorNodeContextMenu )
+GafferUI.GraphEditor.nodeContextMenuSignal( True ).connect( __graphEditorNodeContextMenu )

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -172,13 +172,12 @@ def _load( node, filePath, parentWindow ) :
 # GraphEditor node context menu
 ##########################################################################
 
-def __duplicateAsBox( graphEditor, nodeList ) :
+def __duplicateAsBox( graphGadget, nodeList ) :
 
 	script = nodeList[0].scriptNode()
 	with Gaffer.UndoScope( script ) :
 
 		script.selection().clear()
-		graphGadget = graphEditor.graphGadget()
 		for node in nodeList :
 			box = Gaffer.Box( node.getName() + "Copy" )
 			# We don't want to parent the box to `script` until it is
@@ -191,7 +190,7 @@ def __duplicateAsBox( graphEditor, nodeList ) :
 			with GafferUI.ErrorDialogue.ErrorHandler(
 				title = "Errors Occurred During Loading",
 				closeLabel = "Oy vey",
-				parentWindow = graphEditor.ancestor( GafferUI.Window ),
+				parentWindow = GafferUI.ScriptWindow.acquire( graphGadget.getRoot().scriptNode(), createIfNecessary = False ),
 			) :
 				sp = IECore.SearchPath( os.environ.get( "GAFFER_REFERENCE_PATHS", "" ) )
 				temporaryScript.executeFile( sp.find( str( node.fileName() ) ), parent = box, continueOnError = True )
@@ -212,7 +211,7 @@ def __graphEditorNodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	menuDefinition.append(
 		"/Duplicate as Box",
 		{
-			"command" : functools.partial( __duplicateAsBox, graphEditor, nodeList ),
+			"command" : functools.partial( __duplicateAsBox, graphEditor.graphGadget(), nodeList ),
 			"active" : all( isinstance( n, Gaffer.Reference ) and bool( n.fileName() ) for n in nodeList ),
 		}
 	)

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -47,6 +47,7 @@ import IECore
 
 import Gaffer
 import GafferUI
+from GafferUI.PlugValueWidget import sole
 from . import MetadataWidget
 
 ## The UIEditor class allows the user to edit the interfaces for nodes.
@@ -175,28 +176,31 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 		return self.__plugTab
 
 	@classmethod
-	def appendNodeContextMenuDefinitions( cls, graphEditor, node, menuDefinition ) :
+	def appendNodeContextMenuDefinitions( cls, graphEditor, nodeList, menuDefinition ) :
 
 		menuDefinition.append( "/UIEditorDivider", { "divider" : True } )
 		menuDefinition.append(
 			"/Set Color...",
 			{
-				"command" : functools.partial( cls.__setColor, node = node ),
-				"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+				"command" : functools.partial( cls.__setColor, nodeList = nodeList ),
+				"active" : not any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList ),
 			}
 		)
 
-		nodeGadgetTypes = Gaffer.Metadata.value( node, "uiEditor:nodeGadgetTypes" )
-		if nodeGadgetTypes :
-			nodeGadgetTypes = set( nodeGadgetTypes )
-			if nodeGadgetTypes == { "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" } :
-				nodeGadgetType = Gaffer.Metadata.value( node, "nodeGadget:type" ) or "GafferUI::StandardNodeGadget"
+		nodeGadgetTypes = set().union( *( Gaffer.Metadata.value( n, "uiEditor:nodeGadgetTypes" ) or { None } for n in nodeList ) )
+
+		if nodeGadgetTypes != { None } :
+			if (
+				nodeGadgetTypes == { "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" } or
+				nodeGadgetTypes == { None, "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" }
+			) :
+				nodeGadgetType = sole( Gaffer.Metadata.value( n, "nodeGadget:type" ) or "GafferUI::StandardNodeGadget" for n in nodeList )
 				menuDefinition.append(
 					"/Show Name",
 					{
-						"command" : functools.partial( cls.__setNameVisible, node ),
-						"checkBox" : nodeGadgetType == "GafferUI::StandardNodeGadget",
-						"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+						"command" : functools.partial( cls.__setNameVisible, nodeList ),
+						"checkBox" : None not in nodeGadgetTypes and nodeGadgetType == "GafferUI::StandardNodeGadget",
+						"active" : not any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList ) and None not in nodeGadgetTypes
 					}
 				)
 			else :
@@ -332,23 +336,25 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 		return "GafferUI.UIEditor( scriptNode )"
 
 	@classmethod
-	def __setColor( cls, menu, node ) :
+	def __setColor( cls, menu, nodeList ) :
 
-		color = Gaffer.Metadata.value( node, "nodeGadget:color" ) or imath.Color3f( 1 )
+		color = Gaffer.Metadata.value( nodeList[-1], "nodeGadget:color" ) or imath.Color3f( 1 )
 		dialogue = GafferUI.ColorChooserDialogue( color = color, displayTransform = GafferUI.Widget.identityDisplayTransform )
 		color = dialogue.waitForColor( parentWindow = menu.ancestor( GafferUI.Window ) )
 		if color is not None :
-			with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
-				Gaffer.Metadata.registerValue( node, "nodeGadget:color", color )
+			with Gaffer.UndoScope( nodeList[0].ancestor( Gaffer.ScriptNode ) ) :
+				for node in nodeList :
+					Gaffer.Metadata.registerValue( node, "nodeGadget:color", color )
 
 	@staticmethod
-	def __setNameVisible( node, nameVisible ) :
+	def __setNameVisible( nodeList, nameVisible ) :
 
-		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
-			Gaffer.Metadata.registerValue(
-				node, "nodeGadget:type",
-				"GafferUI::StandardNodeGadget" if nameVisible else "GafferUI::AuxiliaryNodeGadget"
-			)
+		with Gaffer.UndoScope( nodeList[0].ancestor( Gaffer.ScriptNode ) ) :
+			for node in nodeList :
+				Gaffer.Metadata.registerValue(
+					node, "nodeGadget:type",
+					"GafferUI::StandardNodeGadget" if nameVisible else "GafferUI::AuxiliaryNodeGadget"
+				)
 
 GafferUI.Editor.registerType( "UIEditor", UIEditor )
 

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -109,10 +109,10 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
+	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
-	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -97,9 +97,16 @@ def __nodeDoubleClick( graphEditor, node ) :
 
 GafferUI.GraphEditor.nodeDoubleClickSignal().connect( __nodeDoubleClick )
 
-def __nodeContextMenu( graphEditor, node, menuDefinition ) :
+def __acquireNodeEditors( nodeList ) :
 
-	menuDefinition.append( "/Edit...", { "command" : functools.partial( GafferUI.NodeEditor.acquire, node, floating = True ) } )
+	for n in nodeList :
+		GafferUI.NodeEditor.acquire( n, floating = True )
+
+def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
+
+	menuDefinition.append( "/Edit...", { "command" : functools.partial( __acquireNodeEditors, nodeList ) } )
+
+def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
 	GafferUI.GraphEditor.appendEnabledPlugMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, node, menuDefinition )
@@ -110,7 +117,8 @@ def __nodeContextMenu( graphEditor, node, menuDefinition ) :
 	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 
-GafferUI.GraphEditor.nodeContextMenuSignal().connect( __nodeContextMenu )
+GafferUI.GraphEditor.nodeContextMenuSignal( True ).connect( __nodeContextMenu )
+GafferUI.GraphEditor.nodeContextMenuSignal().connect( __singleNodeContextMenu )
 
 def __plugContextMenu( graphEditor, plug, menuDefinition ) :
 

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -111,10 +111,10 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
+	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
-	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 
 GafferUI.GraphEditor.nodeContextMenuSignal( True ).connect( __nodeContextMenu )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -108,10 +108,10 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	GafferUI.GraphEditor.appendEnabledPlugMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, nodeList, menuDefinition )
+	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
-	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -105,10 +105,10 @@ def __acquireNodeEditors( nodeList ) :
 def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 
 	menuDefinition.append( "/Edit...", { "command" : functools.partial( __acquireNodeEditors, nodeList ) } )
+	GafferUI.GraphEditor.appendEnabledPlugMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
-	GafferUI.GraphEditor.appendEnabledPlugMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -107,10 +107,10 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	menuDefinition.append( "/Edit...", { "command" : functools.partial( __acquireNodeEditors, nodeList ) } )
 	GafferUI.GraphEditor.appendEnabledPlugMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, nodeList, menuDefinition )
+	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
-	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -106,10 +106,10 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 
 	menuDefinition.append( "/Edit...", { "command" : functools.partial( __acquireNodeEditors, nodeList ) } )
 	GafferUI.GraphEditor.appendEnabledPlugMenuDefinitions( graphEditor, nodeList, menuDefinition )
+	GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
-	GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -112,13 +112,9 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
-
-def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
-
-	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
+	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 GafferUI.GraphEditor.nodeContextMenuSignal( True ).connect( __nodeContextMenu )
-GafferUI.GraphEditor.nodeContextMenuSignal().connect( __singleNodeContextMenu )
 
 def __plugContextMenu( graphEditor, plug, menuDefinition ) :
 

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -110,10 +110,10 @@ def __nodeContextMenu( graphEditor, nodeList, menuDefinition ) :
 	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
+	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, nodeList, menuDefinition )
 
 def __singleNodeContextMenu( graphEditor, node, menuDefinition ) :
 
-	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferSceneUI.CryptomatteUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 


### PR DESCRIPTION
This updates the menu commands on the Graph Editor's node context menu to handle all of the selected nodes instead of only the node that was clicked on to open the context menu.

Fixes #2783 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
