### PR TITLE
CI : Update RenderMan 26.4 download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,7 +282,7 @@ jobs:
     - name: Install RenderMan 26.4
       run: |
         rm -r "$RMANTREE" # Free up precious disk space from the previous installation
-        ./.github/workflows/main/installRenderMan.py --version 26.4 --dailyBuildDate 2026-06-16 --outputFormat "RMANTREE={rmanTree}" >> $GITHUB_ENV
+        ./.github/workflows/main/installRenderMan.py --version 26.4 --dailyBuildDate 2026-07-16 --outputFormat "RMANTREE={rmanTree}" >> $GITHUB_ENV
       shell: bash
       env:
         RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}


### PR DESCRIPTION
Another round of "find the latest available 26.4 build"... I've diffed the include directories and the only change is the expected `_PRMANAPI_VERSION_BUILD_` bump.