### PR TITLE
IECoreArnold::ParameterAlgo : Support scalar values for vector parms

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.21.1)
 =======
 
+Fixes
+-----
 
+- IECoreArnold::ParameterAlgo : Support setting an array parameter with a StringData or BoolData. This is treated as equivalent to setting the array parameter to a one element array. This fix is important for supporting Arnold 7.5.2, where the `driver_exr` compression parameter has been switched from a string to a string array, which causes a crash without this fix.
 
 1.6.21.1 (relative to 1.6.21.0)
 ========

--- a/python/IECoreArnoldTest/ParameterAlgoTest.py
+++ b/python/IECoreArnoldTest/ParameterAlgoTest.py
@@ -101,6 +101,32 @@ class ParameterAlgoTest( unittest.TestCase ) :
 			self.assertEqual( arnold.AiArrayGetUInt( a, 0 ), 12 )
 			self.assertEqual( arnold.AiArrayGetUInt( a, 1 ), 2147483649 )
 
+	def testVectorFromScalarData( self ) :
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			n = arnold.AiNode( universe, "imager_light_mixer" )
+
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_name", IECore.StringData( "testString" ) )
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_enable", IECore.BoolData( False ) )
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_intensity", IECore.FloatData( 0.42 ) )
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_tint", IECore.Color3fData( imath.Color3f( 7, 8, 9 ) ) )
+
+			a = arnold.AiNodeGetArray( n, "layer_name" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertEqual( arnold.AiArrayGetStr( a, 0 ), "testString" )
+
+			a = arnold.AiNodeGetArray( n, "layer_enable" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertEqual( arnold.AiArrayGetBool( a, 0 ), False )
+
+			a = arnold.AiNodeGetArray( n, "layer_intensity" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertAlmostEqual( arnold.AiArrayGetFlt( a, 0 ), 0.42 )
+			a = arnold.AiNodeGetArray( n, "layer_tint" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertEqual( arnold.AiArrayGetRGB( a, 0 ), arnold.ai_color.AtRGB(7, 8, 9) )
+
 	def testDoubleData( self ) :
 
 		with IECoreArnold.UniverseBlock( writable = True ) as universe :

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -588,9 +588,9 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 	}
 
 
-	if( aiType == AI_TYPE_BOOLEAN )
+	if( aiType == AI_TYPE_BOOLEAN && IECore::runTimeCast<const BoolVectorData>( data ) )
 	{
-		// bools are a special case because of how the STL implements vector<bool>.
+		// bool vectors are a special case because of how the STL implements vector<bool>.
 		// Since the base for vector<bool> are not actual booleans, we need to manually
 		// convert to an AtArray here.
 		const vector<bool> &booleans = static_cast<const BoolVectorData *>( data )->readable();
@@ -601,7 +601,7 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 		}
 		return array;
 	}
-	else if( aiType == AI_TYPE_STRING )
+	else if( aiType == AI_TYPE_STRING && IECore::runTimeCast<const StringVectorData>( data ) )
 	{
 		const vector<string> &strings = static_cast<const StringVectorData *>( data )->readable();
 		const vector<string>::size_type size = strings.size();
@@ -610,6 +610,20 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 		{
 			AiArraySetStr( array, i, strings[i].c_str() );
 		}
+		return array;
+	}
+	else if( aiType == AI_TYPE_STRING && IECore::runTimeCast<const StringData>( data ) )
+	{
+		// The general case below using size() and address() handles setting an array from a
+		// scalar value. It makes sense that setting an array with a scalar value should
+		// result in a single element array, so we should support that for strings as well.
+		//
+		// This special case is not actually necessary ... the call to AiArrayConvert
+		// is actually able to handle a StringData, but I'm not sure why that works,
+		// so it seems safer to explicitly call AiArraySetStr with a char*.
+		const string &val = static_cast<const StringData *>( data )->readable();
+		AtArray *array = AiArrayAllocate( 1, 1, AI_TYPE_STRING );
+		AiArraySetStr( array, 0, val.c_str() );
 		return array;
 	}
 


### PR DESCRIPTION
Arnold 7.5.2 switches the `driver_exr` "compression" parameter from a string to a string array. This currently results in a crash, where we just cast a StringData to a StringVectorData and dereference it.

There is a possible discussion about whether a mismatched data type should be an exception or something, but dataToArray already supports interpreting an IntData or a Color3fData as a one element array. I'm not entirely sure whether this was intentional, or just a side effect of employing `IECore::size()` and `IECore::data()` ... but conveniently, if we make this work for strings as well, then we get backwards compatible support for the "compression" parameter ( in the new Arnold, you can get the same results you used to get for single part EXRs if you set the compression as a one element string array ).

I've gone ahead and implemented that as a good way of avoiding crashes in the short term.

I did also think a little bit about whether we should try and take advantage of this feature, which is intended to allow for different compression settings per subimage when writing multipart EXRs. Ideally, when "multipart" is enabled, we would support a StringData "compression" for each output, which we would assemble into an array on the driver with an element corresponding to the correct output. This would require some special case code, and tracking the ordering of the outputs when creating the driver parameters though ... it didn't feel completely obvious how this would fit in to the current framework, so perhaps we'll leave adding new functionality until it's requested. In the meantime, this PR is sufficient to keep the old functionality working with Arnold 7.5.2.