### PR TITLE
Node Color and Lookthrough shortcuts

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 ------------
 
 - GraphEditor : - Added <kbd>C</kbd> shortcut for setting node colors.
+- SceneView : Added keyboard shortcut <kbd>;</kbd> to toggle between the lookthrough (camera / light) view and the free (perspective / top / front / side) cameras. <kbd>Ctrl</kbd> + click on the toolbar camera icon will perform the same toggle.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - RandomPrimitiveVariable : Added new node for creating random per-face or per-vertex primitive variables with a variety of distributions.
 
+Improvements
+------------
+
+- GraphEditor : - Added <kbd>C</kbd> shortcut for setting node colors.
+
 Fixes
 -----
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -176,6 +176,12 @@ Jump to bookmarked node              | Hover cursor over editor, {kbd}`Ctrl` + {
 Assign numeric bookmark              | {kbd}`Ctrl` + {kbd}`1` … {kbd}`9`
 Remove numeric bookmark              | {kbd}`Ctrl` + {kbd}`0`
 
+### Node Appearance ###
+
+Action                               | Control or shortcut
+-------------------------------------|--------------------
+Set node color                       | {kbd}`C`
+
 ## Node Editor ##
 
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -239,6 +239,7 @@ Light Tool                           | {kbd}`A`
 Light Position Tool                  | {kbd}`D`
 Visualiser Tool                      | {kbd}`L`
 Pin to numeric bookmark              | {kbd}`1` … {kbd}`9`
+Toggle camera / free view            | {kbd}`;`
 
 ### 3D scenes ###
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -554,6 +554,7 @@ class _ShadingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 				if result :
 					result += "\n\n"
 				result += "## Actions\n\n"
+				result += "- Click to open shading menu.\n"
 				result += "- <kbd>Ctrl</kbd> + click to toggle shading to `{}`\n".format( self.__shadingModeToggle if self.getPlug().isSetToDefault() else "Default" )
 
 			return result

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -202,6 +202,11 @@ Gaffer.Metadata.registerNode(
 			"description" :
 			"""
 			Defines the camera used to view the scene.
+
+			## Actions
+
+			- Click to open camera menu.
+			- <kbd>Ctrl</kbd> + click to toggle between camera and free view.
 			""",
 
 			"plugValueWidget:type" : "GafferSceneUI.SceneViewUI._CameraPlugValueWidget",
@@ -883,6 +888,9 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.dragEnterSignal().connectFront( Gaffer.WeakMethod( self.__dragEnter ) )
 		self.dropSignal().connectFront( Gaffer.WeakMethod( self.__drop ) )
 
+		self.__menuButton.buttonPressSignal().connectFront( Gaffer.WeakMethod( self.__buttonPress ) )
+		self.__menuButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__buttonDoubleClick ) )
+
 	def setHighlighted( self, highlighted ) :
 
 		GafferUI.PlugValueWidget.setHighlighted( self, highlighted )
@@ -1064,6 +1072,23 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.setHighlighted( False )
 		self.__lookThrough( event.data[0] )
 		return True
+
+	def __buttonPress( self, widget, event ) :
+
+		if event.buttons == event.Buttons.Left and event.modifiers == event.Modifiers.Control :
+
+			self.getPlug()["lookThroughEnabled"].setValue( not self.getPlug()["lookThroughEnabled"].getValue() )
+			return True
+
+		return False
+
+	def __buttonDoubleClick( self, widget, event ) :
+
+		if event.buttons == event.Buttons.Left and event.modifiers == event.Modifiers.Control :
+			# Prevent menu from opening when Control is held.
+			return True
+
+		return False
 
 	def __setMenu( self, setName, currentLookThrough ) :
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -184,6 +184,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			{
 				"command" : functools.partial( cls.__setColor, nodeList = nodeList ),
 				"active" : not any( Gaffer.MetadataAlgo.readOnly( n ) for n in nodeList ),
+				"shortCut" : "C",
 			}
 		)
 
@@ -275,6 +276,14 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			lambda plug : widgetClass( key, target=plug, defaultValue=defaultValue )
 		)
 
+	@classmethod
+	def connectToEditor( cls, editor ) :
+
+		if not isinstance( editor, GafferUI.GraphEditor ) :
+			return
+
+		editor.keyPressSignal().connect( Gaffer.WeakMethod( cls.__graphEditorKeyPress ) )
+
 	def _updateFromSet( self ) :
 
 		GafferUI.NodeSetEditor._updateFromSet( self )
@@ -345,6 +354,15 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			with Gaffer.UndoScope( nodeList[0].ancestor( Gaffer.ScriptNode ) ) :
 				for node in nodeList :
 					Gaffer.Metadata.registerValue( node, "nodeGadget:color", color )
+
+	@classmethod
+	def __graphEditorKeyPress( cls, graphEditor, event ) :
+
+		selection = [ n for n in graphEditor.scriptNode().selection() if n.parent() == graphEditor.graphGadget().getRoot() ]
+		if event.key == "C" and event.modifiers == event.Modifiers.None_ :
+			if not any( Gaffer.MetadataAlgo.readOnly( n ) for n in selection ) :
+				cls.__setColor( graphEditor, selection )
+			return True
 
 	@staticmethod
 	def __setNameVisible( nodeList, nameVisible ) :

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -2211,6 +2211,12 @@ bool SceneView::keyPress( GafferUI::GadgetPtr gadget, const GafferUI::KeyEvent &
 	{
 		m_sceneGadget->setPaused( true );
 	}
+	else if( event.key == "Semicolon" )
+	{
+		BoolPlug *lookThroughPlug = cameraPlug()->getChild<BoolPlug>( "lookThroughEnabled" );
+		lookThroughPlug->setValue( !lookThroughPlug->getValue() );
+		return true;
+	}
 
 	return false;
 }

--- a/startup/gui/editor.py
+++ b/startup/gui/editor.py
@@ -43,6 +43,7 @@ def __editorCreated( editor ) :
 	GafferSceneUI.SceneHistoryUI.connectToEditor( editor )
 	GafferSceneUI.EditScopeUI.connectToEditor( editor )
 	GafferUI._PlugVisibilityGadget.connectToEditor( editor )
+	GafferUI.UIEditor.connectToEditor ( editor )
 
 GafferUI.Editor.instanceCreatedSignal().connect( __editorCreated )
 GafferUI.CompoundEditor.nodeSetMenuSignal().connect( GafferUI.GraphBookmarksUI.appendNodeSetMenuDefinitions )


### PR DESCRIPTION
This adds a couple of new shortcuts, one for setting the node color in the Graph Editor and one to switch between the lookthrough camera (camera view, render camera view or light view) and the free view (perpsective or ortho cameras).

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
