### PR TITLE
IECoreArnold::ParameterAlgo : Support scalar values for vector parms

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@ Fixes
 -----
 
 - Shuffle nodes : Fixed bug that disabled the "+" button if a shuffle plug had an input connection.
+- Arnold : Fixed crash with Arnold 7.5.2 when setting the `driver_exr` "compression" parameter, which was previously a string but is now a string array.
+- IECoreArnold::ParameterAlgo : Added support for setting an array parameter with a StringData or BoolData. This is treated as equivalent to setting the array parameter to a one element array.
 
 1.6.21.1 (relative to 1.6.21.0)
 ========

--- a/python/IECoreArnoldTest/ParameterAlgoTest.py
+++ b/python/IECoreArnoldTest/ParameterAlgoTest.py
@@ -101,6 +101,32 @@ class ParameterAlgoTest( unittest.TestCase ) :
 			self.assertEqual( arnold.AiArrayGetUInt( a, 0 ), 12 )
 			self.assertEqual( arnold.AiArrayGetUInt( a, 1 ), 2147483649 )
 
+	def testVectorFromScalarData( self ) :
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			n = arnold.AiNode( universe, "imager_light_mixer" )
+
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_name", IECore.StringData( "testString" ) )
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_enable", IECore.BoolData( False ) )
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_intensity", IECore.FloatData( 0.42 ) )
+			IECoreArnold.ParameterAlgo.setParameter( n, "layer_tint", IECore.Color3fData( imath.Color3f( 7, 8, 9 ) ) )
+
+			a = arnold.AiNodeGetArray( n, "layer_name" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertEqual( arnold.AiArrayGetStr( a, 0 ), "testString" )
+
+			a = arnold.AiNodeGetArray( n, "layer_enable" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertEqual( arnold.AiArrayGetBool( a, 0 ), False )
+
+			a = arnold.AiNodeGetArray( n, "layer_intensity" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertAlmostEqual( arnold.AiArrayGetFlt( a, 0 ), 0.42 )
+			a = arnold.AiNodeGetArray( n, "layer_tint" )
+			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 1 )
+			self.assertEqual( arnold.AiArrayGetRGB( a, 0 ), arnold.ai_color.AtRGB(7, 8, 9) )
+
 	def testDoubleData( self ) :
 
 		with IECoreArnold.UniverseBlock( writable = True ) as universe :

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -588,9 +588,9 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 	}
 
 
-	if( aiType == AI_TYPE_BOOLEAN )
+	if( aiType == AI_TYPE_BOOLEAN && IECore::runTimeCast<const BoolVectorData>( data ) )
 	{
-		// bools are a special case because of how the STL implements vector<bool>.
+		// bool vectors are a special case because of how the STL implements vector<bool>.
 		// Since the base for vector<bool> are not actual booleans, we need to manually
 		// convert to an AtArray here.
 		const vector<bool> &booleans = static_cast<const BoolVectorData *>( data )->readable();
@@ -601,8 +601,10 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 		}
 		return array;
 	}
-	else if( aiType == AI_TYPE_STRING )
+	else if( aiType == AI_TYPE_STRING && IECore::runTimeCast<const StringVectorData>( data ) )
 	{
+		// string vectors should be setup using AiArraySetStr since we can't rely on the memory
+		// layout matching
 		const vector<string> &strings = static_cast<const StringVectorData *>( data )->readable();
 		const vector<string>::size_type size = strings.size();
 		AtArray *array = AiArrayAllocate( size, 1, AI_TYPE_STRING );
@@ -610,6 +612,14 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 		{
 			AiArraySetStr( array, i, strings[i].c_str() );
 		}
+		return array;
+	}
+	else if( aiType == AI_TYPE_STRING && IECore::runTimeCast<const StringData>( data ) )
+	{
+		// Same thing when setting the string vector from a StringData
+		const string &val = static_cast<const StringData *>( data )->readable();
+		AtArray *array = AiArrayAllocate( 1, 1, AI_TYPE_STRING );
+		AiArraySetStr( array, 0, val.c_str() );
 		return array;
 	}
 


### PR DESCRIPTION
Recreating #7059 with branch on main repo, with comments addressed.