### PR TITLE
GraphGadget : Fix bug in node context menu

### DIFF
--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -451,8 +451,10 @@ class GraphEditor( GafferUI.Editor ) :
 					if not isinstance( nodeGadget, GafferUI.NodeGadget ) :
 						nodeGadget = nodeGadget.ancestor( GafferUI.NodeGadget )
 					if nodeGadget is not None :
-						selection = self.scriptNode().selection()
-						nodeList = list( selection ) if nodeGadget.node() in selection else [nodeGadget.node()]
+						if nodeGadget.node() in self.scriptNode().selection() :
+							nodeList = [ node for node in self.scriptNode().selection() if self.graphGadget().nodeGadget( node ) is not None ]
+						else :
+							nodeList = [ nodeGadget.node() ]
 						self.nodeContextMenuSignal( True )( self, nodeList, overrideMenuDefinition )
 
 						self.nodeContextMenuSignal()( self, nodeGadget.node(), overrideMenuDefinition )


### PR DESCRIPTION
The `ScriptNode.selection()` might contain nodes that are not being shown in the GraphEditor, either because they are filtered out, or because they are in a different Box. But we were invoking the menu signal with _all_ selected nodes, leading to errors from slots which expected to be able to find a NodeGadget for each of them :

```
ERROR : EventSignalCombiner : Traceback (most recent call last):
ERROR :   File "/home/john/dev/build/gaffer-1.7/startup/gui/graphEditor.py", line 109, in __nodeContextMenu
ERROR :     GafferUI.GraphEditor.appendConnectionVisibilityMenuDefinitions( graphEditor, nodeList, menuDefinition )
ERROR :   File "/home/john/dev/build/gaffer-1.7/python/GafferUI/GraphEditor.py", line 260, in appendConnectionVisibilityMenuDefinitions
ERROR :     nodePlugDirections = [ plugDirectionsWalk( graphEditor.graphGadget().nodeGadget( n ) ) for n in nodeList ]
ERROR :                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR :   File "/home/john/dev/build/gaffer-1.7/python/GafferUI/GraphEditor.py", line 260, in <listcomp>
ERROR :     nodePlugDirections = [ plugDirectionsWalk( graphEditor.graphGadget().nodeGadget( n ) ) for n in nodeList ]
ERROR :                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR :   File "/home/john/dev/build/gaffer-1.7/python/GafferUI/GraphEditor.py", line 255, in plugDirectionsWalk
ERROR :     for c in gadget.children() :
ERROR :              ^^^^^^^^^^^^^^^
ERROR : AttributeError: 'NoneType' object has no attribute 'children'
```

This could be triggered as follows :

- Open a second GraphEditor showing the contents of a Box. Select a node in this Box.
- Ctrl+click to select an additional node in the primary GraphEditor.
- Right-click on the selected node in the primary GraphEditor.

The user wouldn't expect the menu to operate on nodes outside the current editor anyway, so the solution is just to limit the node list to only those we have a NodeGadget for.
