### PR TITLE
GraphEditor : Add per-instance versions of static signals

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,7 +27,13 @@ Fixes
 API
 ---
 
-- GraphEditor : Added an optional argument to `nodeContextMenuSignal()` to request a signal that will pass a list of nodes to the handler, rather than a single node. This can be used to register menu items that will act on multiple nodes.
+- GraphEditor :
+  - Added an optional argument to `nodeContextMenuSignal()` to request a signal that will pass a list of nodes to the handler, rather than a single node. This can be used to register menu items that will act on multiple nodes.
+  - Added per-instance signals in addition to existing class-level signals. These are accessed by calling the same methods as before, but from an instance (`graphEditorInstance.plugContextMenuSignal()`) rather than the class (`GraphEditor.plugContextMenuSignal()`) (#137). The following signals are available in this form :
+    - `plugContextMenuSignal()`
+    - `connectionContextMenuSignal()`
+    - `nodeContextMenuSignal()`
+    - `nodeDoubleClickSignal()`
 - Spreadsheet : Added support for `spreadsheet:outputRowVisible` metadata, which can be used to hide the output row.
 
 Breaking Changes

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - GraphEditor :
   - Changed node context menu items to operate on multiple nodes where possible (#2783).
   - Added drag & drop from LightEditor and AttributeEditor. Dropping a location navigates to the node that created the location.
+  - Added context menu item and keyboard shortcut, <kbd>/</kbd>, for hiding all of a node's unconnected plugs.
 - RenderMan : Changed PxrCryptomatte's material output to use the name of the terminal shader, rather than a hash of the network. This is stable under animation. As before, the output can be customised by creating a `user:__materialid` attribute.
 - SpreadsheetUI : Added "Output" row, showing the output value computed for each column. Cells in this row can be left-dragged to connect the column to a plug, or middle-dragged to transfer the current value.
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -156,6 +156,7 @@ Auto-arrange selected nodes          | {kbd}`Ctrl` + {kbd}`L`
 Duplicate outgoing connection        | {kbd}`Shift` + {{leftClick}} and drag connection just before in plug
 Disconnect connections under cursor  | {kbd}`X` + {{leftClick}}
 Disconnect connections under line    | {kbd}`X` + {{leftClick}} and drag to draw a line, then release {{leftClick}}
+Hide disconnected nodules            | {kbd}`/`
 
 ### Focus Node ###
 

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import functools
+import types
 import imath
 
 import IECore
@@ -72,6 +73,25 @@ def _currentFrame( viewportGadget ) :
 	frame.extendBy( imath.V2f( rasterMax[0], rasterMax[1] ) )
 
 	return frame
+
+# Decorator equivalent to `@classmethod` if function is
+# called as `Class.foo()`, but also allows use as an instance
+# method if called as `instance.foo()`. We use this to aid
+# a transition from class-level signals to instance-level
+# signals.
+class _ClassOrInstanceMethod :
+
+	def __init__( self, function ) :
+
+		self.__function = function
+		functools.update_wrapper( self, function )
+
+	def __get__( self, instance, owner ) :
+
+		if instance is not None :
+			return types.MethodType( self.__function, instance )
+		else :
+			return types.MethodType( self.__function, owner )
 
 class GraphEditor( GafferUI.Editor ) :
 
@@ -134,6 +154,12 @@ class GraphEditor( GafferUI.Editor ) :
 		self.__nodeMenu = None
 		self.__readOnlyPopup = None
 
+		self.__plugContextMenuSignal = Gaffer.Signals.Signal3()
+		self.__connectionContextMenuSignal = Gaffer.Signals.Signal3()
+		self.__nodeContextMenuSignal = Gaffer.Signals.Signal3()
+		self.__multiNodeContextMenuSignal = Gaffer.Signals.Signal3()
+		self.__nodeDoubleClickSignal = GafferUI.WidgetEventSignal()
+
 	## Returns the internal GadgetWidget holding the GraphGadget.
 	def graphGadgetWidget( self ) :
 
@@ -174,10 +200,10 @@ class GraphEditor( GafferUI.Editor ) :
 	# menu definition on the fly - the signature for the signal is
 	# ( graphEditor, plug, menuDefinition ) and the menu definition should just be
 	# edited in place.
-	@classmethod
-	def plugContextMenuSignal( cls ) :
+	@_ClassOrInstanceMethod
+	def plugContextMenuSignal( classOrSelf ) :
 
-		return cls.__plugContextMenuSignal
+		return classOrSelf.__plugContextMenuSignal
 
 	__connectionContextMenuSignal = Gaffer.Signals.Signal3()
 	## Returns a signal which is emitted to create a context menu for a
@@ -185,10 +211,10 @@ class GraphEditor( GafferUI.Editor ) :
 	# menu definition on the fly - the signature for the signal is
 	# ( graphEditor, destinationPlug, menuDefinition ) and the menu definition
 	# should just be edited in place.
-	@classmethod
-	def connectionContextMenuSignal( cls ) :
+	@_ClassOrInstanceMethod
+	def connectionContextMenuSignal( classOrSelf ) :
 
-		return cls.__connectionContextMenuSignal
+		return classOrSelf.__connectionContextMenuSignal
 
 	@classmethod
 	def appendConnectionNavigationMenuDefinitions( cls, graphEditor, destinationPlug, menuDefinition ) :
@@ -232,14 +258,13 @@ class GraphEditor( GafferUI.Editor ) :
 	# single node signal with the same `menuDefinition`.
 	# For both, the menu definition should just be edited in place. Typically
 	# you would add slots to this signal as part of a startup script.
-
 	# \todo Deprecate the single node signal in version `1.8` and remove it in `1.9`.
-	@classmethod
-	def nodeContextMenuSignal( cls, multiNode = False ) :
+	@_ClassOrInstanceMethod
+	def nodeContextMenuSignal( classOrSelf, multiNode = False ) :
 
 		if multiNode :
-			return cls.__multiNodeContextMenuSignal
-		return cls.__nodeContextMenuSignal
+			return classOrSelf.__multiNodeContextMenuSignal
+		return classOrSelf.__nodeContextMenuSignal
 
 	## May be used from a slot attached to nodeContextMenuSignal() to install some
 	# standard menu items for modifying the connection visibility for a node.
@@ -353,10 +378,10 @@ class GraphEditor( GafferUI.Editor ) :
 	__nodeDoubleClickSignal = GafferUI.WidgetEventSignal()
 	## Returns a signal which is emitted whenever a node is double clicked.
 	# Slots should have the signature ( graphEditor, node ).
-	@classmethod
-	def nodeDoubleClickSignal( cls ) :
+	@_ClassOrInstanceMethod
+	def nodeDoubleClickSignal( classOrSelf ) :
 
-		return cls.__nodeDoubleClickSignal
+		return classOrSelf.__nodeDoubleClickSignal
 
 	## Ensures that the specified node has a visible GraphEditor viewing
 	# it, and returns that editor.
@@ -441,9 +466,11 @@ class GraphEditor( GafferUI.Editor ) :
 				overrideMenuTitle = None
 
 				if isinstance( gadgets[0], GafferUI.Nodule ) :
+					GraphEditor.plugContextMenuSignal()( self, gadgets[0].plug(), overrideMenuDefinition )
 					self.plugContextMenuSignal()( self, gadgets[0].plug(), overrideMenuDefinition )
 					overrideMenuTitle = gadgets[0].plug().relativeName( self.graphGadget().getRoot() )
 				elif isinstance( gadgets[0], GafferUI.ConnectionGadget ) :
+					GraphEditor.connectionContextMenuSignal()( self, gadgets[0].dstNodule().plug(), overrideMenuDefinition )
 					self.connectionContextMenuSignal()( self, gadgets[0].dstNodule().plug(), overrideMenuDefinition )
 					overrideMenuTitle = "-> " + gadgets[0].dstNodule().plug().relativeName( self.graphGadget().getRoot() )
 				else :
@@ -455,8 +482,10 @@ class GraphEditor( GafferUI.Editor ) :
 							nodeList = [ node for node in self.scriptNode().selection() if self.graphGadget().nodeGadget( node ) is not None ]
 						else :
 							nodeList = [ nodeGadget.node() ]
-						self.nodeContextMenuSignal( True )( self, nodeList, overrideMenuDefinition )
 
+						GraphEditor.nodeContextMenuSignal( True )( self, nodeList, overrideMenuDefinition )
+						self.nodeContextMenuSignal( True )( self, nodeList, overrideMenuDefinition )
+						GraphEditor.nodeContextMenuSignal()( self, nodeGadget.node(), overrideMenuDefinition )
 						self.nodeContextMenuSignal()( self, nodeGadget.node(), overrideMenuDefinition )
 
 						overrideMenuTitle = ( "{} Nodes".format( len( nodeList ) ) ) if len( nodeList ) > 1 else nodeList[0].getName()
@@ -601,7 +630,10 @@ class GraphEditor( GafferUI.Editor ) :
 
 		nodeGadget = self.__nodeGadgetAt( event.line.p1 )
 		if nodeGadget is not None :
-			return self.nodeDoubleClickSignal()( self, nodeGadget.node() )
+			return (
+				self.nodeDoubleClickSignal()( self, nodeGadget.node() ) or
+				GraphEditor.nodeDoubleClickSignal()( self, nodeGadget.node() )
+			)
 
 	def __dragEnter( self, widget, event ) :
 

--- a/python/GafferUI/_PlugVisibilityGadget.py
+++ b/python/GafferUI/_PlugVisibilityGadget.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import itertools
 
 import Gaffer
 import GafferUI
@@ -42,43 +43,93 @@ import GafferUI
 # This file adds context menu items associated with the PlugVisibilityGadget,
 # the rest of which is implemented in `src/GafferUI/PlugVisibilityGadget.cpp`.
 
-def __setPlugMetadata( plug, key, value ) :
+def __hide( plugs ) :
 
-	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
-		Gaffer.Metadata.registerValue( plug, key, value )
+	with Gaffer.UndoScope( next( iter( plugs ) ).ancestor( Gaffer.ScriptNode ) ) :
+		for plug in plugs :
+			Gaffer.Metadata.registerValue( plug, "noduleLayout:visible", False )
 
-def __hasVisibilityGadget( plug ) :
+def __managedPlugs( parent ) :
 
-	parent = plug.parent()
-	while True :
-		for key in Gaffer.Metadata.registeredValues( parent ) :
-			if key.endswith( ":gadgetType" ) and Gaffer.Metadata.value( parent, key ) == "GafferUI.PlugVisibilityGadget" :
-				return True
-		parent = parent.parent()
-		if parent is None or isinstance( parent, Gaffer.Node ) :
-			return False
+	for key in Gaffer.Metadata.registeredValues( parent ) :
+		if key.endswith( ":gadgetType" ) and Gaffer.Metadata.value( parent, key ) == "GafferUI.PlugVisibilityGadget" :
+			return [
+				p for p in Gaffer.Metadata.plugsWithMetadata( parent, "plugVisibilityGadget:showable" )
+				if Gaffer.Metadata.value( p, "plugVisibilityGadget:showable" )
+			]
+
+	result = []
+	for child in Gaffer.GraphComponent.Range( parent ) :
+		result.extend( __managedPlugs( child ) )
+
+	return result
+
+def __unconnected( plug ) :
+
+	if plug.direction() == plug.Direction.In :
+		return plug.getInput() is None and all( p.getInput() is None for p in Gaffer.Plug.RecursiveRange( plug ) )
+	else :
+		return len( plug.outputs() ) == 0 and all( len( p.outputs() ) == 0 for p in Gaffer.Plug.RecursiveRange( plug ) )
+
+def __visible( plug ) :
+
+	return Gaffer.Metadata.value( plug, "noduleLayout:visible" ) != False and Gaffer.Metadata.value( plug, "nodule:type" ) != ""
 
 def __graphEditorPlugContextMenu( graphEditor, plug, menuDefinition ) :
 
-	if not __hasVisibilityGadget( plug ) or not Gaffer.Metadata.value( plug, "plugVisibilityGadget:showable" ) :
+	if plug not in __managedPlugs( plug.node() ) :
 		return
 
 	if len( menuDefinition.items() ) :
 		menuDefinition.append( "/HideDivider", { "divider" : True } )
 
-	if plug.direction() == plug.Direction.In :
-		numConnections = 1 if plug.getInput() else 0
-	else :
-		numConnections = len( plug.outputs() )
-
 	menuDefinition.append(
 
 		"/Hide",
 		{
-			"command" : functools.partial( __setPlugMetadata, plug, "noduleLayout:visible", False ),
-			"active" : numConnections == 0 and not Gaffer.MetadataAlgo.readOnly( plug ),
+			"command" : functools.partial( __hide, [ plug ] ),
+			"active" : __unconnected( plug ) and not Gaffer.MetadataAlgo.readOnly( plug ),
 		}
 
 	)
 
-GafferUI.GraphEditor.plugContextMenuSignal().connect( __graphEditorPlugContextMenu )
+def __graphEditorKeyPress( editor, event ) :
+
+	assert( isinstance( editor, GafferUI.GraphEditor ) )
+	if event.key == "Slash" and event.modifiers == event.Modifiers.None_ :
+
+		nodes = [ n for n in editor.scriptNode().selection() if n.parent() == editor.graphGadget().getRoot() ]
+		toHide = []
+		for node in nodes :
+			toHide.extend( [ p for p in __managedPlugs( node ) if __unconnected( p ) and __visible( p ) ] )
+
+		if toHide and not any( Gaffer.MetadataAlgo.readOnly( p ) for p in toHide ) :
+			__hide( toHide )
+
+		return True
+
+	return False
+
+def __graphEditorNodeContextMenu( graphEditor, nodeList, menuDefinition ) :
+
+	managedPlugs = [ __managedPlugs( node ) for node in nodeList ]
+	if all( managedPlugs ) :
+		toHide = [ p for p in itertools.chain( *managedPlugs ) if __unconnected( p ) and __visible( p ) ]
+		menuDefinition.append(
+			"/Connections/Hide Unconnected Plugs",
+			{
+				"command" : functools.partial( __hide, toHide ),
+				"shortCut" : "/",
+				"active" : len( toHide ) and not any( Gaffer.MetadataAlgo.readOnly( p ) for p in toHide ),
+			}
+		)
+		return
+
+def connectToEditor( editor ) :
+
+	if not isinstance( editor, GafferUI.GraphEditor ) :
+		return
+
+	editor.plugContextMenuSignal().connect( __graphEditorPlugContextMenu )
+	editor.nodeContextMenuSignal( True ).connect( __graphEditorNodeContextMenu )
+	editor.keyPressSignal().connect( __graphEditorKeyPress )

--- a/python/GafferUITest/GraphEditorTest.py
+++ b/python/GafferUITest/GraphEditorTest.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import types
 import unittest
 import weakref
 
@@ -194,6 +195,23 @@ class GraphEditorTest( GafferUITest.TestCase ) :
 		del s["b"]
 
 		self.assertEqual( e.graphGadget().getRoot(), s )
+
+	def testPlugContextMenuSignal( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		graphEditor1 = GafferUI.GraphEditor( script )
+		graphEditor2 = GafferUI.GraphEditor( script )
+
+		self.assertIsNot( graphEditor1.plugContextMenuSignal(), graphEditor2.plugContextMenuSignal() )
+		self.assertIsNot( GafferUI.GraphEditor.plugContextMenuSignal(), graphEditor1.plugContextMenuSignal() )
+		self.assertIsNot( GafferUI.GraphEditor.plugContextMenuSignal(), graphEditor2.plugContextMenuSignal() )
+
+		self.assertIs( graphEditor1.plugContextMenuSignal(), graphEditor1.plugContextMenuSignal() )
+		self.assertIs( graphEditor2.plugContextMenuSignal(), graphEditor2.plugContextMenuSignal() )
+
+		self.assertIsInstance( graphEditor1.plugContextMenuSignal, types.MethodType )
+		self.assertIsInstance( GafferUI.GraphEditor.plugContextMenuSignal, types.MethodType )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/startup/gui/editor.py
+++ b/startup/gui/editor.py
@@ -42,6 +42,7 @@ def __editorCreated( editor ) :
 	GafferUI.GraphBookmarksUI.connectToEditor( editor )
 	GafferSceneUI.SceneHistoryUI.connectToEditor( editor )
 	GafferSceneUI.EditScopeUI.connectToEditor( editor )
+	GafferUI._PlugVisibilityGadget.connectToEditor( editor )
 
 GafferUI.Editor.instanceCreatedSignal().connect( __editorCreated )
 GafferUI.CompoundEditor.nodeSetMenuSignal().connect( GafferUI.GraphBookmarksUI.appendNodeSetMenuDefinitions )


### PR DESCRIPTION
The static signals were convenient, but left us in the awkward position of not having an easy way to customise individual GraphEditors. It was also confusing that some signals were available statically but others were not, as documented in issue https://github.com/GafferHQ/gaffer/issues/137, and bumped into when considering how to enable the features from #7020.

I've also included the hide-unconnected feature from #7020 in this PR, enabled using a `connectToEditor()` function which I think will become our standard way of bolting on extensions to the UI now we're moving away from static signals. I've done some additional refactoring here, so that even the old plug menu item uses the same single-source-of-truth as the new node menu item and hotkey. See what you think @ericmehl - the code is a fair bit shorter now, but no doubt I've broken something at the same time.