### PR TITLE
RenderMan : Define `user:__materialid` from name of terminal shader

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - GraphEditor :
   - Changed node context menu items to operate on multiple nodes where possible (#2783).
   - Added drag & drop from LightEditor and AttributeEditor. Dropping a location navigates to the node that created the location.
+- RenderMan : Changed PxrCryptomatte's material output to use the name of the terminal shader, rather than a hash of the network. This is stable under animation. As before, the output can be customised by creating a `user:__materialid` attribute.
 
 Fixes
 -----
@@ -23,6 +24,11 @@ API
 ---
 
 - GraphEditor : Added an optional argument to `nodeContextMenuSignal()` to request a signal that will pass a list of nodes to the handler, rather than a single node. This can be used to register menu items that will act on multiple nodes.
+
+Breaking Changes
+----------------
+
+- RenderMan : Changed the default values used for PxrCryptomatte's material output.
 
 1.7.0.0a8 (relative to 1.7.0.0a7)
 =========

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -3035,6 +3035,55 @@ class RendererTest( GafferTest.TestCase ) :
 		del sphere
 		del renderer
 
+	def testMaterialID( self ) :
+
+		surfaceNetwork = IECoreScene.ShaderNetwork(
+			shaders = { "surfaceOutputHandle" : IECoreScene.Shader( "PxrConstant" ) },
+			output = ( "surfaceOutputHandle", "bxdf_out" ),
+		)
+
+		volumeNetwork = IECoreScene.ShaderNetwork(
+			shaders = { "volumeOutputHandle" : IECoreScene.Shader( "PxrVolume" ) },
+			output = ( "volumeOutputHandle", "out" ),
+		)
+
+		for surface, volume, materialID, expectedID in [
+			( surfaceNetwork, None, None, "surfaceOutputHandle" ),
+			( None, volumeNetwork, None, "volumeOutputHandle" ),
+			( surfaceNetwork, volumeNetwork, None, "volumeOutputHandle" ),
+			( None, None, None, "defaultFacingRatio" ),
+			( surfaceNetwork, volumeNetwork, "customID", "customID" ),
+		] :
+
+			with self.subTest( surface = surface is not None, volume = volume is not None, materialID = materialID ) :
+
+				with IECoreRenderManTest.RileyCapture() as capture :
+
+					renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+						self.renderer,
+						GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+					)
+
+					attributes = IECore.CompoundObject()
+					if surface :
+						attributes["ri:surface"] = surfaceNetwork
+					if volume :
+						attributes["ri:volume"] = volumeNetwork
+					if materialID :
+						attributes["user:__materialid"] = IECore.StringData( materialID )
+
+					renderer.object(
+						"/sphere", IECoreScene.SpherePrimitive( 1 ),
+						renderer.attributes( attributes )
+					)
+
+					del renderer
+
+				self.__assertParameterEqual(
+					next( x for x in capture.json if x["method"] == "CreateGeometryInstance" )["attributes"]["params"],
+					"user:__materialid", [ expectedID ]
+				)
+
 	def __assertParameterEqual( self, paramList, name, data, tolerance = None ) :
 
 		p = next( x for x in paramList if x["info"]["name"] == name )

--- a/src/IECoreRenderMan/Attributes.cpp
+++ b/src/IECoreRenderMan/Attributes.cpp
@@ -195,12 +195,12 @@ IECoreScene::ConstShaderNetworkPtr g_facingRatio = []() {
 		"toFloat3", new Shader( "PxrToFloat3" )
 	);
 	const InternedString constantHandle = result->addShader(
-		"constant", new Shader( "PxrConstant" )
+		"defaultFacingRatio", new Shader( "PxrConstant" )
 	);
 
 	result->addConnection( { { facingRatioHandle, "resultF" }, { toFloat3Handle, "input" } } );
 	result->addConnection( { { toFloat3Handle, "resultRGB" }, { constantHandle, "emitColor" } } );
-	result->setOutput( { "constant", "out" } );
+	result->setOutput( { "defaultFacingRatio", "out" } );
 
 	return result;
 
@@ -230,6 +230,7 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 	const auto [surfaceName, surface] = shaderNetworkAttribute( attributes->members(), g_surfaceAttributeNames );
 	const auto [volumeName, volume] = shaderNetworkAttribute( attributes->members(), g_volumeAttributeNames );
 
+	InternedString materialId;
 	if( volume )
 	{
 		// We can only choose a single material - either a volume or a surface.
@@ -237,6 +238,7 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 		// volume shader, so if a volume shader is assigned then we use it for all
 		// geometry types.
 		m_material = materialCache->getMaterial( volume, volumeName, attributes );
+		materialId = volume->getOutput().shader;
 	}
 	else
 	{
@@ -246,6 +248,7 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 		// > volume as we don't know the right value for the `densityFloatPrimVar`
 		// > parameter.
 		m_material = materialCache->getMaterial( surface ? surface : g_facingRatio.get(), surface ? surfaceName : InternedString(), attributes );
+		materialId = surface ? surface->getOutput().shader : g_facingRatio->getOutput().shader;
 	}
 
 	const auto [displacementName, displacement] = shaderNetworkAttribute( attributes->members(), g_displacementAttributeNames );
@@ -264,13 +267,9 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 		m_lightMaterial = materialCache->getMaterial( surface ? surface : g_black.get(), surface ? surfaceName : InternedString(), attributes );
 	}
 
-	if( surface )
-	{
-		// Set up material id for PxrCryptomatte. This can be overridden if desired
-		// by specifying it in `attributes`, in which case it will be set again below.
-		const string materialId = surface->Object::hash().toString();
-		m_instanceAttributes.SetString( g_userMaterialId, RtUString( materialId.c_str() ) );
-	}
+	// Set up material id for PxrCryptomatte. This can be overridden if desired
+	// by specifying it in `attributes`, in which case it will be set again below.
+	m_instanceAttributes.SetString( g_userMaterialId, RtUString( materialId.c_str() ) );
 
 	// Convert attributes into parameter lists for instances and prototypes, and
 	// calculate a hash for how the latter affects automatic instancing.


### PR DESCRIPTION
This is better for PxrCryptomatte usages because it is more user-recognisable than the previous hash, and is also stable under animation. As before, the attribute can be specified explicitly to override the default.

Requested by Cinesite, but I think it makes decent sense in general.