### PR TITLE
Support `IECoreScene::PointInstancer::instanceAttributes()`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
             testRunner: runuser -u testUser --
             sconsCacheMegabytes: 400
             jobs: 4
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a14/cortex-10.7.0.0a14-linux-platform24.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.7.0.0/cortex-10.7.0.0-linux-platform24.tar.gz
             extraBuildArguments: CYCLES_ROOT=""
 
           - name: windows

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.7.0.0a14/cortex-10.7.0.0a14-{platform}-{vfxPlatform}.{extension}"
+defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.7.0.0/cortex-10.7.0.0-{platform}-{vfxPlatform}.{extension}"
 
 # Parse command line arguments.
 
@@ -85,8 +85,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 archiveURL = args.archiveURL.format(
-	## \todo Rename "macos-arm64" Cortex release to "macos" to match GafferDependencies.
-	platform = { "darwin" : "macos-arm64", "win32" : "windows" }.get( sys.platform, "linux" ),
+	platform = { "darwin" : "macos", "win32" : "windows" }.get( sys.platform, "linux" ),
 	vfxPlatform = args.vfxPlatform,
 	extension = "tar.gz" if sys.platform != "win32" else "zip"
 )

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,11 @@ Fixes
   - Fixed handling of connections between floats and color/vector components [^2].
   - Fixed bug preventing attributes from being deleted from lights during an interactive render [^2].
 
+Build
+-----
+
+- Cortex : Updated to version 10.7.0.0.
+
 [^1]: Improvement to a feature introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
 [^2]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1795,6 +1795,13 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 		light.loadShader( "distant_light" )
 		return light, light["parameters"]["color"]
 
+	def _createColorAttributeReader( self, attributeName ) :
+
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "user_data_rgb" )
+		shader["parameters"]["attribute"].setValue( attributeName )
+		return shader, shader["out"]
+
 	def _cameraVisibilityAttribute( self ) :
 
 		return "ai:visibility:camera"

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -38,7 +38,6 @@
 import pathlib
 import inspect
 import unittest
-import subprocess
 import threading
 
 import arnold

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -81,6 +81,15 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 		shader.loadShader( "Surface/Constant" )
 		return shader, shader["parameters"]["Cs"], shader["out"]["out"]
 
+	def _createColorAttributeReader( self, attributeName ) :
+
+		shader = GafferOSL.OSLShader()
+		shader.loadShader( "dlPrimitiveAttribute" )
+		shader["parameters"]["attribute_name"].setValue( attributeName )
+		shader["parameters"]["attribute_type"].setValue( 1 ) # color
+
+		return shader, shader["out"]["o_color"]
+
 	def _createOptions( self ) :
 
 		# Improve anti-aliasing for motion-blur tests.

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -46,6 +46,7 @@ import IECoreRenderMan
 import Gaffer
 import GafferTest
 import GafferScene
+import GafferOSL
 import GafferRenderMan
 import GafferSceneTest
 
@@ -134,6 +135,15 @@ class RenderManRenderTest( GafferSceneTest.RenderTest ) :
 		light = GafferRenderMan.RenderManLight()
 		light.loadShader( "PxrDistantLight" )
 		return light, light["parameters"]["lightColor"]
+
+	def _createColorAttributeReader( self, attributeName ) :
+
+		shader = GafferOSL.OSLShader()
+		shader.loadShader( "PxrAttribute" )
+		shader["parameters"]["varname"].setValue( attributeName )
+		shader["parameters"]["type"].setValue( "color" )
+
+		return shader, shader["out"]["resultRGB"]
 
 	def _cameraVisibilityAttribute( self ) :
 

--- a/python/GafferSceneTest/PointInstancerAlgoTest.py
+++ b/python/GafferSceneTest/PointInstancerAlgoTest.py
@@ -211,6 +211,18 @@ class PointInstancerAlgoTest( GafferSceneTest.SceneTestCase ) :
 		pointInstancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 1, 0, 0 ) ] ) )
 		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 1 ] ) )
 		pointInstancer.setPrototypes( IECore.StringVectorData( [ "prototypes/prototype1", "prototypes/prototype2" ] ) )
+		pointInstancer["intPrimitiveVariable"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.IntVectorData( [ 1, 2 ] )
+		)
+		pointInstancer["stringPrimitiveVariable"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.StringVectorData( [ "apple", "pear" ] )
+		)
+		pointInstancer["v3fPrimitiveVariable"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V3fVectorData( [ imath.V3f( 0 ), imath.V3f( 1 ) ], IECore.GeometricData.Interpretation.Normal )
+		)
 
 		pointInstancerNode = GafferScene.ObjectToScene()
 		pointInstancerNode["object"].setValue( pointInstancer )
@@ -254,6 +266,13 @@ class PointInstancerAlgoTest( GafferSceneTest.SceneTestCase ) :
 					imath.V3f( 1, 0, 0 ),
 					imath.V3f( 1, 0, 0 ),
 				]
+			)
+
+			self.assertEqual( flattened["intPrimitiveVariable"].data, IECore.IntVectorData( [ 1, 1, 1, 2, 2 ] ) )
+			self.assertEqual( flattened["stringPrimitiveVariable"].data, IECore.StringVectorData( [ "apple", "apple", "apple", "pear", "pear" ] ) )
+			self.assertEqual(
+				flattened["v3fPrimitiveVariable"].data,
+				IECore.V3fVectorData( [ imath.V3f( 0 ), imath.V3f( 0 ), imath.V3f( 0 ), imath.V3f( 1 ), imath.V3f( 1 ) ], IECore.GeometricData.Interpretation.Normal )
 			)
 
 	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -1591,6 +1591,100 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 				sampler["pixel"].setValue( imath.V2f( x, y ) )
 				self.assertEqualWithAbsError( sampler["color"]["a"].getValue(), 0, 0.005 )
 
+	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
+	def testPointInstancerInstanceAttributes( self ) :
+
+		if not self.pointInstancerSupported :
+			raise unittest.SkipTest( "PointInstancer not supported" )
+
+		script = Gaffer.ScriptNode()
+
+		pointInstancer = IECoreScene.PointInstancer( 2 )
+		pointInstancer.setPosition(
+			IECore.V3fVectorData( [
+				imath.V3f( -1, 0, 0 ), imath.V3f( 1, 0, 0 ),
+			] )
+		)
+		pointInstancer.setPrototypeIndex( IECore.IntVectorData( [ 0, 0 ] ) )
+		pointInstancer.setPrototypes( IECore.StringVectorData( [ "./sphere" ] ) )
+		pointInstancer["myColor"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.Color3fVectorData( [ imath.Color3f( 1, 0, 0 ), imath.Color3f( 0, 1, 0 ) ] )
+		)
+
+		script["pointInstancer"] = GafferScene.ObjectToScene()
+		script["pointInstancer"]["name"].setValue( "instancer" )
+		script["pointInstancer"]["object"].setValue( pointInstancer )
+
+		script["sphere"] = GafferScene.Sphere()
+		script["sphere"]["radius"].setValue( 0.5 )
+
+		script["attributeReader"], attributeReaderOut = self._createColorAttributeReader( "myColor" )
+		script["constantShader"], colorPlug, constantShaderOut = self._createConstantShader()
+		colorPlug.setInput( attributeReaderOut )
+
+		script["shaderAssignment"] = GafferScene.ShaderAssignment()
+		script["shaderAssignment"]["in"].setInput( script["sphere"]["out"] )
+		script["shaderAssignment"]["shader"].setInput( constantShaderOut )
+
+		script["prototypeParent"] = GafferScene.Parent()
+		script["prototypeParent"]["in"].setInput( script["pointInstancer"]["out"] )
+		script["prototypeParent"]["children"][0].setInput( script["shaderAssignment"]["out"] )
+		script["prototypeParent"]["parent"].setValue( "/instancer" )
+
+		script["camera"] = GafferScene.Camera()
+		script["camera"]["transform"]["translate"]["z"].setValue( 5 )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["prototypeParent"]["out"] )
+		script["parent"]["children"][0].setInput( script["camera"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				imagePath.as_posix(),
+				"exr",
+				"rgba"
+			)
+		)
+
+		script["outputs"]["in"].setInput( script["parent"]["out"] )
+
+		script["options"] = GafferScene.StandardOptions()
+		script["options"]["in"].setInput( script["outputs"]["out"] )
+		script["options"]["options"]["render:camera"]["enabled"].setValue( True )
+		script["options"]["options"]["render:camera"]["value"].setValue( "/camera" )
+
+		script["rendererOptions"] = self._createOptions()
+		script["rendererOptions"]["in"].setInput( script["options"]["out"] )
+
+		script["render"] = GafferScene.Render()
+		script["render"]["in"].setInput( script["rendererOptions"]["out"] )
+		script["render"]["renderer"].setValue( self.renderer )
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( imagePath )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( reader["out"] )
+
+		script["render"]["task"].execute()
+
+		for centre, expectedColor in [
+			[ imath.V2f( 180, 240 ), imath.Color4f( 1, 0, 0, 1 ) ],
+			[ imath.V2f( 456, 240 ), imath.Color4f( 0, 1, 0, 1 ) ],
+		] :
+
+			with self.subTest( centre = centre ) :
+
+				# Assert there's an instance where we expect it.
+				sampler["pixel"].setValue( centre )
+				self.assertEqual( sampler["color"].getValue(), expectedColor )
+
 	## Should be implemented by derived classes to return
 	# an appropriate Shader node with a constant surface shader loaded, along
 	# with the plug for the colour parameter and the output plug to be connected
@@ -1611,6 +1705,13 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	# node with a distant light loaded, along with the plug for the colour
 	# parameter.
 	def _createDistantLight( self ) :
+
+		raise NotImplementedError
+
+	# Should be implemented by derived classes to return a Shader node
+	# which will read the requested attribute, along with the output plug
+	# from that node.
+	def _createColorAttributeReader( self, attributeName ) :
 
 		raise NotImplementedError
 

--- a/src/GafferScene/PointInstancerAlgo.cpp
+++ b/src/GafferScene/PointInstancerAlgo.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferScene/SceneAlgo.h"
 
+#include "IECore/DataAlgo.h"
 #include "IECore/NullObject.h"
 
 #include "Imath/ImathMatrixAlgo.h"
@@ -266,6 +267,47 @@ FlattenedPrototype flattenedPrototype( const Private::RendererAlgo::RenderOption
 	return result;
 }
 
+struct FlattenedPrimitiveVariable
+{
+	using FlattenFunction = std::function<void ( size_t sourceIndex, size_t flattenedIndex, size_t numFlattenedPoints )>;
+	DataPtr data;
+	FlattenFunction flattenFunction;
+};
+
+FlattenedPrimitiveVariable createFlattenedPrimitiveVariable( const PrimitiveVariable &primitiveVariable, size_t flattenedSize )
+{
+	FlattenedPrimitiveVariable result;
+	IECore::dispatch(
+
+		primitiveVariable.data.get(),
+
+		[&]( auto typedData ) -> void {
+
+			using DataType = remove_const_t<remove_pointer_t<decltype( typedData )>>;
+
+			if constexpr( TypeTraits::IsVectorTypedData<DataType>::value )
+			{
+				typename DataType::Ptr flattenedData = new DataType;
+				flattenedData->writable().resize( flattenedSize );
+				result.data = flattenedData;
+				if constexpr( TypeTraits::IsGeometricTypedData<DataType>::value )
+				{
+					flattenedData->setInterpretation( typedData->getInterpretation() );
+				}
+
+				using ElementType = typename DataType::ValueType::value_type;
+				PrimitiveVariable::IndexedView<ElementType> indexedView( primitiveVariable );
+
+				result.flattenFunction = [indexedView, &out=flattenedData->writable()] ( size_t sourceIndex, size_t flattenedIndex, size_t numFlattenedPoints ) {
+					std::fill( out.begin() + flattenedIndex, out.begin() + flattenedIndex + numFlattenedPoints, indexedView[sourceIndex] );
+				};
+			}
+		}
+
+	);
+	return result;
+}
+
 } // namespace
 
 IECoreScene::PointInstancerPtr Private::PointInstancerAlgo::flatten( const IECoreScene::PointInstancer *instancer, const RendererAlgo::RenderOptions &renderOptions, const ScenePlug *scene )
@@ -380,6 +422,17 @@ IECoreScene::PointInstancerPtr Private::PointInstancerAlgo::flatten( const IECor
 	auto &flattenedOrientation = flattenedOrientationData->writable();
 	flattenedOrientation.resize( numFlattenedPoints );
 
+	vector<FlattenedPrimitiveVariable::FlattenFunction> primitiveVariableFunctions;
+	for( const auto &[name, primitiveVariable] : instancer->instanceAttributes() )
+	{
+		FlattenedPrimitiveVariable f = createFlattenedPrimitiveVariable( primitiveVariable, numFlattenedPoints );
+		if( f.data )
+		{
+			primitiveVariableFunctions.push_back( f.flattenFunction );
+			result->variables[name] = PrimitiveVariable( primitiveVariable.interpolation, f.data );
+		}
+	}
+
 	// Fill the vertex data, parallelising across points.
 
 	PointInstancer::TransformQuery transformQuery( *instancer );
@@ -397,6 +450,7 @@ IECoreScene::PointInstancerPtr Private::PointInstancerAlgo::flatten( const IECor
 				{
 					continue;
 				}
+
 				size_t flattenedPointIndex = pointOffsets[pointIndex];
 				for( const auto &location : flattenedPrototypes[prototypeIndex[pointIndex]] )
 				{
@@ -410,6 +464,16 @@ IECoreScene::PointInstancerPtr Private::PointInstancerAlgo::flatten( const IECor
 					flattenedOrientation[flattenedPointIndex] = extractQuat( m );
 
 					flattenedPointIndex++;
+				}
+
+				for( const auto &f : primitiveVariableFunctions )
+				{
+					/// \todo Investigate the `std::function` call overhead,
+					/// which we are paying for each source point. We might be
+					/// faster dispatching per primitive variable instead, but
+					/// then we would need a different approach to the
+					/// threading.
+					f( pointIndex, pointOffsets[pointIndex], flattenedPrototypes[prototypeIndex[pointIndex]].size() );
 				}
 			}
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2804,6 +2804,15 @@ class PointInstancerCache : public IECore::RefCounted
 			AiNodeSetArray( instancerNode.get(), g_instanceVisibilityArnoldString, visibilityArray );
 			AiNodeSetArray( instancerNode.get(), g_instanceShaderArnoldString, shaderArray );
 
+			// Add instance attributes
+
+			for( const auto &[name, primitiveVariable] : samples[0]->instanceAttributes() )
+			{
+				string prefixedName = "instance_" + name;
+				IECore::ConstDataPtr data = primitiveVariable.expandedData();
+				ParameterAlgo::setParameter( instancerNode.get(), AtString( prefixedName.c_str() ), data.get() );
+			}
+
 			AiNodeSetByte( instancerNode.get(), g_visibilityArnoldString, 0 );
 
 			return std::make_shared<InstancerNodes>( InstancerNodes{

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1401,6 +1401,15 @@ class PointInstancerCache : public IECore::RefCounted
 			ParameterList parameters;
 			parameters.add( "modelindices", prototypeIndex.get() );
 
+			vector<ConstDataPtr> instanceAttributeData;
+			for( const auto &[name, value] : samples[0]->instanceAttributes() )
+			{
+				ConstDataPtr d = value.expandedData();
+				parameters.add( name.c_str(), d.get() );
+				// Keep alive until `NSISetAttribute()` call.
+				instanceAttributeData.push_back( d );
+			}
+
 			NSISetAttribute( m_context, handle, parameters.size(), parameters.data() );
 
 			// Convert prototypes and connect to `sourcemodels` attribute.

--- a/src/IECoreRenderMan/PointInstancerCache.cpp
+++ b/src/IECoreRenderMan/PointInstancerCache.cpp
@@ -39,10 +39,132 @@
 #include "Loader.h"
 #include "Transform.h"
 
+#include "IECore/DataAlgo.h"
+#include "IECore/TypeTraits.h"
+#include "IECore/VectorTypedData.h"
+
 using namespace std;
 using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreRenderMan;
+
+namespace
+{
+
+struct ParameterSetter
+{
+
+	GeometricData::Interpretation interpretation = GeometricData::Interpretation::None;
+
+	void operator()( RtParamList &paramList, RtUString name, int value ) const
+	{
+		paramList.SetInteger( name, value );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, float value ) const
+	{
+		paramList.SetFloat( name, value );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, const std::string &value ) const
+	{
+		paramList.SetString( name, RtUString( value.c_str() ) );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, InternedString value ) const
+	{
+		paramList.SetString( name, RtUString( value.c_str() ) );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, const Imath::Color3f &value ) const
+	{
+		paramList.SetColor( name, RtColorRGB( value.getValue() ) );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, const Imath::V2i &value ) const
+	{
+		paramList.SetIntegerArray( name, value.getValue(), 2 );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, const Imath::V2f &value ) const
+	{
+		paramList.SetFloatArray( name, value.getValue(), 2 );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, const Imath::V3f &value ) const
+	{
+		switch( interpretation )
+		{
+			case GeometricData::Vector :
+				paramList.SetVector( name, reinterpret_cast<const RtVector3 &>( value ) );
+				break;
+			case GeometricData::Normal :
+				paramList.SetNormal( name, reinterpret_cast<const RtVector3 &>( value ) );
+				break;
+			case GeometricData::Point :
+				paramList.SetPoint( name, reinterpret_cast<const RtVector3 &>( value ) );
+				break;
+			default :
+				paramList.SetFloatArray( name, value.getValue(), 3 );
+		}
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, const Imath::M44f &value ) const
+	{
+		paramList.SetMatrix( name, reinterpret_cast<const pxrcore::Matrix4x4 &>( value ) );
+	}
+
+	void operator()( RtParamList &paramList, RtUString name, const Imath::M44d &value ) const
+	{
+		const Imath::M44f m( value );
+		paramList.SetMatrix( name, pxrcore::Matrix4x4( m.x ) );
+	}
+
+};
+
+using InstanceAttributeFunction = std::function<void ( size_t pointIndex, RtParamList &attributes )>;
+
+vector<InstanceAttributeFunction> createInstanceAttributeFunctions( const PointInstancer *instancer )
+{
+	vector<InstanceAttributeFunction> result;
+
+	for( const auto &[name, primitiveVariable] : instancer->instanceAttributes() )
+	{
+		IECore::dispatch(
+
+			primitiveVariable.data.get(),
+
+			[&]( auto typedData ) -> void {
+
+				using DataType = remove_const_t<remove_pointer_t<decltype( typedData )>>;
+				if constexpr( TypeTraits::IsVectorTypedData<DataType>::value )
+				{
+					using ElementType = typename DataType::ValueType::value_type;
+					if constexpr( std::is_invocable_v<ParameterSetter, RtParamList &, RtUString, ElementType> )
+					{
+						PrimitiveVariable::IndexedView<ElementType> indexedView( primitiveVariable );
+						ParameterSetter setter;
+						if constexpr( TypeTraits::IsGeometricTypedData<DataType>::value )
+						{
+							setter.interpretation = typedData->getInterpretation();
+						}
+						RtUString userName( ( "user:" + name ).c_str() );
+						InstanceAttributeFunction f = [userName, indexedView, setter] ( size_t pointIndex, RtParamList &attributes ) {
+							setter( attributes, userName, indexedView[pointIndex] );
+						};
+						result.push_back( f );
+					}
+				}
+
+			}
+
+		);
+	}
+
+	return result;
+}
+
+} // namespace
 
 PointInstancerCache::PointInstancer::~PointInstancer()
 {
@@ -83,6 +205,7 @@ PointInstancerCache::ConstPointInstancerPtr PointInstancerCache::get(
 
 		result->m_prototypeGeometries.reserve( prototypes.size() );
 		result->m_prototypeAttributes.reserve( prototypes.size() );
+		vector<RtParamList> prototypeInstanceAttributes; prototypeInstanceAttributes.reserve( prototypes.size() );
 		for( size_t prototypeIndex = 0; prototypeIndex < prototypes.size(); ++prototypeIndex )
 		{
 			const auto &prototype = prototypes[prototypeIndex];
@@ -93,6 +216,7 @@ PointInstancerCache::ConstPointInstancerPtr PointInstancerCache::get(
 					/* messageContext = */ fmt::format( "{}:prototype{}", messageContext, prototypeIndex )
 				)
 			);
+			prototypeInstanceAttributes.push_back( result->m_prototypeAttributes.back()->instanceAttributes() );
 		}
 
 		result->group = new GeometryPrototype(
@@ -107,6 +231,8 @@ PointInstancerCache::ConstPointInstancerPtr PointInstancerCache::get(
 		}
 
 		auto prototypeIndices = samples[0]->getPrototypeIndex();
+
+		auto attributeFunctions = createInstanceAttributeFunctions( samples[0].get() );
 
 		IECoreScenePreview::Renderer::TransformSamples transformSamples;
 		transformSamples.resize( samples.size() );
@@ -124,6 +250,11 @@ PointInstancerCache::ConstPointInstancerPtr PointInstancerCache::get(
 				continue;
 			}
 
+			for( const auto &f : attributeFunctions )
+			{
+				f( instanceIndex, prototypeInstanceAttributes[prototypeIndex] );
+			}
+
 			/// \todo Investigate `Riley::CreateGeometryInstances()` (plural) to see if
 			/// it offers any performance advantage.
 			result->m_instances.push_back(
@@ -131,7 +262,7 @@ PointInstancerCache::ConstPointInstancerPtr PointInstancerCache::get(
 					riley::UserId(), result->group->id(), result->m_prototypeGeometries[prototypeIndex]->id(),
 					result->m_prototypeAttributes[prototypeIndex]->material()->id(), riley::CoordinateSystemList(),
 					AnimatedTransform( transformSamples, sampleTimes ),
-					result->m_prototypeAttributes[prototypeIndex]->instanceAttributes()
+					prototypeInstanceAttributes[prototypeIndex]
 				)
 			);
 		}


### PR DESCRIPTION
This adds support for instance attributes in PointInstancerAlgo and the renderer backends for Arnold, RenderMan and 3Delight. Requires https://github.com/ImageEngine/cortex/pull/1545, so won't build until we update to the official Cortex 10.7 release.