### PR TITLE
RenderMan ShaderNetworkAlgo : Ignore `treatAsPoint` and `treatAsLine`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,13 +10,10 @@ Fixes
 -----
 
 - Application : Fixed bug that prevented the use of `sys.executable` for launching a Python process. `sys.executable` now points to the included `python` executable instead of `gaffer` [^1].
-
-Fixes
------
-
 - MenuButton : Fixed immediate mode when the menu contained a single submenu.
 - RandomChoice : Fixed "Value/Weight" table headers when first setting up the node.
 - VectorDataPlugValueWidget : Fixed handling of custom header metadata when adding and removing columns.
+- RenderMan : Fixed handling of `treatAsPoint` and `treatAsLine` UsdLuxLight parameters. These are now ignored, matching the behaviour of `hdPrman`.
 
 1.7.0.0a9 (relative to 1.7.0.0a8)
 =========

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -395,9 +395,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 				IECoreScene.Shader(
 					"PxrSphereLight", "light",
-					expectedLightParameters( {
-						"areaNormalize" : True,
-					} )
+					expectedLightParameters( {} )
 				),
 
 			],
@@ -413,9 +411,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 				IECoreScene.Shader(
 					"PxrCylinderLight", "light",
-					expectedLightParameters( {
-						"areaNormalize" : True,
-					} )
+					expectedLightParameters( {} )
 				),
 
 			],
@@ -547,8 +543,8 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
 			IECoreScene.Shader( "DomeLight", "light", {} ) : imath.M44f(),
 			IECoreScene.Shader( "CylinderLight", "light", { "length" : 2.0, "radius" : 4.0 } ) : imath.M44f().scale( imath.V3f( 2.0, 8.0, 8.0 ) ),
-			IECoreScene.Shader( "SphereLight", "light", { "treatAsPoint" : True } ) : imath.M44f().scale( imath.V3f( 0.002 ) ),
-			IECoreScene.Shader( "CylinderLight", "light", { "treatAsLine" : True } ) : imath.M44f().scale( imath.V3f( 1.0, 0.002, 0.002 ) ),
+			IECoreScene.Shader( "SphereLight", "light", { "treatAsPoint" : True } ) : imath.M44f().scale( imath.V3f( 1.0 ) ),
+			IECoreScene.Shader( "CylinderLight", "light", { "treatAsLine" : True } ) : imath.M44f().scale( imath.V3f( 1.0 ) ),
 
 		}.items() :
 			with self.subTest() :

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -1075,8 +1075,6 @@ const InternedString g_specularRoughnessParameter( "specularRoughness" );
 const InternedString g_temperatureParameter( "temperature" );
 const InternedString g_textureFileParameter( "texture:file" );
 const InternedString g_textureFormatParameter( "texture:format" );
-const InternedString g_treatAsPointParameter( "treatAsPoint" );
-const InternedString g_treatAsLineParameter( "treatAsLine" );
 const InternedString g_typeParameter( "type" );
 const InternedString g_usdPrimvarReaderIntShaderName( "UsdPrimvarReader_int" );
 const InternedString g_usdPrimvarReaderFloatShaderName( "UsdPrimvarReader_float" );
@@ -1249,11 +1247,6 @@ void IECoreRenderMan::ShaderNetworkAlgo::convertUSDShaders( ShaderNetwork *shade
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
-
-			if( parameterValue( shader.get(), g_treatAsPointParameter, false ) )
-			{
-				newShader->parameters()[g_areaNormalizeParameter] = new BoolData( true );
-			}
 		}
 		else if( shader->getName() == "DiskLight" )
 		{
@@ -1312,11 +1305,6 @@ void IECoreRenderMan::ShaderNetworkAlgo::convertUSDShaders( ShaderNetwork *shade
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
-
-			if( parameterValue( shader.get(), g_treatAsLineParameter, false ) )
-			{
-				newShader->parameters()[g_areaNormalizeParameter] = new BoolData( true );
-			}
 		}
 
 		const auto it = g_primVarMap.find( shader->getName() );
@@ -1354,10 +1342,7 @@ M44f IECoreRenderMan::ShaderNetworkAlgo::usdLightTransform( const Shader *lightS
 
 	if( lightShader->getName() == "SphereLight" )
 	{
-		const float radius = !parameterValue( lightShader, g_treatAsPointParameter, false ) ?
-			parameterValue( lightShader, g_radiusParameter, 0.5f ) :
-			0.001f
-		;
+		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
 		return M44f().scale( V3f( radius * 2.f ) );
 	}
 	else if( lightShader->getName() == "DiskLight" )
@@ -1374,11 +1359,7 @@ M44f IECoreRenderMan::ShaderNetworkAlgo::usdLightTransform( const Shader *lightS
 	else if( lightShader->getName() == "CylinderLight" )
 	{
 		const float length = parameterValue( lightShader, g_lengthParameter, 1.f );
-		const float radius = !parameterValue( lightShader, g_treatAsLineParameter, false ) ?
-			parameterValue( lightShader, g_radiusParameter, 0.5f ) :
-			0.001f
-		;
-
+		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
 		return M44f().scale( V3f( length, radius * 2.f, radius * 2.f ) );
 	}
 


### PR DESCRIPTION
While in the glorious anarchy of UsdLux interpretation `hdArnold`` _does_ respect these parameters, `hdPrman` does not. So we bring ourselves into line, for better or worse.
