### PR TITLE
RenderMan : Fix lingering light attributes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- RenderMan : Fixed handling of connections between floats and color/vector components.
+- RenderMan :
+  - Fixed handling of connections between floats and color/vector components.
+  - Fixed bug preventing attributes from being deleted from lights during an interactive render.
 
 1.6.21.2 (relative to 1.6.21.1)
 ========

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1505,6 +1505,22 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 			lambda : self.assertNotEqual( self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 0.0 )
 		)
 
+		# Mute the light again.
+
+		s["l"]["mute"]["value"].setValue( True )
+
+		self.assertEventually(
+			lambda : self.assertEqual( self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 0.0 )
+		)
+
+		# This time, unmute the light by removing the attribute.
+
+		s["l"]["mute"]["enabled"].setValue( False )
+
+		self.assertEventually(
+			lambda : self.assertNotEqual( self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 0.0 )
+		)
+
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 
 	def testDeleteLightShader( self ) :

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -2617,6 +2617,85 @@ class RendererTest( GafferTest.TestCase ) :
 			"grouping:membership", [ "shadowGroup0 groupA groupB" ]
 		)
 
+	def testRemoveLightAttributes( self ) :
+
+		with IECoreRenderManTest.RileyCapture() as capture :
+
+			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				self.renderer,
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+			)
+
+			lightShader = IECoreScene.ShaderNetwork(
+				shaders = { "output" : IECoreScene.Shader( "PxrRectLight", "ri:light" ) },
+				output = "output",
+			)
+
+			light = renderer.light(
+				"light", None,
+				renderer.attributes( IECore.CompoundObject( {
+					"ri:light" : lightShader,
+					"user:test" : IECore.IntData( 10 ),
+					"ri:visibility:camera" : IECore.BoolData( False ),
+				} ) )
+			)
+
+			# Remove the "user:test" attribute and add "light:mute"
+			self.assertTrue(
+				light.attributes(
+					renderer.attributes( IECore.CompoundObject( {
+						"ri:light" : lightShader,
+						"ri:visibility:camera" : IECore.BoolData( False ),
+						"light:mute" : IECore.BoolData( True ),
+					} ) )
+				)
+			)
+
+			# Remove "light:mute" and update "ri:visibility:camera"
+			self.assertTrue(
+				light.attributes(
+					renderer.attributes( IECore.CompoundObject( {
+						"ri:light" : lightShader,
+						"ri:visibility:camera" : IECore.BoolData( True ),
+					} ) )
+				)
+			)
+
+			# Remove "ri:visibility:camera"
+			self.assertTrue(
+				light.attributes(
+					renderer.attributes( IECore.CompoundObject( {
+						"ri:light" : lightShader,
+					} ) )
+				)
+			)
+
+			del light
+			del renderer
+
+		self.__assertParameterEqual(
+			next( x for x in capture.json if x["method"] == "CreateLightInstance" )["attributes"]["params"],
+			"user:test", [ 10 ]
+		)
+
+		modifications = [
+			x for x in capture.json
+			if x["method"] == "ModifyLightInstance" and x["attributes"] is not None
+		]
+
+		self.assertEqual( len( modifications ), 3 )
+		self.__assertNotInParameters( modifications[0]["attributes"]["params"], "user:test" )
+		self.__assertParameterEqual( modifications[0]["attributes"]["params"], "visibility:camera", [ 0 ] )
+		self.__assertParameterEqual( modifications[0]["attributes"]["params"], "lighting:mute", [ 1 ] )
+
+		self.__assertNotInParameters( modifications[1]["attributes"]["params"], "user:test" )
+		self.__assertParameterEqual( modifications[1]["attributes"]["params"], "visibility:camera", [ 1 ] )
+		self.__assertNotInParameters( modifications[1]["attributes"]["params"], "lighting:mute" )
+
+		self.__assertNotInParameters( modifications[2]["attributes"]["params"], "user:test" )
+		self.__assertNotInParameters( modifications[2]["attributes"]["params"], "visibility:camera" )
+		self.__assertNotInParameters( modifications[2]["attributes"]["params"], "lighting:mute" )
+
 	def testShaderSubstitutions( self ) :
 
 		with IECoreRenderManTest.RileyCapture() as capture :

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -109,6 +109,14 @@ M44f preTransform( const Attributes *attributes )
 	return IECoreRenderMan::ShaderNetworkAlgo::usdLightTransform( lightShader ) * correctiveTransform( lightShader );
 }
 
+RtParamList mergedAttributes( const RtParamList &attributes, const RtParamList &extraAttributes )
+{
+	RtParamList result = attributes;
+	result.Update( extraAttributes );
+
+	return result;
+}
+
 const IECore::InternedString g_lightFilters( "lightFilters" );
 const RtUString g_defaultLightGroup( "defaultLightGroup" );
 const RtUString g_defaultShadowGroup( "defaultShadowGroup" );
@@ -121,8 +129,7 @@ Light::Light( const ConstGeometryPrototypePtr &geometryPrototype, const Attribut
 		m_attributes( attributes ), m_geometryPrototype( geometryPrototype ), m_shadowSubset( g_defaultShadowGroup )
 
 {
-	m_allAttributes.SetString( Loader::strings().k_grouping_membership, g_defaultLightGroup );
-	m_allAttributes.Update( attributes->instanceAttributes() );
+	m_extraAttributes.SetString( Loader::strings().k_grouping_membership, g_defaultLightGroup );
 
 	m_lightShader = acquireLightShader( attributes );
 	if( !m_lightShader || m_lightShader->id() == riley::LightShaderId::InvalidId() )
@@ -135,7 +142,8 @@ Light::Light( const ConstGeometryPrototypePtr &geometryPrototype, const Attribut
 	const Material *material = attributes->lightMaterial();
 	m_lightInstance = m_session->createLightInstance(
 		m_geometryPrototype ? m_geometryPrototype->id() : riley::GeometryPrototypeId(),
-		material ? material->id() : riley::MaterialId(), m_lightShader->id(), { 0, nullptr }, IdentityTransform(), m_allAttributes
+		material ? material->id() : riley::MaterialId(), m_lightShader->id(), { 0, nullptr }, IdentityTransform(),
+		mergedAttributes( attributes->instanceAttributes(), m_extraAttributes )
 	);
 }
 
@@ -243,7 +251,7 @@ bool Light::attributes( const IECoreScenePreview::Renderer::AttributesInterface 
 		return true;
 	}
 
-	m_allAttributes.Update( renderManAttributes->instanceAttributes() );
+	const RtParamList allAttributes = mergedAttributes( renderManAttributes->instanceAttributes(), m_extraAttributes );
 
 	const Material *material = renderManAttributes->lightMaterial();
 	const riley::LightInstanceResult result = m_session->modifyLightInstance(
@@ -252,7 +260,7 @@ bool Light::attributes( const IECoreScenePreview::Renderer::AttributesInterface 
 		/* light shader = */ &lightShader->id(),
 		/* coordinateSystems = */ nullptr,
 		/* xform = */ nullptr,
-		&m_allAttributes
+		&allAttributes
 	);
 
 	m_attributes = renderManAttributes;
@@ -358,7 +366,7 @@ void Light::updateLightFilterShader( const IECoreScene::ConstShaderNetworkPtr &l
 
 void Light::updateLinking( RtUString memberships, RtUString shadowSubset )
 {
-	m_allAttributes.SetString( Loader::strings().k_grouping_membership, memberships );
+	m_extraAttributes.SetString( Loader::strings().k_grouping_membership, memberships );
 
 	if( m_lightInstance == riley::LightInstanceId::InvalidId() )
 	{
@@ -374,13 +382,14 @@ void Light::updateLinking( RtUString memberships, RtUString shadowSubset )
 		lightShaderId = &lightShader->id();
 	}
 
+	const RtParamList allAttributes = mergedAttributes( m_attributes->instanceAttributes(), m_extraAttributes );
 	const riley::LightInstanceResult result = m_session->modifyLightInstance(
 		m_lightInstance,
 		/* material = */ nullptr,
 		lightShaderId,
 		/* coordinateSystems = */ nullptr,
 		/* xform = */ nullptr,
-		&m_allAttributes
+		&allAttributes
 	);
 
 	if( lightShaderId )

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -87,9 +87,9 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		ConstAttributesPtr m_attributes;
 		/// Used to keep geometry prototype alive as long as we need it.
 		ConstGeometryPrototypePtr m_geometryPrototype;
-		/// Combination of `m_attributes->instanceAttributes()` and
-		/// "grouping:membership" attribute used to implement light linking.
-		RtParamList m_allAttributes;
+		/// Attributes in addition to those received from the scene. Currently
+		/// just the "grouping:membership" attribute used to implement light linking.
+		RtParamList m_extraAttributes;
 		IECoreScene::ConstShaderNetworkPtr m_lightFilterShader;
 		IECoreScenePreview::Renderer::ConstObjectSetPtr m_linkedFilters;
 		RtUString m_shadowSubset;


### PR DESCRIPTION
Previously we were storing all light attributes as a RtParamList, and then calling Update() with any later changes from the scene. RtParamList::Update() only adds or replaces parameters, but doesn't remove them, so attributes later deleted from the scene would remain on the light. This commit changes Light to follow Object's example of only storing the extra attributes and merging them with the instance attributes as required.
