### PR TITLE
CI : Migrate to new MSVC setup action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,9 +117,11 @@ jobs:
       shell: pwsh
       if: runner.os == 'Windows'
 
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+    - uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
       with:
         sdk: 10.0.20348.0
+        arch: x64
+      if: runner.os == 'Windows'
 
     - name: Install toolchain (Windows)
       run: |


### PR DESCRIPTION
[ilammy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd) appears to be no longer supported and hasn't been updated to run on the new minimum Node version that GitHub is now expecting actions to run on. [TheMrMilchmann/setup-msvc-dev](https://github.com/TheMrMilchmann/setup-msvc-dev) is a new (currently) maintained fork which projects like [intel/LLVM](https://github.com/intel/llvm/commit/7b780dbae63247e23be948d9332c206adaa6b9de) and [libsdl-org/SDL](https://github.com/libsdl-org/SDL/commit/f6a1eb9ba96e054aa22c2fa51d291bcfb24dcac4) have migrated to instead.