### PR TITLE
gaffer : Set `sys.executable` to `bin/python`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,11 @@ Features
 Fixes
 -----
 
+- Application : Fixed bug that prevented the use of `sys.executable` for launching a Python process. `sys.executable` now points to the included `python` executable instead of `gaffer` [^1].
+
+Fixes
+-----
+
 - MenuButton : Fixed immediate mode when the menu contained a single submenu.
 - RandomChoice : Fixed "Value/Weight" table headers when first setting up the node.
 - VectorDataPlugValueWidget : Fixed handling of custom header metadata when adding and removing columns.
@@ -58,6 +63,8 @@ Breaking Changes
 - ScriptNode : Changed preconditions for calling `serialiseToFile`. If the desired behaviour is that the ScriptNode in memory will be now be associated with the new file ( ie. a saveAs operation ), then the caller is responsible for setting `ScriptNode.fileNamePlug()` to the new file name before calling `serialiseToFile`.
 
 [^1]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.
+
+[^1]: Improvement to a feature introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
 
 1.7.0.0a8 (relative to 1.7.0.0a7)
 =========

--- a/bin/__private/_gaffer.py
+++ b/bin/__private/_gaffer.py
@@ -425,10 +425,11 @@ if "PYTHONNOUSERSITE" not in os.environ :
 # Exec `__gaffer.py`
 # ==================
 
-args = [ sys.executable ] + sys.argv[1:]
+gafferExecutable = str( gafferRoot / "bin" / "__private" / ( "gaffer" + ( ".exe" if os.name == "nt" else "" ) ) )
+args = [ gafferExecutable ] + sys.argv[1:]
 
 if sys.platform != "win32" :
-	os.execv( sys.executable, args )
+	os.execv( gafferExecutable, args )
 else :
 	# On Windows, Python emulates `execv()` badly by launching another process
 	# (rather than replacing this one) and not even waiting for it to finish.

--- a/bin/__private/gaffer.cpp
+++ b/bin/__private/gaffer.cpp
@@ -64,16 +64,13 @@ namespace
 {
 
 template<typename T>
-int launchGaffer( int argc, T** argv, std::function<int( int, T** )> pyMain )
+int launchGaffer( int argc, T** argv )
 {
-	// Windows does not support process renaming or replacing a parent process with its child.
-	// We want all of our processes to be called `gaffer` (`gaffer.exe` on Windows) so we run
-	// this executable with `_gaffer.py` bootstrap script. We execute that script as-is and
-	// all other cases get `__gaffer.py` inserted into the argument list.
-	if( argc > 1 && std::filesystem::path( argv[1] ).filename() == std::filesystem::path( "_gaffer.py" ) )
-	{
-		return pyMain( argc, argv );
-	}
+	// This executable should be run after the environment is configured. The default launch
+	// script does that in `_gaffer.py`. We want all of our processes to be called `gaffer`
+	// (`gaffer.exe` on Windows). Windows does not support process renaming or replacing a
+	// parent process with its child, so this executable, rather than `python` is used to
+	// launch the Gaffer application (`__gaffer.py`).
 
 	std::vector<T *> modifiedArgv( argv, argv + argc );
 
@@ -83,7 +80,64 @@ int launchGaffer( int argc, T** argv, std::function<int( int, T** )> pyMain )
 	T *script = genericLaunchScriptPath.data();
 	modifiedArgv.insert( modifiedArgv.begin() + 1, script );
 
-	return pyMain( modifiedArgv.size(), modifiedArgv.data() );
+	PyStatus status;
+
+	PyConfig config;
+	PyConfig_InitPythonConfig( &config );
+
+	// `config.executable` is the source of Python's `sys.executable` value. We set
+	// that to `python` (in the exception handling block below) to allow subprocesses
+	// to be launched using `sys.executable` and not have to work around the automatic
+	// insertion of `__gaffer.py` done above.
+	std::filesystem::path pythonPath = exePath.parent_path().parent_path() / "python";
+#ifdef MS_WINDOWS
+	pythonPath.replace_extension( "exe" );
+#endif
+	std::wstring pythonPathString = pythonPath.wstring();
+
+	try
+	{
+		// `PyConfig_Set*Argv` takes care of Python's preconfiguration.
+		if constexpr( std::is_same_v<T, char> )
+		{
+			status = PyConfig_SetBytesArgv( &config, modifiedArgv.size(), modifiedArgv.data() );
+		}
+		else if constexpr( std::is_same_v<T, wchar_t> )
+		{
+			status = PyConfig_SetArgv( &config, modifiedArgv.size(), modifiedArgv.data() );
+		}
+		if( PyStatus_Exception( status ) )
+		{
+			throw std::runtime_error( "Error initializing command line arguments." );
+		}
+
+		status = PyConfig_SetString( &config, &config.executable, pythonPathString.data() );
+		if( PyStatus_Exception( status ) )
+		{
+			throw std::runtime_error( "Error initializing \"sys.executable\"." );
+		}
+
+		status = Py_InitializeFromConfig( &config );
+		if( PyStatus_Exception( status ) )
+		{
+			throw std::runtime_error( "Error initializing Python configuration." );
+		}
+	}
+	catch( const std::runtime_error &e )
+	{
+		std::string msg = std::string( e.what() ) + " : " + std::string( status.err_msg );
+		status.err_msg = msg.data();
+		PyConfig_Clear( &config );
+		if( PyStatus_IsExit( status ) )
+		{
+			return status.exitcode;
+		}
+		Py_ExitStatusException( status );
+	}
+
+	PyConfig_Clear( &config );
+
+	return Py_RunMain();
 
 }
 
@@ -106,12 +160,12 @@ int wmain( int argc, wchar_t **argv )
 		}
 	}
 
-	return launchGaffer<wchar_t>( argc, argv, Py_Main );
-	
+	return launchGaffer<wchar_t>( argc, argv );
+
 }
 #else
 int main( int argc, char **argv )
 {
-	return launchGaffer<char>( argc, argv, Py_BytesMain );
+	return launchGaffer<char>( argc, argv );
 }
 #endif

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -125,7 +125,7 @@ if [[ -n $GAFFER_DEBUG ]] ; then
 			export GAFFER_DEBUGGER="lldb -- "
 		fi
 	fi
-	exec $GAFFER_DEBUGGER $rootDir/bin/__private/gaffer "$rootDir/bin/__private/_gaffer.py" "$@"
+	exec $GAFFER_DEBUGGER $rootDir/bin/python "$rootDir/bin/__private/_gaffer.py" "$@"
 else
-	exec $rootDir/bin/__private/gaffer "$rootDir/bin/__private/_gaffer.py" "$@"
+	exec $rootDir/bin/python "$rootDir/bin/__private/_gaffer.py" "$@"
 fi

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -13,9 +13,9 @@ rem Needed for `gaffer.exe` to find the Python DLLs it needs because they are no
 set PATH=%PYTHONHOME%\bin;%PATH%
 
 if "%GAFFER_DEBUG%" NEQ "" (
-	%GAFFER_DEBUGGER% "%PYTHONHOME%"\bin\__private\gaffer.exe "%PYTHONHOME%"/bin/__private/_gaffer.py %*
+	%GAFFER_DEBUGGER% "%PYTHONHOME%"\bin\python.exe "%PYTHONHOME%"/bin/__private/_gaffer.py %*
 ) else (
-	"%PYTHONHOME%"\bin\__private\gaffer.exe "%PYTHONHOME%"/bin/__private/_gaffer.py %*
+	"%PYTHONHOME%"\bin\python.exe "%PYTHONHOME%"/bin/__private/_gaffer.py %*
 )
 
 endlocal

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -207,5 +207,9 @@ class ApplicationTest( GafferTest.TestCase ) :
 			universal_newlines = True, env = env
 		)
 
+	def testSysExecutable( self ) :
+
+		self.assertEqual( sys.executable, str( Gaffer.rootPath() / "bin" / ( "python" + ( ".exe" if os.name == "nt" else "" ) ) ) )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This changes the value of Python's `sys.executable` to point to Gaffer's included Python executable rather than the `__private/gaffer` executable. Previously, if you were trying to launch a Python process using `sys.executable`, it would likely fail because it would be calling our executable which inserts the `__gaffer.py` script to the command line.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
