### PR TITLE
For discussion, possible approach to GafferImage::Warp integer overflow

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - RenderMan :
   - Fixed handling of connections between floats and color/vector components.
   - Fixed bug preventing attributes from being deleted from lights during an interactive render.
+- GafferImage::VectorWarp : Fixed crash with pixel offsets much larger than any reasonable image.
 
 1.6.21.2 (relative to 1.6.21.1)
 ========

--- a/python/GafferImageTest/VectorWarpTest.py
+++ b/python/GafferImageTest/VectorWarpTest.py
@@ -117,6 +117,44 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 
 		GafferImageTest.processTiles( vectorWarp["out"] )
 
+	def testIntegerOverflow( self ) :
+
+		constantBig = GafferImage.Constant()
+		constantBig["format"].setValue( GafferImage.Format( 1, 1, 1.000 ) )
+
+		constantBackground = GafferImage.Constant()
+		constantBackground["format"].setValue( GafferImage.Format( 100, 100, 1.000 ) )
+
+		merge = GafferImage.Merge()
+		merge["in"][0].setInput( constantBig["out"] )
+		merge["in"][1].setInput( constantBackground["out"] )
+
+		vectorWarp = GafferImage.VectorWarp()
+		vectorWarp["in"].setInput( merge["out"] )
+		vectorWarp["vector"].setInput( merge["out"] )
+		vectorWarp["useDerivatives"].setValue( False )
+		vectorWarp["vectorMode"].setValue( GafferImage.VectorWarp.VectorMode.Relative )
+		vectorWarp["vectorUnits"].setValue( GafferImage.VectorWarp.VectorUnits.Pixels )
+
+		# Test a bunch of bogus values for a warp that would be outside the bounds
+		# of representable integers if we didn't clamp them.
+
+		for offsetX, offsetY in [
+			( 1e10, 1e10 ),
+			( -1e10, 1e10 ),
+			( 1e10, -1e10 ),
+			( -1e10, -1e10 ),
+			( 0, 1e10 ),
+			( 0, -1e10 ),
+			( 1e10, 0 ),
+			( -1e10, 0 )
+		]:
+			constantBig["color"].setValue( imath.Color4f( offsetX, offsetY, 0, 1 ) )
+
+			# We aren't concerned about what values we get for these ridiculous values,
+			# we just want to make sure it doesn't crash
+			GafferImageTest.processTiles( vectorWarp["out"] )
+
 	def testWarpImage( self ):
 		dotGridReader = GafferImage.ImageReader()
 		dotGridReader["fileName"].setValue( self.imagesPath() / "dotGrid.300.exr" )

--- a/src/GafferImage/VectorWarp.cpp
+++ b/src/GafferImage/VectorWarp.cpp
@@ -92,6 +92,13 @@ struct VectorWarp::Engine : public Warp::Engine
 				return black;
 			}
 
+			// As part of implementing inputPixel, we are required to clamp the result so
+			// that we don't go near pixels that can't be represented as integers.
+			result = V2f(
+				std::min( 10000000.0f, std::max( -10000000.0f, result.x ) ),
+				std::min( 10000000.0f, std::max( -10000000.0f, result.y ) )
+			);
+
 			return result;
 		}
 	}


### PR DESCRIPTION
I spent some time today debugging a crash at IE which turned out to be due to invalid inputs to a vector warp.

If the pixel offsets are greater than `2e9`, then the size of the input bound needed could wrap around, resulting in trying to do lookups within a zero-sized tile cache.

We should definitely do better than crashing here, but it's probably debateable what the right approach is. Because of how we handle accesses outside the image using the bounding mode, we theoretically could make everything work consistently for floating point values that aren't representable as integers ... but this would result in some fiddly off-by-one issues: we usually store the bound max as the highest index + 1, which if we allow the index to reach MAX_INT, will wrap. So would we need to limit the indices to be no higher than MAX_INT - 1? It's all doable, but a bit fiddly, and we'd want to make sure we don't slow down the common case in order to handle this exceptional case.

For the moment, I've just done the simple thing, of throwing an exception if Warp is run on out-of-bound inputs, to make sure we at least don't crash, and make this much quicker to debug in the future.