### PR TITLE
Stylesheet : Style MenuBar extension button

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.7.x.x (relative to 1.7.0.0a10)
 =======
 
+Fixes
+-----
 
+- MenuBar : Made the main window menu extension button more visible. This button is shown when the window is not wide enough to show all menu items.
 
 1.7.0.0a10 (relative to 1.7.0.0a9)
 ==========

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
 
 - GraphEditor : - Added <kbd>C</kbd> shortcut for setting node colors.
 - SceneView : Added keyboard shortcut <kbd>;</kbd> to toggle between the lookthrough (camera / light) view and the free (perspective / top / front / side) cameras. <kbd>Ctrl</kbd> + click on the toolbar camera icon will perform the same toggle.
+- MenuBar : Made the main window menu extension button more visible. This button is shown when the window is not wide enough to show all menu items.
 
 Fixes
 -----

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -283,6 +283,11 @@ _styleSheet = string.Template(
 		padding: 5px 8px 5px 8px;
 	}
 
+	QMenuBar QToolButton#qt_menubar_ext_button {
+		qproperty-icon: url(:/pathListingList.png);
+		qproperty-iconSize: 10px 10px;
+	}
+
 	#gafferMenuBarWidgetContainer {
 		background-color: $backgroundDarkest;
 	}


### PR DESCRIPTION
This makes the menu extension button more visible. That button is shown when the window is too narrow for the full menu bar. Qt's default is a pair or pretty dark arrows / chevrons, which are not very visible against Gaffer's dark menu background.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
