### PR TITLE
InteractiveRenderTest : Increase tolerance for colour comparison

### DIFF
--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -3640,7 +3640,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		def assertColor( expectedColor ) :
 
 			color = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
-			self.assertEqualWithAbsError( color, expectedColor, 0.01 )
+			self.assertEqualWithAbsError( color, expectedColor, 0.04 )
 
 		# Shader assignment disabled, so should get white from default facing
 		# ratio shader.


### PR DESCRIPTION
This would have been sufficient for https://github.com/GafferHQ/gaffer/actions/runs/31096845140/job/92600798646 to pass, but is still small enough to be sure that we have actually switched shaders as expected.
