### PR TITLE
ScriptNode : Fix context update for variables with inputs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Fixes
 
 - FocalBlur : Fixed issue with excess alpha near depth discontinuities. This resulted in small bright edges near silhouettes where there is a sharp change in depth.
 - Filter : Fixed bug with `Select affected objects` where only the relevant locations from one scene connected to the filter would be included in the selection instead of from all scenes connected to the filter.
+- ScriptNode : Fixed context updates for `variables` plugs with an input connection.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -20,7 +20,9 @@ Fixes
 
 - FocalBlur : Fixed issue with excess alpha near depth discontinuities. This resulted in small bright edges near silhouettes where there is a sharp change in depth.
 - Filter : Fixed bug with `Select affected objects` where only the relevant locations from one scene connected to the filter would be included in the selection instead of from all scenes connected to the filter.
-- ScriptNode : Fixed context updates for `variables` plugs with an input connection.
+- ScriptNode :
+  - Fixed context updates for `variables` plugs with an input connection.
+  - Prevented invalid input connections to `variables` plugs. Connections from node outputs are considered invalid because they could create a circular dependency between context variables.
 
 API
 ---

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -292,6 +292,7 @@ class GAFFER_API ScriptNode : public Node
 	protected :
 
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
+		bool acceptsInput( const Plug *plug, const Plug *inputPlug ) const override;
 
 	private :
 

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -364,7 +364,7 @@ class GAFFER_API ScriptNode : public Node
 		boost::container::flat_set<IECore::InternedString> m_currentVariables;
 
 		void updateContextVariables();
-		void plugSet( Plug *plug );
+		void plugSetOrInputChanged( const Plug *plug, bool inputChanged );
 		void contextChanged( const Context *context, const IECore::InternedString &name );
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -2767,10 +2767,6 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["framesPerSecond"].setValue( 1.0 )
 		s["variables"].addChild( Gaffer.NameValuePlug( "a", IECore.StringData( "####" ), name = "a", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		s["variables"].addChild( Gaffer.NameValuePlug( "b", Gaffer.StringPlug( "value" ), name = "b", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-
-		s["variablesBExpression"] = Gaffer.Expression()
-		s["variablesBExpression"].setExpression( 'parent["variables"]["b"]["value"] = {1: "a", 2: "b", 3: "c", 4: "d", 5: "e"}[context.getFrame()]' )
 
 		s["n"] = GafferDispatchTest.TextWriter()
 		s["n"]["dispatcher"]["isolated"].setValue( True )
@@ -2826,10 +2822,9 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( set( [ type( n ) for n in Gaffer.Node.RecursiveRange( newScript ) ] ), set( [ GafferDispatchTest.TextWriter, Gaffer.Spreadsheet ] ) )
 
 		self.assertEqual( len( newScript["isolatedAnimation"]["rows"] ), 6 )  # default + frame count
-		self.assertEqual( len( newScript["isolatedAnimation"]["rows"].defaultRow()["cells"] ), 4 )
+		self.assertEqual( len( newScript["isolatedAnimation"]["rows"].defaultRow()["cells"] ), 3 )
 
 		self.assertIsNone( newScript["variables"]["a"]["value"].getInput() )
-		self.assertEqual( newScript["variables"]["b"]["value"].getInput(), newScript["isolatedAnimation"]["out"]["variables_b_value"] )
 		self.assertIsNone( newScript["n"]["fileName"].getInput() )
 		self.assertIsNone( newScript["n"]["text"].getInput() )
 		self.assertIsNone( newScript["n"]["mode"].getInput() )
@@ -2842,7 +2837,6 @@ class DispatcherTest( GafferTest.TestCase ) :
 				with self.subTest( f = f ) :
 					c.setFrame( f )
 					self.assertEqual( newScript["variables"]["a"]["value"].getValue(), "####" )
-					self.assertEqual( newScript["variables"]["b"]["value"].getValue(), [ "a", "b", "c", "d", "e" ][f-1] )
 					self.assertEqual( newScript["n"]["fileName"].getValue(), "${script:name}" )
 					self.assertEqual( newScript["n"]["text"].getValue(), "####" )
 					self.assertEqual( newScript["n"]["mode"].getValue(), "x" )
@@ -3004,6 +2998,35 @@ class DispatcherTest( GafferTest.TestCase ) :
 						newScript["n"]["user"]["objectVectorPlug"].getValue(),
 						IECore.ObjectVector( [ IECore.StringData( "hello" ), IECore.FloatData( f ) ] )
 					)
+
+	def testIsolatedScriptVariableWithInputConnection( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["variables"]["test"] = Gaffer.NameValuePlug( "a", 10, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		script["add"] = GafferTest.AddNode()
+		script["add"]["op1"].setValue( 20 )
+		script["variables"]["test"]["value"].setInput( script["add"]["op1"] )
+
+		script["writer"] = GafferDispatchTest.TextWriter()
+		script["writer"]["dispatcher"]["isolated"].setValue( True )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() / "test.txt" )
+		script["writer"]["text"].setValue( "Hello world" )
+
+		script["dispatcher"] = self.NullDispatcher()
+		script["dispatcher"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		script["dispatcher"]["tasks"][0].setInput( script["writer"]["task"] )
+
+		with script.context() :
+			script["dispatcher"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+
+		isolatedScript = Gaffer.ScriptNode()
+		isolatedScript["fileName"].setValue( dispatchDir / "isolated" / "writer" / self.__soleSubdirectory( dispatchDir / "isolated" / "writer" ) / "1" / "untitled.gfr" )
+		isolatedScript.load()
+
+		self.assertEqual( isolatedScript["variables"]["test"]["value"].getValue(), 20 )
 
 	def testOmitEmptyTasks( self ) :
 

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -36,9 +36,7 @@
 ##########################################################################
 
 import unittest
-import sys
 import weakref
-import gc
 import os
 import pathlib
 import shutil

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1835,5 +1835,32 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		self.assertTrue( "Line 3" in mh.messages[0].context )
 		self.assertTrue( "name 'b' is not defined" in mh.messages[0].message )
 
+	def testConnectionsBetweenContextVariables( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["variables"].addChild(
+			Gaffer.NameValuePlug( "variable1", 1, name = "variable1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		)
+		script["variables"].addChild(
+			Gaffer.NameValuePlug( "variable2", 2, name = "variable2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		)
+
+		self.assertEqual( script.context()["variable1"], 1, )
+		self.assertEqual( script.context()["variable2"], 2 )
+
+		script["variables"]["variable1"]["value"].setInput( script["variables"]["variable2"]["value"] )
+		self.assertEqual( script.context()["variable1"], 2, )
+		self.assertEqual( script.context()["variable2"], 2 )
+
+		script["variables"]["variable2"]["value"].setValue( 3 )
+		self.assertEqual( script.context()["variable1"], 3, )
+		self.assertEqual( script.context()["variable2"], 3 )
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+		self.assertEqual( script2.context()["variable1"], 3, )
+		self.assertEqual( script2.context()["variable2"], 3 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1862,5 +1862,25 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( script2.context()["variable1"], 3, )
 		self.assertEqual( script2.context()["variable2"], 3 )
 
+	def testCantConnectComputedOutputToContextVariable( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["variables"].addChild(
+			Gaffer.NameValuePlug( "variable1", 1, name = "variable1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		)
+		script["add"] = GafferTest.AddNode()
+
+		self.assertFalse( script["variables"]["variable1"]["value"].acceptsInput( script["add"]["sum"] ) )
+
+	def testCantConnectNonValuePlugToContextVariable( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["variables"].addChild(
+			Gaffer.NameValuePlug( "variable1", 1, name = "variable1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		)
+		script["node"] = Gaffer.Node()
+		script["node"]["user"]["plug"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		self.assertFalse( script["variables"]["variable1"]["value"].acceptsInput( script["node"]["user"]["plug"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -377,7 +377,9 @@ ScriptNode::ScriptNode( const std::string &name )
 
 	m_selection->memberAcceptanceSignal().connect( boost::bind( &ScriptNode::selectionSetAcceptor, this, ::_1, ::_2 ) );
 
-	plugSetSignal().connect( boost::bind( &ScriptNode::plugSet, this, ::_1 ) );
+	plugSetSignal().connect( boost::bind( &ScriptNode::plugSetOrInputChanged, this, ::_1, false ) );
+	plugInputChangedSignal().connect( boost::bind( &ScriptNode::plugSetOrInputChanged, this, ::_1, true ) );
+
 	m_context->changedSignal().connect( boost::bind( &ScriptNode::contextChanged, this, ::_1, ::_2 ) );
 }
 
@@ -980,7 +982,7 @@ void ScriptNode::updateContextVariables()
 	}
 }
 
-void ScriptNode::plugSet( Plug *plug )
+void ScriptNode::plugSetOrInputChanged( const Plug *plug, bool inputChanged )
 {
 	if( plug == frameStartPlug() )
 	{
@@ -1000,7 +1002,15 @@ void ScriptNode::plugSet( Plug *plug )
 	{
 		context()->setFramesPerSecond( framesPerSecondPlug()->getValue() );
 	}
-	else if( plug == variablesPlug() )
+	else if(
+		// `plugSetSignal` propagates to ancestors of the plug that was set,
+		// so by operating only on the ancestor we minimise the number of context
+		// edits we make.
+		plug == variablesPlug() ||
+		// `plugInputChangedSignal` is emitted only for the plug whose input
+		// changed, so we must update for any plug below `variablesPlug()`.
+		( inputChanged && variablesPlug()->isAncestorOf( plug ) )
+	)
 	{
 		updateContextVariables();
 	}

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -46,6 +46,7 @@
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/Monitor.h"
+#include "Gaffer/PlugAlgo.h"
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/TypedPlug.h"
@@ -478,6 +479,24 @@ void ScriptNode::parentChanging( Gaffer::GraphComponent *newParent )
 	{
 		BackgroundTask::cancelAffectedTasks( this );
 	}
+}
+
+bool ScriptNode::acceptsInput( const Plug *plug, const Plug *inputPlug ) const
+{
+	if( !Node::acceptsInput( plug, inputPlug ) )
+	{
+		return false;
+	}
+
+	auto inputValuePlug = IECore::runTimeCast<const ValuePlug>( inputPlug );
+	if( variablesPlug()->isAncestorOf( plug ) && inputValuePlug && PlugAlgo::dependsOnCompute( inputValuePlug ) )
+	{
+		// Can't drive context variables by values which themselves
+		// are context-sensitive.
+		return false;
+	}
+
+	return true;
 }
 
 bool ScriptNode::selectionSetAcceptor( const Set *s, const Set::Member *m )


### PR DESCRIPTION
Prior to this we were only updating the context from `plugSetSignal()`, so to support input connections we now also update the context from `plugInputChangedSignal()`.

It would be reasonable to ask why we don't just do a single update from `plugDirtiedSignal()` instead. In practice we probably could, but conceptually it doesn't seem quite right. As documented on Node, slots connected to `plugSet` and `plugInputChanged` are permitted to modify the node graph, but plugs connected to `plugDirtiedSignal` are not. The idea is that `plugDirtiedSignal` is used to trigger computes in the UI, and it makes no sense to modify the graph just as a UI refresh starts, as it would invalidate the refresh. While `ScriptNode::updateContextVariables()` isn't strictly a graph edit, it falls into the same broad category of actions that would invalidate an update only just started by the UI, because it modifies the context that the UI uses.
