### PR TITLE
IECoreArnold : Support for AiSceneWrite parameters binary and open_procs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - RandomPrimitiveVariable : Added new node for creating random per-face or per-vertex primitive variables with a variety of distributions.
+- ArnoldOptions : Added new "Scene Description" options to control how Arnold archive files are written. "Binary" can be disabled to produce human readable files, and "Open Procs" expands procedurals, making it possible to write Gaffer scenes that use encapsulation.
 
 Improvements
 ------------

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1451,6 +1451,52 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			# node to have been created for ours.
 			self.assertIsNone( arnold.AiNodeLookUpByName( universe, "/coordinateSystem" ) )
 
+	def testSceneDescriptionOptions( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["cube"] = GafferScene.Cube()
+
+		s["pathFilter"] = GafferScene.PathFilter()
+		s["pathFilter"]["paths"].setValue( IECore.StringVectorData( [ '/cube' ] ) )
+
+		s["encapsulate"] = GafferScene.Encapsulate()
+		s["encapsulate"]["in"].setInput( s["cube"]["out"] )
+		s["encapsulate"]["filter"].setInput( s["pathFilter"]["out"] )
+
+		s["options"] = GafferArnold.ArnoldOptions()
+		s["options"]["in"].setInput( s["encapsulate"]["out"] )
+
+		s["render"] = GafferScene.Render()
+		s["render"]["in"].setInput( s["options"]["out"] )
+		s["render"]["renderer"].setValue( "Arnold" )
+		s["render"]["mode"].setValue( s["render"].Mode.SceneDescriptionMode )
+		s["render"]["fileName"].setValue( self.temporaryDirectory() / "test.ass" )
+
+		s["render"]["task"].execute()
+
+		# Since the cube is encapsulated, we won't see it in the output
+		with open( self.temporaryDirectory() / "test.ass", "r", encoding = "utf-8" ) as f :
+			self.assertFalse( "vidxs" in f.read() )
+
+		s["options"]["options"]["ai:scene_write:open_procs"]["enabled"].setValue( True )
+		s["options"]["options"]["ai:scene_write:open_procs"]["value"].setValue( True )
+
+		s["render"]["task"].execute()
+
+		# With open_procs set, we now see the cube data
+		with open( self.temporaryDirectory() / "test.ass", "r", encoding = "utf-8" ) as f :
+			self.assertTrue( " vidxs 24 1 b85UINT\n" + r"B$$-0*%<hl0%s\>:$$?K4%XA/5%s@u/" in f.read() )
+
+		s["options"]["options"]["ai:scene_write:binary"]["enabled"].setValue( True )
+		s["options"]["options"]["ai:scene_write:binary"]["value"].setValue( False )
+
+		s["render"]["task"].execute()
+
+		# Turning off binary gets us plain text vertex data
+		with open( self.temporaryDirectory() / "test.ass", "r", encoding = "utf-8" ) as f :
+			self.assertTrue( "vidxs 24 1 UINT\n  3 2 1 0 1 2 5 4 4 5 7 6 6 7 3 0 2 3 7 5 0 1 4 6" in f.read() )
+
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
 	def testInstancerPerf( self ) :
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -3645,6 +3645,8 @@ const IECore::InternedString g_profileFileNameOptionName( "ai:profileFileName" )
 const IECore::InternedString g_progressiveMinAASamplesOptionName( "ai:progressive_min_AA_samples" );
 const IECore::InternedString g_reportFileNameOptionName( "ai:reportFileName" );
 const IECore::InternedString g_sampleMotionOptionName( "sampleMotion" );
+const IECore::InternedString g_sceneWriteBinaryOptionName( "ai:scene_write:binary" );
+const IECore::InternedString g_sceneWriteOpenProcsOptionName( "ai:scene_write:open_procs" );
 const IECore::InternedString g_statisticsFileNameOptionName( "ai:statisticsFileName" );
 const IECore::InternedString g_subdivDicingCameraOptionName( "ai:subdiv_dicing_camera" );
 const IECore::InternedString g_textureAutoGenerateOptionName( "ai:texture_auto_generate_tx" );
@@ -4078,6 +4080,30 @@ class ArnoldGlobals
 				// updating the drivers every time we render, so we don't need to flag anything here.
 				return;
 			}
+			else if( name == g_sceneWriteBinaryOptionName )
+			{
+				if( value == nullptr )
+				{
+					m_binary = std::nullopt;
+				}
+				else if( const IECore::BoolData *d = reportedCast<const IECore::BoolData>( value, "option", name ) )
+				{
+					m_binary = d->readable();
+				}
+				return;
+			}
+			else if( name == g_sceneWriteOpenProcsOptionName )
+			{
+				if( value == nullptr )
+				{
+					m_openProcs = std::nullopt;
+				}
+				else if( const IECore::BoolData *d = reportedCast<const IECore::BoolData>( value, "option", name ) )
+				{
+					m_openProcs = d->readable();
+				}
+				return;
+			}
 			else if( boost::starts_with( name.c_str(), "ai:aov_shader:" ) )
 			{
 				m_aovShaders.erase( name );
@@ -4281,6 +4307,8 @@ class ArnoldGlobals
 					unique_ptr<AtParamValueMap, decltype(&AiParamValueMapDestroy)> params(
 						AiParamValueMap(), AiParamValueMapDestroy
 					);
+					AiParamValueMapSetBool( params.get(), AtString( "binary" ), m_binary.value_or( true ) );
+					AiParamValueMapSetBool( params.get(), AtString( "open_procs" ), m_openProcs.value_or( false ) );
 					AiSceneWrite( m_universeBlock->universe(), m_fileName.c_str(), params.get() );
 					break;
 				}
@@ -4836,6 +4864,8 @@ class ArnoldGlobals
 		std::optional<int> m_aaSeed;
 		bool m_enableProgressiveRender;
 		std::optional<int> m_progressiveMinAASamples;
+		std::optional<bool> m_binary;
+		std::optional<bool> m_openProcs;
 		ShaderCachePtr m_shaderCache;
 		FilterCache m_filterCache;
 

--- a/startup/GafferScene/arnoldOptions.py
+++ b/startup/GafferScene/arnoldOptions.py
@@ -1033,6 +1033,34 @@ Gaffer.Metadata.registerValues( {
 
 	},
 
+	"option:ai:scene_write:binary" : {
+
+		"defaultValue" : True,
+		"description" :
+		"""
+		Enable binary encoding in `.ass` files. Arrays will be written in a format that is more
+		compact but can't be read with a text editor.
+		""",
+
+		"layout:section" : "Scene Description",
+		"label" : "Binary",
+
+	},
+
+	"option:ai:scene_write:open_procs" : {
+
+		"defaultValue" : False,
+		"description" :
+		"""
+		Procedurals will be expanded before writing. Because procedurals are used internally by Gaffer,
+		this setting is required when writing Gaffer scenes that make any use of encapsulation. It will
+		also expand any other procedurals, such as USD procedurals.
+		""",
+
+		"layout:section" : "Scene Description",
+		"label" : "Open Procs",
+
+	},
 } )
 
 Gaffer.Metadata.registerValue( "option:ai:*", "category", "Arnold" )


### PR DESCRIPTION
I think this is a pretty straightforward implementation of exposing the parameters to AiSceneWrite.

I did also look a little bit at whether there's a way to expand just our procedurals - you had suggested that it could be a better approach if we could automatically expand encapsulated things when writing scene descriptions. There is a function AiProceduralExpand which seems like it ought to do the trick - it does cause procGetNode to be called ... but it doesn't actually cause the procedural contents to end up in the scene description. Maybe I'm just missing something? But maybe just exposing the option is good enough for now ... I don't know if we have a lot of use cases for this anyway, it just seems like there ought to be some way to use the scene description for debugging when you have encapsulation involved.