### PR TITLE
RenderMan ShaderNetworkAlgo : Support rendering of component connections

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.21.2)
 =======
 
+Fixes
+-----
 
+- RenderMan : Fixed handling of connections between floats and color/vector components.
 
 1.6.21.2 (relative to 1.6.21.1)
 ========

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -1078,6 +1078,48 @@ class RendererTest( GafferTest.TestCase ) :
 
 		del renderer
 
+	def testComponentConnections( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			self.renderer,
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		fileName = str( self.temporaryDirectory() / "test.exr" )
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				fileName,
+				"exr",
+				"rgba",
+				{
+				},
+			)
+		)
+
+		renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"attribute" : IECoreScene.Shader( "PxrAttribute", "osl:shader", { "defaultFloat" : 0.5 } ),
+						"output" : IECoreScene.Shader( "PxrConstant", "ri:surface", { "emitColor" : imath.Color3f( 0.25, 1, 0.75 ) } ),
+					},
+					connections = [
+						( ( "attribute", "resultRGB.r" ), ( "output", "emitColor.g" ) ),
+					],
+					output = "output",
+				),
+			} ) )
+		).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
+
+		renderer.render()
+		del renderer
+
+		image = OpenImageIO.ImageBuf( fileName )
+		self.assertEqual( image.getpixel( 320, 240, 0 ), ( 0.25, 0.5, 0.75, 1.0 ) )
+
 	def testConnectionToOSLShader( self ) :
 
 		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -887,6 +887,7 @@ ShaderNetworkPtr preprocessedNetwork( const IECoreScene::ShaderNetwork *shaderNe
 	IECoreScene::ShaderNetworkAlgo::expandSplines( result.get() );
 	IECoreRenderMan::ShaderNetworkAlgo::convertUSDShaders( result.get() );
 	IECoreRenderMan::ShaderNetworkAlgo::resolveVStructs( result.get() );
+	IECoreScene::ShaderNetworkAlgo::addComponentConnectionAdapters( result.get() );
 
 	return result;
 }


### PR DESCRIPTION
RenderMan doesn't support these natively, instead using separate `resultR`, `resultG` and `resultB` outputs as a crutch alongside `resultRGB`. Using those outputs instead isn't _too_ bad, but there's no equivalent for making component connections to _input_ colours, which leaves people manually inserting `PxrToFloat3` shaders.

So we emulate this all by inserting split/join shaders automatically while exporting to the renderer.

I did also look into registering specific Pxr shaders to use for the adaptors via `IECoreScene::ShaderNetworkAlgo::register[Split|Join]Adapter`. The problem there is that the registrations are keyed off `Shader::getType()`, which for RenderMan shaders isn't round-tripped through USD (and which we want to get rid of in general anyway). So we'd end up using different adaptors based on whether or not we'd saved and loaded via USD. Better to use the same (mx) adaptors consistently until we can improve the registration mechanism.
