### PR TITLE
GraphEditor History Fix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
   - Fixed handling of `treatAsPoint` and `treatAsLine` UsdLuxLight parameters. These are now ignored, matching the behaviour of `hdPrman`.
   - Fixed handling of connections between floats and color/vector components [^2].
   - Fixed bug preventing attributes from being deleted from lights during an interactive render [^2].
+- GraphEditor : Fixed bug with history back and forward buttons when a node in the history has been deleted (#7071) [^1].
 
 [^1]: Improvement to a feature introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
 [^2]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - PathListingWidget : Paths dragged from a PathListingWidget now preserve the order in which they are displayed.
 - SetExpressionAlgo : Fixed invalid set expressions returned by `exclude()` when the set expression to be excluded contains only whitespace [^1].
 - PlugLayout : `<layoutName>:width` metadata is now correctly reapplied to widgets with labels when a PlugLayout is rebuilt.
+- GraphEditor : Fixed bug with history back and forward buttons when a node in the history has been deleted (#7071) [^1].
 
 API
 ---

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import functools
 import types
 import imath
@@ -556,10 +557,10 @@ class GraphEditor( GafferUI.Editor ) :
 
 			return True
 		elif event.key == "BracketLeft" and not event.modifiers :
-			self.__historyWidget.moveHistoryIndex( -1 )
+			self.__historyWidget.moveHistoryIndex( self.__historyWidget.Direction.Back )
 			return True
 		elif event.key == "BracketRight" and not event.modifiers :
-			self.__historyWidget.moveHistoryIndex( 1 )
+			self.__historyWidget.moveHistoryIndex( self.__historyWidget.Direction.Forward )
 			return True
 
 		return False
@@ -966,61 +967,60 @@ class _HistoryWidget( GafferUI.Widget ) :
 		with self.__row :
 			self.__backButton = GafferUI.Button( "", "historyBack.png", hasFrame = False, toolTip = "Go back. [<kbd>[</kbd>]<br>Right-click for history menu." )
 			self.__forwardButton = GafferUI.Button( "", "historyForward.png", hasFrame = False, toolTip = "Go forward. [<kbd>]</kbd>]<br>Right-click for history menu." )
-			self.__backButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__backButtonPressed ) )
-			self.__backButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__backButtonPressed ) )
-			self.__forwardButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__forwardButtonPressed ) )
-			self.__forwardButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__forwardButtonPressed ) )
+			self.__backButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPressed ) )
+			self.__backButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__buttonPressed ) )
+			self.__forwardButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPressed ) )
+			self.__forwardButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__buttonPressed ) )
 
-		# A list of tuples of the form `( rootNode, frame )`. A frame value of `None`
-		# indicates framing to fit all child nodes.
-		self.__history = [ ( self.__scriptNode, None ) ]
+		# A list of tuples of the form `( rootNode, frame, scoped rootNode.parentChangedSignal() connection )`.
+		# A frame value of `None` indicates framing to fit all child nodes.
+		self.__history = [ ( self.__scriptNode, None, None ) ]
 		self.__historyIndex = 0
 		self.__historyPopup = None
 
 		self.__updateHistoryButtonsEnabled()
 
-	def moveHistoryIndex( self, delta ) :
+	Direction = enum.Enum( "Direction", [ "Forward", "Back" ] )
 
-		if self.__historyIndex + delta < 0 or self.__historyIndex + delta >= len( self.__history ) :
-			return
+	# Moves forwards or backwards in the history. Returns `True`
+	# on success and `False` if there was nothing to navigate to.
+	def moveHistoryIndex( self, direction ) :
 
-		self.__history[self.__historyIndex] = ( self.__history[self.__historyIndex][0], _currentFrame( self.__graphGadget.parent() ) )
+		assert( isinstance( direction, self.Direction ) )
+		nextIndex = next( self.__navigableHistoryIndices( direction ), None )
+		if nextIndex is not None :
+			self.__setHistoryIndex( nextIndex )
+			return True
 
-		self.__historyIndex += delta
+		return False
 
-		# \todo Where do we go if the node has been deleted?
-		graphEditor = self.ancestor( GafferUI.GraphEditor )
-		assert( graphEditor is not None )
-		rootNode = self.__history[self.__historyIndex][0]
-		if rootNode.isSame( self.__scriptNode ) or self.__scriptNode.isAncestorOf( rootNode ) :
-			with Gaffer.Signals.BlockedConnection( self.__rootChangedConnection ) :
-				# We're blocking `__rootChangedConnection` so we don't append to history.
-				# That connection also handles framing, so we need to take care of that here.
-				self.__frame()
-				self.__graphGadget.setRoot( rootNode )
+	def __buttonPressed( self, button, event ) :
+
+		direction = self.Direction.Forward if button is self.__forwardButton else self.Direction.Back
+
+		if event.buttons == event.Buttons.Left :
+			self.moveHistoryIndex( direction )
+		elif event.buttons == event.Buttons.Right :
+			self.__showHistoryPopup( direction, button )
+
+	def __historyNodeParentChanged( self, child, oldParent ) :
 
 		self.__updateHistoryButtonsEnabled()
 
-	def __backButtonPressed( self, button, event ) :
+	def __createHistoryEntry( self, node ) :
 
-		if event.buttons == event.Buttons.Left :
-			self.moveHistoryIndex( -1 )
-		elif event.buttons == event.Buttons.Right :
-			self.__showHistoryPopup( range( self.__historyIndex - 1, -1, -1 ), button )
-
-	def __forwardButtonPressed( self, button, event ) :
-
-		if event.buttons == event.Buttons.Left :
-			self.moveHistoryIndex( 1 )
-		elif event.buttons == event.Buttons.Right :
-			self.__showHistoryPopup( range( self.__historyIndex + 1, len( self.__history ), 1 ), button )
+		return (
+			node,
+			_currentFrame( self.__graphGadget.parent() ),
+			node.parentChangedSignal().connect( Gaffer.WeakMethod( self.__historyNodeParentChanged ), scoped = True )
+		)
 
 	def __rootChanged( self, graphGadget, previousRoot ) :
 
 		self.__history = self.__history[:self.__historyIndex + 1]
-		self.__history[self.__historyIndex] = ( self.__history[self.__historyIndex][0], _currentFrame( self.__graphGadget.parent() ) )
+		self.__history[self.__historyIndex]  = self.__createHistoryEntry( self.__history[self.__historyIndex][0] )
 
-		self.__history.append( ( graphGadget.getRoot(), None ) )
+		self.__history.append( ( graphGadget.getRoot(), None, None ) )
 		self.__historyIndex += 1
 		self.__frame()
 		self.__updateHistoryButtonsEnabled()
@@ -1030,7 +1030,7 @@ class _HistoryWidget( GafferUI.Widget ) :
 		rootNode = self.__history[self.__historyIndex][0]
 		frame = None
 		for i in range( self.__historyIndex, -1, -1 ) :
-			historyNode, historyFrame = self.__history[i]
+			historyNode, historyFrame, parentChangedConnection = self.__history[i]
 			if historyNode.isSame( rootNode ) and historyFrame is not None :
 				frame = historyFrame
 				break
@@ -1044,20 +1044,57 @@ class _HistoryWidget( GafferUI.Widget ) :
 		else :
 			graphEditor.frame( graphEditor.graphGadget().getRoot().children( Gaffer.Node ) )
 
-	def __showHistoryPopup(self, historyRange, popupParent ) :
+	def __setHistoryIndex( self, index ) :
+
+		if index < 0 or index >= len( self.__history ) or index == self.__historyIndex :
+			return
+
+		self.__history[self.__historyIndex] = self.__createHistoryEntry( self.__history[self.__historyIndex][0] )
+
+		self.__historyIndex = index
+
+		graphEditor = self.ancestor( GafferUI.GraphEditor )
+		assert( graphEditor is not None )
+		rootNode = self.__history[self.__historyIndex][0]
+		if rootNode.isSame( self.__scriptNode ) or self.__scriptNode.isAncestorOf( rootNode ) :
+			with Gaffer.Signals.BlockedConnection( self.__rootChangedConnection ) :
+				# We're blocking `__rootChangedConnection` so we don't append to history.
+				# That connection also handles framing, so we need to take care of that here.
+				self.__frame()
+				self.__graphGadget.setRoot( rootNode )
+
+		self.__updateHistoryButtonsEnabled()
+
+	def __navigableHistoryIndices( self, direction ) :
+
+		increment = 1 if direction == self.Direction.Forward else -1
+		i = previousI = self.__historyIndex
+		while i >= 0 and i < len( self.__history ) :
+			if (
+				# Node not deleted
+				( self.__history[i][0].scriptNode() is not None ) and
+				# Node different from previous yield
+				( not self.__history[i][0].isSame( self.__history[previousI][0] ) )
+			) :
+				previousI = i
+				yield i
+			i += increment
+
+	def __showHistoryPopup(self, direction, popupParent ) :
 
 		menuDefinition = IECore.MenuDefinition()
 		prefix = "/"
-		for counter, i in enumerate( historyRange ) :
+
+		for counter, i in enumerate( self.__navigableHistoryIndices( direction ) ) :
 			menuDefinition.append(
-				prefix + str( counter ),
+				f"{prefix}{counter}",
 				{
 					"label" : ( "/" + self.__history[i][0].relativeName( self.__scriptNode ).replace( ".", "/" ) ) if not self.__history[i][0].isSame( self.__scriptNode ) else "/",
-					"command" : functools.partial( Gaffer.WeakMethod( self.moveHistoryIndex ), i - self.__historyIndex ),
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setHistoryIndex ), i ),
 				}
 			)
 
-			if counter == 10 :
+			if counter == 11 :
 				prefix = "/More/"
 				menuDefinition.append( "/Divider", { "divider" : True } )
 
@@ -1066,5 +1103,9 @@ class _HistoryWidget( GafferUI.Widget ) :
 
 	def __updateHistoryButtonsEnabled( self ) :
 
-		self.__backButton.setEnabled( self.__historyIndex > 0 )
-		self.__forwardButton.setEnabled( self.__historyIndex < ( len( self.__history ) - 1 ) )
+		self.__backButton.setEnabled(
+			next( self.__navigableHistoryIndices( self.Direction.Back ), None ) is not None
+		)
+		self.__forwardButton.setEnabled(
+			next( self.__navigableHistoryIndices( self.Direction.Forward ), None ) is not None
+		)

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -981,14 +981,23 @@ class _HistoryWidget( GafferUI.Widget ) :
 
 	def moveHistoryIndex( self, delta ) :
 
-		if self.__historyIndex + delta < 0 or self.__historyIndex + delta >= len( self.__history ) :
+		if delta == 0 or self.__historyIndex + delta < 0 or self.__historyIndex + delta >= len( self.__history ) :
 			return
+
+		i = self.__historyIndex + delta
+		while self.__history[i][0].parent() is None :
+			i += -1 if delta < 0 else 1
+			if i < 0 or i >= len( self.__history ) :
+				GafferUI.PopupWindow.showWarning(
+					"All nodes in history have been removed.",
+					parent = self.__backButton if delta < 0 else self.__forwardButton
+				)
+				return
 
 		self.__history[self.__historyIndex] = ( self.__history[self.__historyIndex][0], _currentFrame( self.__graphGadget.parent() ) )
 
-		self.__historyIndex += delta
+		self.__historyIndex = i
 
-		# \todo Where do we go if the node has been deleted?
 		graphEditor = self.ancestor( GafferUI.GraphEditor )
 		assert( graphEditor is not None )
 		rootNode = self.__history[self.__historyIndex][0]
@@ -1049,6 +1058,8 @@ class _HistoryWidget( GafferUI.Widget ) :
 		menuDefinition = IECore.MenuDefinition()
 		prefix = "/"
 		for counter, i in enumerate( historyRange ) :
+			if self.__history[i][0].parent() is None :
+				continue
 			menuDefinition.append(
 				prefix + str( counter ),
 				{
@@ -1061,8 +1072,11 @@ class _HistoryWidget( GafferUI.Widget ) :
 				prefix = "/More/"
 				menuDefinition.append( "/Divider", { "divider" : True } )
 
-		self.__historyPopup = GafferUI.Menu( menuDefinition )
-		self.__historyPopup.popup( popupParent, position = imath.V2i( popupParent.bound().min().x, popupParent.bound().max().y ) )
+		if menuDefinition.size() :
+			self.__historyPopup = GafferUI.Menu( menuDefinition )
+			self.__historyPopup.popup( popupParent, position = imath.V2i( popupParent.bound().min().x, popupParent.bound().max().y ) )
+		else :
+			GafferUI.PopupWindow.showWarning( "All nodes in history have been removed.", parent = popupParent )
 
 	def __updateHistoryButtonsEnabled( self ) :
 

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -38,6 +38,7 @@
 import functools
 import types
 import imath
+from itertools import islice
 
 import IECore
 
@@ -971,65 +972,58 @@ class _HistoryWidget( GafferUI.Widget ) :
 			self.__forwardButton.buttonPressSignal().connect( Gaffer.WeakMethod( self.__forwardButtonPressed ) )
 			self.__forwardButton.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__forwardButtonPressed ) )
 
-		# A list of tuples of the form `( rootNode, frame )`. A frame value of `None`
-		# indicates framing to fit all child nodes.
-		self.__history = [ ( self.__scriptNode, None ) ]
+		# A list of tuples of the form `( rootNode, frame, scoped rootNode.parentChangedSignal() connection )`.
+		# A frame value of `None` indicates framing to fit all child nodes.
+		self.__history = [ ( self.__scriptNode, None, None ) ]
 		self.__historyIndex = 0
 		self.__historyPopup = None
 
 		self.__updateHistoryButtonsEnabled()
 
+	# Sets the history index to the node that is `delta` navigable nodes away from the current index.
+	# Returns `True` if moving the index to that position succeeds.
 	def moveHistoryIndex( self, delta ) :
 
-		if delta == 0 or self.__historyIndex + delta < 0 or self.__historyIndex + delta >= len( self.__history ) :
-			return
+		increment = -1 if delta < 0 else 1
+		for counter, i in enumerate( self.__navigableHistoryIndices( range( self.__historyIndex, -1 if increment < 0 else len( self.__history ), increment ) ) ) :
+			if counter == abs( delta ) :
+				self.__setHistoryIndex( i )
+				return True
 
-		i = self.__historyIndex + delta
-		while self.__history[i][0].parent() is None :
-			i += -1 if delta < 0 else 1
-			if i < 0 or i >= len( self.__history ) :
-				GafferUI.PopupWindow.showWarning(
-					"All nodes in history have been removed.",
-					parent = self.__backButton if delta < 0 else self.__forwardButton
-				)
-				return
-
-		self.__history[self.__historyIndex] = ( self.__history[self.__historyIndex][0], _currentFrame( self.__graphGadget.parent() ) )
-
-		self.__historyIndex = i
-
-		graphEditor = self.ancestor( GafferUI.GraphEditor )
-		assert( graphEditor is not None )
-		rootNode = self.__history[self.__historyIndex][0]
-		if rootNode.isSame( self.__scriptNode ) or self.__scriptNode.isAncestorOf( rootNode ) :
-			with Gaffer.Signals.BlockedConnection( self.__rootChangedConnection ) :
-				# We're blocking `__rootChangedConnection` so we don't append to history.
-				# That connection also handles framing, so we need to take care of that here.
-				self.__frame()
-				self.__graphGadget.setRoot( rootNode )
-
-		self.__updateHistoryButtonsEnabled()
+		return False
 
 	def __backButtonPressed( self, button, event ) :
 
 		if event.buttons == event.Buttons.Left :
 			self.moveHistoryIndex( -1 )
 		elif event.buttons == event.Buttons.Right :
-			self.__showHistoryPopup( range( self.__historyIndex - 1, -1, -1 ), button )
+			self.__showHistoryPopup( range( self.__historyIndex, -1, -1 ), button )
 
 	def __forwardButtonPressed( self, button, event ) :
 
 		if event.buttons == event.Buttons.Left :
 			self.moveHistoryIndex( 1 )
 		elif event.buttons == event.Buttons.Right :
-			self.__showHistoryPopup( range( self.__historyIndex + 1, len( self.__history ), 1 ), button )
+			self.__showHistoryPopup( range( self.__historyIndex, len( self.__history ), 1 ), button )
+
+	def __historyNodeParentChanged( self, child, oldParent ) :
+
+		self.__updateHistoryButtonsEnabled()
+
+	def __createHistoryEntry( self, node ) :
+
+		return (
+			node,
+			_currentFrame( self.__graphGadget.parent() ),
+			node.parentChangedSignal().connect( Gaffer.WeakMethod( self.__historyNodeParentChanged ), scoped = True )
+		)
 
 	def __rootChanged( self, graphGadget, previousRoot ) :
 
 		self.__history = self.__history[:self.__historyIndex + 1]
-		self.__history[self.__historyIndex] = ( self.__history[self.__historyIndex][0], _currentFrame( self.__graphGadget.parent() ) )
+		self.__history[self.__historyIndex]  = self.__createHistoryEntry( self.__history[self.__historyIndex][0] )
 
-		self.__history.append( ( graphGadget.getRoot(), None ) )
+		self.__history.append( ( graphGadget.getRoot(), None, None ) )
 		self.__historyIndex += 1
 		self.__frame()
 		self.__updateHistoryButtonsEnabled()
@@ -1039,7 +1033,7 @@ class _HistoryWidget( GafferUI.Widget ) :
 		rootNode = self.__history[self.__historyIndex][0]
 		frame = None
 		for i in range( self.__historyIndex, -1, -1 ) :
-			historyNode, historyFrame = self.__history[i]
+			historyNode, historyFrame, parentChangedConnection = self.__history[i]
 			if historyNode.isSame( rootNode ) and historyFrame is not None :
 				frame = historyFrame
 				break
@@ -1053,32 +1047,70 @@ class _HistoryWidget( GafferUI.Widget ) :
 		else :
 			graphEditor.frame( graphEditor.graphGadget().getRoot().children( Gaffer.Node ) )
 
+	def __setHistoryIndex( self, index ) :
+
+		if index < 0 or index >= len( self.__history ) or index == self.__historyIndex :
+			return
+
+		self.__history[self.__historyIndex] = self.__createHistoryEntry( self.__history[self.__historyIndex][0] )
+
+		self.__historyIndex = index
+
+		graphEditor = self.ancestor( GafferUI.GraphEditor )
+		assert( graphEditor is not None )
+		rootNode = self.__history[self.__historyIndex][0]
+		if rootNode.isSame( self.__scriptNode ) or self.__scriptNode.isAncestorOf( rootNode ) :
+			with Gaffer.Signals.BlockedConnection( self.__rootChangedConnection ) :
+				# We're blocking `__rootChangedConnection` so we don't append to history.
+				# That connection also handles framing, so we need to take care of that here.
+				self.__frame()
+				self.__graphGadget.setRoot( rootNode )
+
+		self.__updateHistoryButtonsEnabled()
+
+	def __navigableHistoryIndices( self, historyRange ) :
+
+		previousI = None
+		for i in historyRange :
+			if (
+				( not self.__history[i][0].isSame( self.__scriptNode ) and self.__history[i][0].ancestor(Gaffer.ScriptNode ) is None ) or
+				( previousI is not None and self.__history[i][0].isSame( self.__history[previousI][0] ) )
+			) :
+				continue
+			previousI = i
+			yield i
+
 	def __showHistoryPopup(self, historyRange, popupParent ) :
 
 		menuDefinition = IECore.MenuDefinition()
 		prefix = "/"
-		for counter, i in enumerate( historyRange ) :
-			if self.__history[i][0].parent() is None :
+		for counter, i in enumerate( self.__navigableHistoryIndices( historyRange ) ) :
+			if counter == 0 :
+				# Skip element 0, which is `self.__historyIndex`
 				continue
 			menuDefinition.append(
 				prefix + str( counter ),
 				{
 					"label" : ( "/" + self.__history[i][0].relativeName( self.__scriptNode ).replace( ".", "/" ) ) if not self.__history[i][0].isSame( self.__scriptNode ) else "/",
-					"command" : functools.partial( Gaffer.WeakMethod( self.moveHistoryIndex ), i - self.__historyIndex ),
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setHistoryIndex ), i ),
 				}
 			)
 
-			if counter == 10 :
+			if counter == 11 :
 				prefix = "/More/"
 				menuDefinition.append( "/Divider", { "divider" : True } )
 
-		if menuDefinition.size() :
-			self.__historyPopup = GafferUI.Menu( menuDefinition )
-			self.__historyPopup.popup( popupParent, position = imath.V2i( popupParent.bound().min().x, popupParent.bound().max().y ) )
-		else :
-			GafferUI.PopupWindow.showWarning( "All nodes in history have been removed.", parent = popupParent )
+		self.__historyPopup = GafferUI.Menu( menuDefinition )
+		self.__historyPopup.popup( popupParent, position = imath.V2i( popupParent.bound().min().x, popupParent.bound().max().y ) )
 
 	def __updateHistoryButtonsEnabled( self ) :
 
-		self.__backButton.setEnabled( self.__historyIndex > 0 )
-		self.__forwardButton.setEnabled( self.__historyIndex < ( len( self.__history ) - 1 ) )
+		# The first index will be `self.__historyIndex`, so we check that a second element exists.
+		self.__backButton.setEnabled(
+			self.__historyIndex > 0 and
+			next( islice( self.__navigableHistoryIndices( range( self.__historyIndex, -1, -1 ) ), 1, None ), None ) is not None
+		)
+		self.__forwardButton.setEnabled(
+			self.__historyIndex < len( self.__history ) - 1 and
+			next( islice( self.__navigableHistoryIndices( range( self.__historyIndex, len( self.__history ), 1 ) ), 1, None ), None ) is not None
+		)

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -1046,7 +1046,6 @@ class _HistoryWidget( GafferUI.Widget ) :
 
 	def __showHistoryPopup(self, historyRange, popupParent ) :
 
-		graphEditor = self.ancestor( GafferUI.GraphEditor )
 		menuDefinition = IECore.MenuDefinition()
 		prefix = "/"
 		for counter, i in enumerate( historyRange ) :


### PR DESCRIPTION
This fixes a bug where an error was raised because a node in the history had been deleted. We were trying to build the context menu with a label using the deleted node's name relative to the script root, which is invalid since the node is not part of the script.

This PR filters out nodes that don't have a parent from the history popup menu and skips such nodes when clicking the forward and back buttons. There's also a popup warning if none of the nodes in the applicable history (forward or back) are part of a script.

The reproduction to get the warning is slightly different from the original repro in #7071 since that original bug is solved just by filtering.

1. Create a box.
2. Select the Box and press the down arrow key to navigate inside.
3. Press the back button to return to root. The Box is now in the forward history list.
4. Delete the Box.
5. Click or right-click the forward button.
6. Warning pops up.

It's debatable whether or not it would be more fitting to disable the button entirely as we do when you've reached either end of the history. This would require connecting to a lot of `childAdded()` / `childRemoved()` signals to determine if the button should be active. There's precedent in the inspector columns and elsewhere for the simple warning popup, so I've implemented that for now.

Fixes #7071.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
