### PR TITLE
QuantizePrimitiveVariables : Add new node based on Instancer internals

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.7.x.x (relative to 1.7.0.0a8)
 =======
 
+Features
+--------
 
+- QuantizePrimitiveVariables : Added new node for quantizing the values of primitive variables.
 
 1.7.0.0a8 (relative to 1.7.0.0a7)
 =========

--- a/include/GafferScene/QuantizePrimitiveVariables.h
+++ b/include/GafferScene/QuantizePrimitiveVariables.h
@@ -1,0 +1,71 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Image Engine Design Inc nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/PrimitiveVariableProcessor.h"
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API QuantizePrimitiveVariables : public PrimitiveVariableProcessor
+{
+
+	public :
+
+		explicit QuantizePrimitiveVariables( const std::string &name = defaultName<QuantizePrimitiveVariables>() );
+		~QuantizePrimitiveVariables() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::QuantizePrimitiveVariables, QuantizePrimitiveVariablesTypeId, PrimitiveVariableProcessor );
+
+		Gaffer::FloatPlug *quantizationPlug();
+		const Gaffer::FloatPlug *quantizationPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECoreScene::ConstPrimitivePtr inputGeometry, IECoreScene::PrimitiveVariable &inputVariable ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+};
+
+IE_CORE_DECLAREPTR( QuantizePrimitiveVariables )
+
+} // namespace GafferScene

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -202,6 +202,7 @@ enum TypeId
 	PrimitiveQueryTypeId = 120157,
 	SceneStatsTypeId = 120158,
 	CopyObjectTypeId = 120159,
+	QuantizePrimitiveVariablesTypeId = 120160,
 
 	LastTypeId = 120999
 };

--- a/python/GafferSceneTest/QuantizePrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/QuantizePrimitiveVariablesTest.py
@@ -1,0 +1,190 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of  Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import math
+
+import imath
+
+import IECore
+import IECoreScene
+
+import GafferScene
+import GafferSceneTest
+
+class QuantizePrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
+
+	def testNumericTypes( self ) :
+
+		points = IECoreScene.PointsPrimitive( 0 )
+		points["float"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( 0.1 )
+		)
+		points["int"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.IntData( 5 )
+		)
+		points["v2i"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V2iData( imath.V2i( 20, 35 ) )
+		)
+		points["v3i"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V3iData( imath.V3i( -10, 101, 5 ) )
+		)
+		points["v2f"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V2fData( imath.V2f( 20.2, 350.1 ) )
+		)
+		points["v3f"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V3fData( imath.V3f( -10.5, 101.2, 50 ) )
+		)
+		points["color3f"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.Color3fData( imath.Color3f( 99, 1, 505 ) )
+		)
+		points["floatArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatVectorData( [ 0.1, 0.4, 5.1 ] )
+		)
+		points["intArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.IntVectorData( [ 3, 4, 5 ] )
+		)
+		points["v2iArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V2iVectorData( [ imath.V2i( 1, 2 ), imath.V2i( 4, 5 ) ] )
+		)
+		points["v3iArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V3iVectorData( [ imath.V3i( 1, 2, 3 ), imath.V3i( 4, 5, 6 ) ] )
+		)
+		points["v2fArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V2fVectorData( [ imath.V2f( 111, 112 ), imath.V2f( 114, 115 ) ] )
+		)
+		points["v3fArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] )
+		)
+		points["color3fArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.Color3fVectorData( [ imath.Color3f( -1, -2, -3 ), imath.Color3f( -4, -5, -6 ) ] )
+		)
+
+		objectToScene = GafferScene.ObjectToScene()
+		objectToScene["object"].setValue( points )
+
+		objectFilter = GafferScene.PathFilter()
+		objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+		quantize = GafferScene.QuantizePrimitiveVariables()
+		quantize["in"].setInput( objectToScene["out"] )
+		quantize["filter"].setInput( objectFilter["out"] )
+		quantize["names"].setValue( "*" )
+		quantize["quantization"].setValue( 4 )
+
+		points = quantize["out"].object( "/object" )
+		self.assertEqual( points["float"].data, IECore.FloatData( 0 ) )
+		self.assertEqual( points["int"].data, IECore.IntData( 4 ) )
+		self.assertEqual( points["v2i"].data, IECore.V2iData( imath.V2i( 20, 36 ) ) )
+		self.assertEqual( points["v3i"].data, IECore.V3iData( imath.V3i( -8, 100, 4 ) ) )
+		self.assertEqual( points["v2f"].data, IECore.V2fData( imath.V2f( 20, 352 ) ) )
+		self.assertEqual( points["v3f"].data, IECore.V3fData( imath.V3f( -12, 100, 52 ) ) )
+		self.assertEqual( points["color3f"].data, IECore.Color3fData( imath.Color3f( 100, 0, 504 ) ) )
+		self.assertEqual( points["floatArray"].data, IECore.FloatVectorData( [ 0, 0, 4 ] ) )
+		self.assertEqual( points["intArray"].data, IECore.IntVectorData( [ 4, 4, 4 ] ) )
+		self.assertEqual( points["v2iArray"].data, IECore.V2iVectorData( [ imath.V2i( 0, 4 ), imath.V2i( 4, 4 ) ] ) )
+		self.assertEqual( points["v3iArray"].data, IECore.V3iVectorData( [ imath.V3i( 0, 4, 4 ), imath.V3i( 4, 4, 8 ) ] ) )
+		self.assertEqual( points["v2fArray"].data, IECore.V2fVectorData( [ imath.V2f( 112, 112 ), imath.V2f( 116, 116 ) ] ) )
+		self.assertEqual( points["v3fArray"].data, IECore.V3fVectorData( [ imath.V3f( 0, 4, 4 ), imath.V3f( 4, 4, 8 ) ] ) )
+		self.assertEqual( points["color3fArray"].data, IECore.Color3fVectorData( [ imath.Color3f( 0, -4, -4 ), imath.Color3f( -4, -4, -8 ) ] ) )
+
+	def testNonNumericTypesPassThrough( self ) :
+
+		points = IECoreScene.PointsPrimitive( 0 )
+		points["string"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringData( "Hello" )
+		)
+		points["stringArray"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringVectorData( [ "Hello" ] )
+		)
+
+		objectToScene = GafferScene.ObjectToScene()
+		objectToScene["object"].setValue( points )
+
+		objectFilter = GafferScene.PathFilter()
+		objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+		quantize = GafferScene.QuantizePrimitiveVariables()
+		quantize["in"].setInput( objectToScene["out"] )
+		quantize["filter"].setInput( objectFilter["out"] )
+		quantize["names"].setValue( "string*" )
+		quantize["quantization"].setValue( 4 )
+
+		self.assertEqual( quantize["out"].object( "/object" ), quantize["in"].object( "/object" ) )
+
+	def testNegativeZero( self ) :
+
+		points = IECoreScene.PointsPrimitive( 0 )
+		points["float"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( -0.1 )
+		)
+
+		objectToScene = GafferScene.ObjectToScene()
+		objectToScene["object"].setValue( points )
+
+		objectFilter = GafferScene.PathFilter()
+		objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+		quantize = GafferScene.QuantizePrimitiveVariables()
+		quantize["in"].setInput( objectToScene["out"] )
+		quantize["filter"].setInput( objectFilter["out"] )
+		quantize["names"].setValue( "*" )
+		quantize["quantization"].setValue( 0.5 )
+
+		points = quantize["out"].object( "/object" )
+		self.assertEqual( points["float"].data.value, 0.0 )
+		self.assertEqual( math.copysign( 1,  points["float"].data.value ), 1 )
+
+	def testPassThroughForZeroQuantization( self ) :
+
+		points = IECoreScene.PointsPrimitive( 0 )
+		points["float"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( -0.1 )
+		)
+
+		objectToScene = GafferScene.ObjectToScene()
+		objectToScene["object"].setValue( points )
+
+		objectFilter = GafferScene.PathFilter()
+		objectFilter["paths"].setValue( IECore.StringVectorData( [ "/object" ] ) )
+
+		quantize = GafferScene.QuantizePrimitiveVariables()
+		quantize["in"].setInput( objectToScene["out"] )
+		quantize["filter"].setInput( objectFilter["out"] )
+		quantize["names"].setValue( "*" )
+		self.assertEqual( quantize["quantization"].getValue(), 0 )
+
+		self.assertScenesEqual( quantize["out"], quantize["in"] )
+		self.assertSceneHashesEqual( quantize["out"], quantize["in"] )

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -202,6 +202,7 @@ from .PrimitiveQueryTest import PrimitiveQueryTest
 from .SceneStatsTest import SceneStatsTest
 from .PointInstancerAlgoTest import PointInstancerAlgoTest
 from .CopyObjectTest import CopyObjectTest
+from .QuantizePrimitiveVariablesTest import QuantizePrimitiveVariablesTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/QuantizePrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/QuantizePrimitiveVariablesUI.py
@@ -1,0 +1,67 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.QuantizePrimitiveVariables,
+
+	"description",
+	"""
+	Quantizes the values of numeric primitive variables.
+	Compound types such as vectors and colours are quantized
+	on a component-by-component basis, with each component being
+	quantized individually.
+	""",
+
+	plugs = {
+
+		"quantization" : {
+
+			"description" :
+			"""
+			Controls the quantization. Each input value is rounded to the
+			nearest multiple of the `quantization` value. The default of 0.0
+			produces no quantization and increasing values cause quantization
+			into increasingly coarse bands.
+			""",
+
+		}
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -220,6 +220,7 @@ from . import MeshLightUI
 from . import AttributeProcessorUI
 from . import CurvesTangentsUI
 from . import CopyObjectUI
+from . import QuantizePrimitiveVariablesUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/QuantizePrimitiveVariables.cpp
+++ b/src/GafferScene/QuantizePrimitiveVariables.cpp
@@ -1,0 +1,165 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Image Engine Design Inc nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/QuantizePrimitiveVariables.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/TypeTraits.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+namespace
+{
+
+// Quantization logic copied from Instancer.cpp.
+
+template<typename T>
+inline T quantize( T v, float q )
+{
+	if( q == 0.0f )
+	{
+		return v;
+	}
+
+	if( std::is_integral_v<T> )
+	{
+		T intQuantize = round( q );
+		if( intQuantize == 0 )
+		{
+			return v;
+		}
+		T halfQuantize = intQuantize / 2;
+		return intQuantize * ( ( v + halfQuantize ) / intQuantize );
+	}
+	else
+	{
+		T r = q * round( v / q );
+		// Convert negative zero to zero.
+		if( r == 0 )
+		{
+			r = 0;
+		}
+		return r;
+	}
+}
+
+} // namespace
+
+GAFFER_NODE_DEFINE_TYPE( QuantizePrimitiveVariables );
+
+size_t QuantizePrimitiveVariables::g_firstPlugIndex = 0;
+
+QuantizePrimitiveVariables::QuantizePrimitiveVariables( const std::string &name ) : PrimitiveVariableProcessor( name, IECore::PathMatcher::NoMatch )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new FloatPlug( "quantization", Plug::In, 0, 0 ) );
+}
+
+QuantizePrimitiveVariables::~QuantizePrimitiveVariables()
+{
+}
+
+Gaffer::FloatPlug *QuantizePrimitiveVariables::quantizationPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::FloatPlug *QuantizePrimitiveVariables::quantizationPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex );
+}
+
+void QuantizePrimitiveVariables::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	PrimitiveVariableProcessor::affects( input, outputs );
+
+	if( input == quantizationPlug() )
+	{
+		outputs.push_back( outPlug()->objectPlug() );
+	}
+}
+
+void QuantizePrimitiveVariables::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	const float q = quantizationPlug()->getValue();
+	if( q == 0.0f )
+	{
+		h = inPlug()->objectPlug()->hash();
+	}
+	else
+	{
+		PrimitiveVariableProcessor::hashProcessedObject( path, context, h );
+		h.append( q );
+	}
+}
+
+void QuantizePrimitiveVariables::processPrimitiveVariable( const ScenePath &path, const Gaffer::Context *context, IECoreScene::ConstPrimitivePtr inputGeometry, IECoreScene::PrimitiveVariable &variable ) const
+{
+	const float q = quantizationPlug()->getValue();
+	if( q == 0.0f )
+	{
+		return;
+	}
+
+	dispatch(
+
+		variable.data.get(),
+
+		[&] ( auto *data ) -> void {
+
+			using DataType = remove_const_t<remove_pointer_t<decltype( data )>>;
+
+			if constexpr( TypeTraits::IsNumericBasedTypedData<DataType>::value )
+			{
+				/// \todo Thread using TBB. So we can deal with cache policies properly,
+				/// this means rederiving PrimitiveVariableProcessor from ObjectProcessor.
+				/// I'm not sure PrimitiveVariableProcessor is actually all that useful - it's
+				/// kindof in the way right now.
+				for( auto p = data->baseWritable(), e = data->baseWritable() + data->baseSize(); p < e; ++p )
+				{
+					*p = quantize( *p, q );
+				}
+			}
+
+		}
+
+	);
+}

--- a/src/GafferSceneModule/PrimitiveVariablesBinding.cpp
+++ b/src/GafferSceneModule/PrimitiveVariablesBinding.cpp
@@ -47,6 +47,7 @@
 #include "GafferScene/PrimitiveVariableExists.h"
 #include "GafferScene/PrimitiveVariables.h"
 #include "GafferScene/PrimitiveVariableTweaks.h"
+#include "GafferScene/QuantizePrimitiveVariables.h"
 #include "GafferScene/ResamplePrimitiveVariables.h"
 #include "GafferScene/ShufflePrimitiveVariables.h"
 
@@ -64,6 +65,7 @@ void GafferSceneModule::bindPrimitiveVariables()
 	GafferBindings::DependencyNodeClass<CollectPrimitiveVariables>();
 	GafferBindings::DependencyNodeClass<PrimitiveVariableExists>();
 	GafferBindings::DependencyNodeClass<ShufflePrimitiveVariables>();
+	GafferBindings::DependencyNodeClass<QuantizePrimitiveVariables>();
 
 	{
 		boost::python::scope tweaksScope = GafferBindings::DependencyNodeClass<PrimitiveVariableTweaks>();

--- a/src/GafferSceneModule/PrimitiveVariablesBinding.cpp
+++ b/src/GafferSceneModule/PrimitiveVariablesBinding.cpp
@@ -38,17 +38,17 @@
 
 #include "PrimitiveVariablesBinding.h"
 
+#include "GafferBindings/DependencyNodeBinding.h"
+
+#include "GafferScene/CollectPrimitiveVariables.h"
 #include "GafferScene/DeletePrimitiveVariables.h"
 #include "GafferScene/MapOffset.h"
 #include "GafferScene/MapProjection.h"
-#include "GafferScene/PrimitiveVariables.h"
-#include "GafferScene/ResamplePrimitiveVariables.h"
-#include "GafferScene/CollectPrimitiveVariables.h"
 #include "GafferScene/PrimitiveVariableExists.h"
-#include "GafferScene/ShufflePrimitiveVariables.h"
+#include "GafferScene/PrimitiveVariables.h"
 #include "GafferScene/PrimitiveVariableTweaks.h"
-
-#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferScene/ResamplePrimitiveVariables.h"
+#include "GafferScene/ShufflePrimitiveVariables.h"
 
 using namespace GafferScene;
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -279,6 +279,7 @@ nodeMenu.append( "/Scene/Object/Copy Primitive Variables", GafferScene.CopyPrimi
 nodeMenu.append( "/Scene/Object/Delete Primitive Variables", GafferScene.DeletePrimitiveVariables, searchText = "DeletePrimitiveVariables" )
 nodeMenu.append( "/Scene/Object/Shuffle Primitive Variables", GafferScene.ShufflePrimitiveVariables, searchText = "ShufflePrimitiveVariables" )
 nodeMenu.append( "/Scene/Object/Resample Primitive Variables", GafferScene.ResamplePrimitiveVariables, searchText = "ResamplePrimitiveVariables" )
+nodeMenu.append( "/Scene/Object/Quantize Primitive Variables", GafferScene.QuantizePrimitiveVariables, searchText = "QuantizePrimitiveVariables" )
 nodeMenu.append( "/Scene/Object/Collect Primitive Variables", GafferScene.CollectPrimitiveVariables, searchText = "CollectPrimitiveVariables" )
 nodeMenu.append( "/Scene/Object/Primitive Variable Tweaks", GafferScene.PrimitiveVariableTweaks, searchText = "PrimitiveVariableTweaks" )
 nodeMenu.append( "/Scene/Object/Orientation", GafferScene.Orientation )


### PR DESCRIPTION
This will support the creation of a new more modular-minded PointInstancer node, where the user will be responsible for quantizing any values used for generating prototype variation.