### PR TITLE
Paint Misc Prereqs

### DIFF
--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -59,6 +59,9 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 		GafferUI.GLWidget.__init__( self, **kw )
 
+		# See comment in mouseMove
+		self.__overOverlay = False
+
 		self._qtWidget().setFocusPolicy( QtCore.Qt.ClickFocus )
 
 		self.enterSignal().connect( Gaffer.WeakMethod( self.__enter ) )
@@ -230,15 +233,33 @@ class GadgetWidget( GafferUI.GLWidget ) :
 
 	def __mouseMove( self, widget, event ) :
 
-		# We get given mouse moves before they're given to the overlay items,
-		# so we must ignore them so they can be used by the overlay.
-		if self._qtWidget().itemAt( event.line.p0.x, event.line.p0.y ) is not None :
-			return False
-
 		if not self._makeCurrent() :
 			return False
 
-		return self.__viewportGadget.mouseMoveSignal()( self.__viewportGadget, event )
+		# When the cursor is over the overlay, it is within this Gadget, but for the
+		# contained ViewportGadget, we want to present things as if the cursor is outside
+		# it when it is over an overlay ( ie. it gets a leaveSignal when the cursor enters
+		# an overlay, an enterSignal when the cursor leave an overlay, and no mouseMove
+		# signals while the cursor is over an overlay )
+
+		overOverlay = self._qtWidget().itemAt( event.line.p0.x, event.line.p0.y ) is not None
+
+		if self.__overOverlay != overOverlay:
+			if overOverlay:
+				self.__viewportGadget.leaveSignal()( self.__viewportGadget, event )
+			else:
+				self.__viewportGadget.enterSignal()( self.__viewportGadget, event )
+			self.__overOverlay = overOverlay
+
+		if overOverlay:
+			return False
+
+		self.__viewportGadget.mouseMoveSignal()( self.__viewportGadget, event )
+
+		# we always return false so that any overlay items will get appropriate
+		# move/enter/leave events, otherwise highlighting for buttons etc can go
+		# awry.
+		return False
 
 	def __dragBegin( self, widget, event ) :
 

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -882,6 +882,10 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			{
 				m_selection = ::option<IECore::PathMatcher>( value, name, IECore::PathMatcher() );
 			}
+			else if( name == "gl:hideSelected" )
+			{
+				m_hideSelected = ::option<bool>( value, name, false );
+			}
 			else if(
 				boost::starts_with( name.string(), "gl:primitive:" ) ||
 				boost::starts_with( name.string(), "gl:pointsPrimitive:" ) ||
@@ -1229,6 +1233,19 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 				{
 					selector->loadName( i++ );
 				}
+				else if( m_hideSelected )
+				{
+					// If this isn't a selection render, and the hideSelected flag is set,
+					// then someone else is responsible for rendering selected objects, we
+					// can skip them.
+					// TODO - it's a bit of a waste to match against m_selection here,
+					// when we'll also need to match against it inside render()
+					if( o->selected( m_selection ) )
+					{
+						continue;
+					}
+				}
+
 				o->render( currentState, m_selection, colorSpace );
 			}
 		}
@@ -1375,6 +1392,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 		RenderType m_renderType;
 		string m_camera;
 		IECore::PathMatcher m_selection;
+		bool m_hideSelected;
 		IECore::CompoundObjectPtr m_baseStateOptions;
 		IECoreGL::StatePtr m_baseState;
 		bool m_renderObjects;

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -301,6 +301,7 @@ class SceneView::DrawingMode : public Signals::Trackable
 			drawingMode->addChild( new BoolPlug( "solid", Plug::In, true ) );
 			drawingMode->addChild( new BoolPlug( "wireframe" ) );
 			drawingMode->addChild( new BoolPlug( "points" ) );
+			drawingMode->addChild( new BoolPlug( "hideSelected" ) );
 
 			ValuePlugPtr curves = new ValuePlug( "curvesPrimitive" );
 			drawingMode->addChild( curves );
@@ -440,6 +441,8 @@ class SceneView::DrawingMode : public Signals::Trackable
 				"forAll" :
 				"forGLPoints"
 			);
+
+			options->members()["gl:hideSelected"] = new BoolData( drawingModePlug()->getChild<BoolPlug>( "hideSelected" )->getValue() );
 
 			sceneGadget()->setOpenGLOptions( options.get() );
 		}


### PR DESCRIPTION
As we prepare for the release of 1.7, I'm looking through the paint branch for anything that might require a compatibility break.

I'm not seeing anything that actually does require a compatibility break, but here are two commits that feel a little bit intrusive into how things currently work.

They aren't urgent ... unless you don't like how they work, and can think of a better approach that would be an ABI break.

One reworks how enter/leave signals are handled with overlays ( you now get a leave event when the cursor is over the overlay instead of the ViewportGadget ). The other is a special OpenGL render override "gl:hideSelected", which allows a tool to implement its own rendering of the selected objects.