### PR TITLE
AnnotationsGadgetTest : Fix intermittent UIThreadCallHandler timeout

### DIFF
--- a/python/GafferUITest/AnnotationsGadgetTest.py
+++ b/python/GafferUITest/AnnotationsGadgetTest.py
@@ -453,10 +453,11 @@ class AnnotationsGadgetTest( GafferUITest.TestCase ) :
 			# Remove annotations while the background task runs.
 			for i in range( 0, numAnnotations ) :
 				Gaffer.MetadataAlgo.removeAnnotation( script["node"], f"test{i}" )
-			self.assertEqual( gadget.annotationText( script["node"], "test0" ), "" )
 
 			# And wait for the task to complete.
 			callHandler.assertCalled()
+
+		self.assertEqual( gadget.annotationText( script["node"], "test0" ), "" )
 
 	def testAnnotationAt( self ) :
 


### PR DESCRIPTION
The `testRemoveAnnotationWhileBackgroundThreadRuns()` method is deliberately removing annotations while the AnnotationsGadget runs an update in a BackgroundTask. The Metadata edits being made on the main thread do not cause cancellation of BackgroundTasks, so the test gives us coverage against concurrent access to the metadata. What makes this OK is that the AnnotationsGadget doesn't access metadata from the background task - it just accesses plug values, having already got the metadata before launching the task.

But we had a problem with the test itself, where we'd occasionally time out in `callHandler.assertCalled()`. The first call to `annotationText()` is what triggers the background update, because at that point we have metadata in need of substituting. But if we then delete the metadata fast enough, the second call to `annotationText()` cancels the update before it has even started, meaning it never schedules a call on the UI thread.

The solution is to move the second `annotationText()` call out of the UIThreadCallHandler block, so we are guaranteed to have run the update to completion already.
