### PR TITLE
SceneView : Add option to show frame time in ms

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - RenderMan : Added support for RenderMan 27.3.
+- SceneView : Added frame time display.
 
 1.7.0.0a7 (relative to 1.7.0.0a6)
 =========

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -142,6 +142,8 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 		std::unique_ptr<Gnomon> m_gnomon;
 		class FPS;
 		std::unique_ptr<FPS> m_fps;
+		class FrameTime;
+		std::unique_ptr<FrameTime> m_frameTime;
 
 		static size_t g_firstPlugIndex;
 		static ViewDescription<SceneView> g_viewDescription;

--- a/include/GafferUI/FPSGadget.h
+++ b/include/GafferUI/FPSGadget.h
@@ -49,7 +49,7 @@ class GAFFERUI_API FPSGadget : public Gadget
 
 	public :
 
-		explicit FPSGadget( Imath::V3f defaultPosition = Imath::V3f( 5.0f, 50.0f, 0.0f ) );
+		explicit FPSGadget( Imath::V3f defaultPosition = Imath::V3f( 5.0f, 50.0f, 0.0f ), bool showFrameTime = false );
 		~FPSGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::FPSGadget, FPSGadgetTypeId, Gadget );
@@ -60,6 +60,7 @@ class GAFFERUI_API FPSGadget : public Gadget
 		Imath::Box3f renderBound() const override;
 
 	private :
+		const bool m_showFrameTime;
 		mutable std::list< std::chrono::time_point<std::chrono::high_resolution_clock> > m_timeBuffer;
 };
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -327,6 +327,12 @@ Gaffer.Metadata.registerNode(
 
 		},
 
+		"frameTime" : {
+
+			"plugValueWidget:type" : "",
+
+		},
+
 		"displayTransform.soloChannel" : {
 
 			# The `RGBAL`` shortcuts conflict with shortcuts used for
@@ -1175,11 +1181,31 @@ class _GridPlugValueWidget( GafferUI.PlugValueWidget ) :
 			"/Show FPS",
 			{
 				"checkBox" : self.getPlug().node()["fps"]["visible"].getValue(),
-				"command" : self.getPlug().node()["fps"]["visible"].setValue,
+				"command" : Gaffer.WeakMethod( self.__setShowFPS )
+			}
+		)
+
+		m.append(
+			"/Show Frame Time",
+			{
+				"checkBox" : self.getPlug().node()["frameTime"]["visible"].getValue(),
+				"command" : Gaffer.WeakMethod( self.__setShowFrameTime )
 			}
 		)
 
 		return m
+
+	def __setShowFPS( self, enable ):
+		self.getPlug().node()["fps"]["visible"].setValue( enable )
+		if enable:
+			self.getPlug().node()["frameTime"]["visible"].setValue( False )
+
+	def __setShowFrameTime( self, enable ):
+		self.getPlug().node()["frameTime"]["visible"].setValue( enable )
+		if enable:
+			self.getPlug().node()["fps"]["visible"].setValue( False )
+
+
 
 ##########################################################################
 # Context menu

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -975,6 +975,56 @@ class SceneView::FPS : public Signals::Trackable
 
 };
 
+class SceneView::FrameTime : public Signals::Trackable
+{
+
+	public :
+
+		FrameTime( SceneView *view )
+			:	m_view( view ), m_gadget( new FPSGadget( Imath::V3f( 5.0f, 50.0f, 0.0f ), true ) )
+		{
+			ValuePlugPtr plug = new ValuePlug( "frameTime" );
+			view->addChild( plug );
+
+			plug->addChild( new BoolPlug( "visible", Plug::In, false ) );
+
+			view->viewportGadget()->setChild( "__frameTime", m_gadget );
+
+			view->plugDirtiedSignal().connect( boost::bind( &FrameTime::plugDirtied, this, ::_1 ) );
+
+			update();
+		}
+
+		Gaffer::ValuePlug *plug()
+		{
+			return m_view->getChild<Gaffer::ValuePlug>( "frameTime" );
+		}
+
+		const Gaffer::ValuePlug *plug() const
+		{
+			return m_view->getChild<Gaffer::ValuePlug>( "frameTime" );
+		}
+
+	private :
+
+		void plugDirtied( Gaffer::Plug *plug )
+		{
+			if( plug == this->plug() )
+			{
+				update();
+			}
+		}
+
+		void update()
+		{
+			m_gadget->setVisible( plug()->getChild<BoolPlug>( "visible" )->getValue() );
+		}
+
+		SceneView *m_view;
+		FPSGadgetPtr m_gadget;
+
+};
+
 //////////////////////////////////////////////////////////////////////////
 // SceneView::Camera implementation
 //////////////////////////////////////////////////////////////////////////
@@ -1979,6 +2029,7 @@ SceneView::SceneView( ScriptNodePtr scriptNode )
 	new Grid( this );
 	m_gnomon.reset( new Gnomon( this ) );
 	m_fps.reset( new FPS( this ) );
+	m_frameTime.reset( new FrameTime( this ) );
 
 	[[maybe_unused]] auto displayTransform = new DisplayTransform( this );
 	assert( displayTransform->parent() == this );

--- a/src/GafferUI/FPSGadget.cpp
+++ b/src/GafferUI/FPSGadget.cpp
@@ -45,8 +45,8 @@ using namespace GafferUI;
 
 GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( FPSGadget );
 
-FPSGadget::FPSGadget( Imath::V3f defaultPosition )
-	:	Gadget( defaultName<FPSGadget>() )
+FPSGadget::FPSGadget( Imath::V3f defaultPosition, bool showFrameTime )
+	:	Gadget( defaultName<FPSGadget>() ), m_showFrameTime( showFrameTime )
 {
 	Imath::M44f m;
 	m.setTranslation( defaultPosition );
@@ -98,13 +98,38 @@ void FPSGadget::renderLayer( Gadget::Layer layer, const Style *style, Gadget::Re
 	// size of m_timeBuffer.
 	float averageFrameTime = elapsed / ( ( m_timeBuffer.size() - 1 ) * 1000000.0f );
 
+	float standardDeviation = 0.0f;
+	if( m_showFrameTime )
+	{
+		for( auto it = m_timeBuffer.begin(); ; it++ )
+		{
+			auto nIt = next( it );
+			if( nIt == m_timeBuffer.end() )
+			{
+				break;
+			}
+
+			float frameTime = std::chrono::duration_cast< std::chrono::microseconds >( *nIt - *it ).count() / 1000000.0f;
+			standardDeviation += sqrtf( ( frameTime - averageFrameTime ) * ( frameTime - averageFrameTime ) );
+		}
+
+		standardDeviation /= ( m_timeBuffer.size() - 1 );
+	}
+
 	const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
 	ViewportGadget::RasterScope rasterScope( viewportGadget );
 
 	glMultMatrixf( getTransform().getValue() );
 	glScalef( 8.0f, -8.0f, 8.0f );
 
-	style->renderText( Style::LabelText, fmt::format( "{:.1f} FPS", ( 1.0f / averageFrameTime ) ) );
+	if( m_showFrameTime )
+	{
+		style->renderText( Style::LabelText, fmt::format( "{:.1f} ms, {:.1f} stddev", 1000.0f * averageFrameTime, 1000.0f * standardDeviation ) );
+	}
+	else
+	{
+		style->renderText( Style::LabelText, fmt::format( "{:.1f} FPS", ( 1.0f / averageFrameTime ) ) );
+	}
 }
 
 unsigned FPSGadget::layerMask() const


### PR DESCRIPTION
Splitting this commit out from the paint branch, since the easiest way to do it might involve a binary compatibility break.

Time in ms is often an easier metric to judge than fps, and showing a standard deviation gives some impression of how stable the frame rate is ( this information is otherwise completely obscured by averaging over a second ).