### PR TITLE
CI : Check that Xvfb is running before starting metacity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,10 @@ jobs:
         rm -rf /hostVolume/usr/lib/jvm /hostVolume/usr/local/lib/android
         # Set up an X server and window manager.
         Xvfb :99 -screen 0 1280x1024x24 &
+        # Make sure Xvfb has started and X display :99 is available before running metacity.
+        # Otherwise metacity can fail to start, which results in documentation screengrabs
+        # being made incorrectly.
+        timeout 5 bash -c 'until xset -display :99 q >/dev/null 2>&1; do sleep 0.1; done'
         metacity --display :99.0 &
         # Create user used for running tests.
         useradd -m testUser


### PR DESCRIPTION
We occasionally see `(metacity:197): metacity-CRITICAL **: 23:10:51.052: Unable to open X display :99.0` [errors](https://github.com/GafferHQ/gaffer/actions/runs/30589368353/job/91028046503#step:7:28) on CI when setting up Xvfb and metacity. This results in our documentation screengrabs being made from a Gaffer window at the incorrect resolution. As the error is intermittent, one explanation could be a race condition on some CI runners where Xvfb hasn't finished startup quickly enough before we run metacity. This PR now gives Xvfb up to 5 seconds to get going, with an early out once the `xset` query returns that the X display is available.
