### PR TITLE
PlugValueWidgetTest : Fix handling of background updates (alternative approach)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,11 @@ Fixes
 [^1]: Improvement to a feature introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
 [^2]: Included in `1.6.x.x`, so should be omitted from final `1.7.0.0` release notes.
 
+Breaking Changes
+----------------
+
+- PlugValueWidgetTest : Removed `waitForUpdate()` method. Use `WidgetUpdateHandler` instead.
+
 1.7.0.0a9 (relative to 1.7.0.0a8)
 =========
 

--- a/python/GafferUITest/BoolPlugValueWidgetTest.py
+++ b/python/GafferUITest/BoolPlugValueWidgetTest.py
@@ -49,26 +49,28 @@ class BoolPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["p1"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		n["user"]["p2"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		w = GafferUI.BoolPlugValueWidget( n["user"]["p1"] )
-		self.assertEqual( w.getPlug(), n["user"]["p1"] )
-		self.assertEqual( w.getPlugs(), { n["user"]["p1"] } )
-		self.assertEqual( w.boolWidget().getState(), False )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		n["user"]["p1"].setValue( True )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.boolWidget().getState(), True )
+			w = GafferUI.BoolPlugValueWidget( n["user"]["p1"] )
+			self.assertEqual( w.getPlug(), n["user"]["p1"] )
+			self.assertEqual( w.getPlugs(), { n["user"]["p1"] } )
+			self.assertEqual( w.boolWidget().getState(), False )
 
-		w.setPlugs( n["user"].children() )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.boolWidget().getState(), w.boolWidget().State.Indeterminate )
+			n["user"]["p1"].setValue( True )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.boolWidget().getState(), True )
 
-		n["user"]["p2"].setValue( True )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.boolWidget().getState(), True )
+			w.setPlugs( n["user"].children() )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.boolWidget().getState(), w.boolWidget().State.Indeterminate )
 
-		w.setPlugs( [] )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.boolWidget().getState(), w.boolWidget().State.Indeterminate )
+			n["user"]["p2"].setValue( True )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.boolWidget().getState(), True )
+
+			w.setPlugs( [] )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.boolWidget().getState(), w.boolWidget().State.Indeterminate )
 
 	def testInitialValue( self ) :
 
@@ -76,10 +78,11 @@ class BoolPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["p"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
 		for v in ( True, False ) :
-			n["user"]["p"].setValue( v )
-			w = GafferUI.BoolPlugValueWidget( n["user"]["p"] )
-			GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-			self.assertEqual( w.boolWidget().getState(), v )
+			with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
+				n["user"]["p"].setValue( v )
+				w = GafferUI.BoolPlugValueWidget( n["user"]["p"] )
+				handler.waitForUpdate( w )
+				self.assertEqual( w.boolWidget().getState(), v )
 
 	def testErrorHandling( self ) :
 
@@ -88,14 +91,16 @@ class BoolPlugValueWidgetTest( GafferUITest.TestCase ) :
 		script["n"] = Gaffer.Node()
 		script["n"]["user"]["p"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		w = GafferUI.BoolPlugValueWidget( script["n"]["user"]["p"] )
-		self.assertFalse( w.boolWidget().getErrored() )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		script["b"] = GafferTest.BadNode()
-		script["n"]["user"]["p"].setInput( script["b"]["out3"] )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertTrue( w.boolWidget().getErrored() )
+			w = GafferUI.BoolPlugValueWidget( script["n"]["user"]["p"] )
+			self.assertFalse( w.boolWidget().getErrored() )
 
-		script["n"]["user"]["p"].setInput( None )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertFalse( w.boolWidget().getErrored() )
+			script["b"] = GafferTest.BadNode()
+			script["n"]["user"]["p"].setInput( script["b"]["out3"] )
+			handler.waitForUpdate( w )
+			self.assertTrue( w.boolWidget().getErrored() )
+
+			script["n"]["user"]["p"].setInput( None )
+			handler.waitForUpdate( w )
+			self.assertFalse( w.boolWidget().getErrored() )

--- a/python/GafferUITest/ColorChooserTest.py
+++ b/python/GafferUITest/ColorChooserTest.py
@@ -246,59 +246,61 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 		script["node"]["rgbaPlug"] = Gaffer.Color4fPlug()
 		script["node"]["rgbaPlug"].setValue( imath.Color4f( 0.1 ) )
 
-		rgbWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbPlug"] )
-		rgbWidget.setColorChooserVisible( True )
-		rgbaWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbaPlug"] )
-		rgbaWidget.setColorChooserVisible( True )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( rgbWidget._ColorPlugValueWidget__colorChooser )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( rgbaWidget._ColorPlugValueWidget__colorChooser )
+			rgbWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbPlug"] )
+			rgbWidget.setColorChooserVisible( True )
+			rgbaWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbaPlug"] )
+			rgbaWidget.setColorChooserVisible( True )
 
-		# Default state
-		for c in "rgbhsvtmi" :
-			self.assertTrue( self.__sliderFromWidget( rgbWidget, c ).getVisible() )
-			self.assertTrue( self.__sliderFromWidget( rgbaWidget, c ).getVisible() )
-		self.assertTrue( self.__sliderFromWidget( rgbaWidget, "a" ).getVisible() )
-		self.assertEqual( self.__getStaticComponent( rgbWidget ), "v" )
-		self.assertEqual( self.__getStaticComponent( rgbaWidget ), "v" )
-		self.assertTrue( self.__getColorFieldVisibility( rgbWidget ) )
-		self.assertTrue( self.__getColorFieldVisibility( rgbaWidget ) )
-		self.assertTrue( self.__getDynamicSliderBackgrounds( rgbWidget ) )
-		self.assertTrue( self.__getDynamicSliderBackgrounds( rgbaWidget ) )
+			handler.waitForUpdate( rgbWidget._ColorPlugValueWidget__colorChooser )
+			handler.waitForUpdate( rgbaWidget._ColorPlugValueWidget__colorChooser )
 
-		# Modify `rgbWidget`
+			# Default state
+			for c in "rgbhsvtmi" :
+				self.assertTrue( self.__sliderFromWidget( rgbWidget, c ).getVisible() )
+				self.assertTrue( self.__sliderFromWidget( rgbaWidget, c ).getVisible() )
+			self.assertTrue( self.__sliderFromWidget( rgbaWidget, "a" ).getVisible() )
+			self.assertEqual( self.__getStaticComponent( rgbWidget ), "v" )
+			self.assertEqual( self.__getStaticComponent( rgbaWidget ), "v" )
+			self.assertTrue( self.__getColorFieldVisibility( rgbWidget ) )
+			self.assertTrue( self.__getColorFieldVisibility( rgbaWidget ) )
+			self.assertTrue( self.__getDynamicSliderBackgrounds( rgbWidget ) )
+			self.assertTrue( self.__getDynamicSliderBackgrounds( rgbaWidget ) )
 
-		self.__setVisibleComponents( rgbWidget, "rgbhsv" )
-		self.__setStaticComponent( rgbWidget, "g" )
-		self.__setColorFieldVisibility( rgbWidget, False )
-		self.__setDynamicSliderBackgrounds( rgbWidget, False )
+			# Modify `rgbWidget`
 
-		# Save defaults
-		colorChooser = self.__colorChooserFromWidget( rgbWidget )
-		saveDefaultOptions( colorChooser, "colorChooser:inline:" )
+			self.__setVisibleComponents( rgbWidget, "rgbhsv" )
+			self.__setStaticComponent( rgbWidget, "g" )
+			self.__setColorFieldVisibility( rgbWidget, False )
+			self.__setDynamicSliderBackgrounds( rgbWidget, False )
 
-		del rgbWidget
-		del rgbaWidget
+			# Save defaults
+			colorChooser = self.__colorChooserFromWidget( rgbWidget )
+			saveDefaultOptions( colorChooser, "colorChooser:inline:" )
 
-		# Both color types get the same value
-		rgbWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbPlug"] )
-		rgbWidget.setColorChooserVisible( True )
-		rgbaWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbaPlug"] )
-		rgbaWidget.setColorChooserVisible( True )
+			del rgbWidget
+			del rgbaWidget
 
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( rgbWidget._ColorPlugValueWidget__colorChooser )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( rgbaWidget._ColorPlugValueWidget__colorChooser )
+			# Both color types get the same value
+			rgbWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbPlug"] )
+			rgbWidget.setColorChooserVisible( True )
+			rgbaWidget = GafferUI.ColorPlugValueWidget( script["node"]["rgbaPlug"] )
+			rgbaWidget.setColorChooserVisible( True )
 
-		for c in "rgbhsv" :
-			self.assertTrue( self.__sliderFromWidget( rgbWidget, c ).getVisible() )
-			self.assertTrue( self.__sliderFromWidget( rgbaWidget, c ).getVisible() )
-		for c in "tmi" :
-			self.assertFalse( self.__sliderFromWidget( rgbWidget, c ).getVisible() )
-			self.assertFalse( self.__sliderFromWidget( rgbaWidget, c ).getVisible() )
-		self.assertTrue( self.__sliderFromWidget( rgbaWidget, "a" ).getVisible() )
-		self.assertEqual( self.__getStaticComponent( rgbWidget ), "g" )
-		self.assertEqual( self.__getStaticComponent( rgbaWidget ), "g" )
-		self.assertFalse( self.__getColorFieldVisibility( rgbWidget ) )
-		self.assertFalse( self.__getColorFieldVisibility( rgbaWidget ) )
-		self.assertFalse( self.__getDynamicSliderBackgrounds( rgbWidget ) )
-		self.assertFalse( self.__getDynamicSliderBackgrounds( rgbaWidget ) )
+			handler.waitForUpdate( rgbWidget._ColorPlugValueWidget__colorChooser )
+			handler.waitForUpdate( rgbaWidget._ColorPlugValueWidget__colorChooser )
+
+			for c in "rgbhsv" :
+				self.assertTrue( self.__sliderFromWidget( rgbWidget, c ).getVisible() )
+				self.assertTrue( self.__sliderFromWidget( rgbaWidget, c ).getVisible() )
+			for c in "tmi" :
+				self.assertFalse( self.__sliderFromWidget( rgbWidget, c ).getVisible() )
+				self.assertFalse( self.__sliderFromWidget( rgbaWidget, c ).getVisible() )
+			self.assertTrue( self.__sliderFromWidget( rgbaWidget, "a" ).getVisible() )
+			self.assertEqual( self.__getStaticComponent( rgbWidget ), "g" )
+			self.assertEqual( self.__getStaticComponent( rgbaWidget ), "g" )
+			self.assertFalse( self.__getColorFieldVisibility( rgbWidget ) )
+			self.assertFalse( self.__getColorFieldVisibility( rgbaWidget ) )
+			self.assertFalse( self.__getDynamicSliderBackgrounds( rgbWidget ) )
+			self.assertFalse( self.__getDynamicSliderBackgrounds( rgbaWidget ) )

--- a/python/GafferUITest/NumericPlugValueWidgetTest.py
+++ b/python/GafferUITest/NumericPlugValueWidgetTest.py
@@ -49,25 +49,27 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["i"]= Gaffer.IntPlug()
 		n["f"] = Gaffer.FloatPlug()
 
-		w = GafferUI.NumericPlugValueWidget( n["i"] )
-		self.assertTrue( w.getPlug().isSame( n["i"] ) )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertTrue( isinstance( w.numericWidget().getValue(), int ) )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		w.setPlug( n["f"] )
-		self.assertTrue( w.getPlug().isSame( n["f"] ) )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertTrue( isinstance( w.numericWidget().getValue(), float ) )
+			w = GafferUI.NumericPlugValueWidget( n["i"] )
+			self.assertTrue( w.getPlug().isSame( n["i"] ) )
+			handler.waitForUpdate( w )
+			self.assertTrue( isinstance( w.numericWidget().getValue(), int ) )
 
-		w = GafferUI.NumericPlugValueWidget( plugs = [] )
-		self.assertEqual( w.getPlug(), None )
-		self.assertEqual( w.numericWidget().getEditable(), False )
+			w.setPlug( n["f"] )
+			self.assertTrue( w.getPlug().isSame( n["f"] ) )
+			handler.waitForUpdate( w )
+			self.assertTrue( isinstance( w.numericWidget().getValue(), float ) )
 
-		w.setPlug( n["f"] )
-		self.assertTrue( w.getPlug().isSame( n["f"] ) )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertTrue( isinstance( w.numericWidget().getValue(), float ) )
-		self.assertEqual( w.numericWidget().getEditable(), True )
+			w = GafferUI.NumericPlugValueWidget( plugs = [] )
+			self.assertEqual( w.getPlug(), None )
+			self.assertEqual( w.numericWidget().getEditable(), False )
+
+			w.setPlug( n["f"] )
+			self.assertTrue( w.getPlug().isSame( n["f"] ) )
+			handler.waitForUpdate( w )
+			self.assertTrue( isinstance( w.numericWidget().getValue(), float ) )
+			self.assertEqual( w.numericWidget().getEditable(), True )
 
 	def testEditMultiplePlugs( self ) :
 
@@ -75,25 +77,27 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["i1"] = Gaffer.IntPlug()
 		n["user"]["i2"] = Gaffer.IntPlug()
 
-		w = GafferUI.NumericPlugValueWidget( n["user"].children() )
-		self.assertEqual( w.getPlugs(), { n["user"]["i1"], n["user"]["i2"] } )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		n["user"]["i1"].setValue( 2 )
-		n["user"]["i2"].setValue( 2 )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.numericWidget().getText(), "2" )
+			w = GafferUI.NumericPlugValueWidget( n["user"].children() )
+			self.assertEqual( w.getPlugs(), { n["user"]["i1"], n["user"]["i2"] } )
 
-		n["user"]["i1"].setValue( 1 )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.numericWidget().getText(), "" )
-		self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "---" )
+			n["user"]["i1"].setValue( 2 )
+			n["user"]["i2"].setValue( 2 )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.numericWidget().getText(), "2" )
 
-		w.numericWidget().setValue( 10 )
-		self.assertEqual( n["user"]["i1"].getValue(), 10 )
-		self.assertEqual( n["user"]["i2"].getValue(), 10 )
+			n["user"]["i1"].setValue( 1 )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.numericWidget().getText(), "" )
+			self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "---" )
 
-		Gaffer.MetadataAlgo.setReadOnly( n["user"]["i1"], True )
-		self.assertFalse( w.numericWidget().getEditable() )
+			w.numericWidget().setValue( 10 )
+			self.assertEqual( n["user"]["i1"].getValue(), 10 )
+			self.assertEqual( n["user"]["i2"].getValue(), 10 )
+
+			Gaffer.MetadataAlgo.setReadOnly( n["user"]["i1"], True )
+			self.assertFalse( w.numericWidget().getEditable() )
 
 	def testChangeToMixedPlugsDoesntOverwriteExistingPlugValues( self ) :
 
@@ -103,19 +107,21 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["i1"].setValue( 1 )
 		n["user"]["i2"].setValue( 2 )
 
-		w = GafferUI.NumericPlugValueWidget( n["user"]["i1"] )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.numericWidget().getText(), "1" )
-		self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "" )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		w.setPlugs( n["user"].children() )
-		self.assertEqual( w.getPlugs(), { n["user"]["i1"], n["user"]["i2"] } )
+			w = GafferUI.NumericPlugValueWidget( n["user"]["i1"] )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.numericWidget().getText(), "1" )
+			self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "" )
 
-		self.assertEqual( n["user"]["i1"].getValue(), 1 )
-		self.assertEqual( n["user"]["i2"].getValue(), 2 )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.numericWidget().getText(), "" )
-		self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "---" )
+			w.setPlugs( n["user"].children() )
+			self.assertEqual( w.getPlugs(), { n["user"]["i1"], n["user"]["i2"] } )
+
+			self.assertEqual( n["user"]["i1"].getValue(), 1 )
+			self.assertEqual( n["user"]["i2"].getValue(), 2 )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.numericWidget().getText(), "" )
+			self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "---" )
 
 	def testMixedOrInvalidValuesPreservesExisting( self ) :
 
@@ -125,23 +131,25 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["i1"].setValue( 1 )
 		n["user"]["i2"].setValue( 2 )
 
-		w = GafferUI.NumericPlugValueWidget( n["user"]["i1"] )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.numericWidget().getValue(), 1 )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		w.numericWidget().setText( "" )
-		w.numericWidget()._qtWidget().editingFinished.emit()
+			w = GafferUI.NumericPlugValueWidget( n["user"]["i1"] )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.numericWidget().getValue(), 1 )
 
-		self.assertEqual( n["user"]["i1"].getValue(), 1 )
+			w.numericWidget().setText( "" )
+			w.numericWidget()._qtWidget().editingFinished.emit()
 
-		w = GafferUI.NumericPlugValueWidget( n["user"].children() )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.numericWidget().getText(), "" )
+			self.assertEqual( n["user"]["i1"].getValue(), 1 )
 
-		w.numericWidget()._qtWidget().editingFinished.emit()
+			w = GafferUI.NumericPlugValueWidget( n["user"].children() )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.numericWidget().getText(), "" )
 
-		self.assertEqual( n["user"]["i1"].getValue(), 1 )
-		self.assertEqual( n["user"]["i2"].getValue(), 2 )
+			w.numericWidget()._qtWidget().editingFinished.emit()
+
+			self.assertEqual( n["user"]["i1"].getValue(), 1 )
+			self.assertEqual( n["user"]["i2"].getValue(), 2 )
 
 	def testFixedCharacterWidth( self ) :
 

--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import unittest
 import warnings
 import weakref
 
@@ -48,10 +47,9 @@ import GafferUITest
 
 class PlugValueWidgetTest( GafferUITest.TestCase ) :
 
-	@staticmethod
-	def waitForUpdate( widget ) :
+	class WidgetUpdateHandler( GafferTest.ParallelAlgoTest.UIThreadCallHandler ) :
 
-		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as handler :
+		def waitForUpdate( self, widget ) :
 
 			# Updates are done lazily, so we need to flush any pending updates.
 			widget._PlugValueWidget__callUpdateFromValues.flush( widget )
@@ -59,7 +57,7 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 			# And updates for computed values are done in the background, so we
 			# need to wait until they're done.
 			if any( isinstance( p, Gaffer.ValuePlug ) and Gaffer.PlugAlgo.dependsOnCompute( p ) for p in widget.getPlugs() ) :
-				handler.assertCalled()
+				self.assertCalled()
 
 	def testContext( self ) :
 
@@ -68,13 +66,16 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent[\"m\"][\"op1\"] = int( context[\"frame\"] )" )
 
-		w = GafferUI.NumericPlugValueWidget( s["m"]["op1"] )
-		self.assertEqual( w.context(), s.context() )
+		with self.WidgetUpdateHandler() as handler :
 
-		s.context().setFrame( 10 )
-		self.waitForUpdate( w )
-		self.assertEqual( w.numericWidget().getValue(), 10 )
-		self.assertEqual( w.context(), s.context() )
+			w = GafferUI.NumericPlugValueWidget( s["m"]["op1"] )
+			self.assertEqual( w.context(), s.context() )
+
+			s.context().setFrame( 10 )
+			handler.waitForUpdate( w )
+
+			self.assertEqual( w.numericWidget().getValue(), 10 )
+			self.assertEqual( w.context(), s.context() )
 
 	def testDisableCreationForSpecificTypes( self ) :
 
@@ -276,41 +277,42 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( widget.updateCount, 1 )
 		self.assertEqual( widget.updateContexts[0], script.context() )
 
-		# Changing the context shouldn't trigger an update, because the
-		# plug value isn't computed.
-		script.context().setFrame( 2 )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 1 )
+		with self.WidgetUpdateHandler() as handler :
 
-		# Changing the plug should trigger an update.
-		widget.setPlug( script["add"]["op2"] )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 2 )
-		self.assertEqual( widget.updateContexts[1], script.context() )
+			# Changing the context shouldn't trigger an update, because the
+			# plug value isn't computed.
+			script.context().setFrame( 2 )
+			self.assertEqual( widget.updateCount, 1 )
 
-		# Changing the context still shouldn't trigger an update, because the
-		# plug value isn't computed.
-		script.context().setFrame( 3 )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 2 )
+			# Changing the plug should trigger an update.
+			widget.setPlug( script["add"]["op2"] )
+			handler.waitForUpdate( widget )
+			self.assertEqual( widget.updateCount, 2 )
+			self.assertEqual( widget.updateContexts[1], script.context() )
 
-		# Changing the plug again should trigger an update again. This time we
-		# see two updates - one to denote the start of the background task, and
-		# one when it completes. This is because the plug's value is computed
-		# and we don't want to block the UI thread with computes.
-		widget.setPlug( script["add"]["sum"] )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 4 )
-		self.assertEqual( widget.updateContexts[2], script.context() )
-		self.assertEqual( widget.updateContexts[3], script.context() )
+			# Changing the context still shouldn't trigger an update, because the
+			# plug value isn't computed.
+			script.context().setFrame( 3 )
+			handler.waitForUpdate( widget )
+			self.assertEqual( widget.updateCount, 2 )
 
-		# And now changing the context should trigger an update, since computed
-		# values may be context-sensitive.
-		script.context().setFrame( 4 )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 6 )
-		self.assertEqual( widget.updateContexts[4], script.context() )
-		self.assertEqual( widget.updateContexts[5], script.context() )
+			# Changing the plug again should trigger an update again. This time we
+			# see two updates - one to denote the start of the background task, and
+			# one when it completes. This is because the plug's value is computed
+			# and we don't want to block the UI thread with computes.
+			widget.setPlug( script["add"]["sum"] )
+			handler.waitForUpdate( widget )
+			self.assertEqual( widget.updateCount, 4 )
+			self.assertEqual( widget.updateContexts[2], script.context() )
+			self.assertEqual( widget.updateContexts[3], script.context() )
+
+			# And now changing the context should trigger an update, since computed
+			# values may be context-sensitive.
+			script.context().setFrame( 4 )
+			handler.waitForUpdate( widget )
+			self.assertEqual( widget.updateCount, 6 )
+			self.assertEqual( widget.updateContexts[4], script.context() )
+			self.assertEqual( widget.updateContexts[5], script.context() )
 
 	class LegacyUpdateCountPlugValueWidget( GafferUI.PlugValueWidget ) :
 
@@ -394,32 +396,36 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		editor.settings()["__contextQuery"].addQuery( Gaffer.StringPlug(), "testVariable" )
 		editor.settings()["testPlug"].setInput( editor.settings()["__contextQuery"]["out"][0]["value"] )
 
-		widget = self.UpdateCountPlugValueWidget( editor.settings()["testPlug"] )
+		with self.WidgetUpdateHandler() as handler :
 
-		# Editor not viewing anything yet, so we just use the default
-		# script context.
+			widget = self.UpdateCountPlugValueWidget( editor.settings()["testPlug"] )
+			handler.waitForUpdate( widget )
 
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 2 ) # One at the start of the background update, and one on completion
-		self.assertEqual( widget.updateContexts[1], script.context() )
+			# Editor not viewing anything yet, so we just use the default
+			# script context.
 
-		# Editor viewing `node`, so we should use the context that has been
-		# tracked for it.
+			self.assertEqual( widget.updateCount, 2 ) # One at the start of the background update, and one on completion
+			self.assertEqual( widget.updateContexts[1], script.context() )
 
-		editor.settings()["in"].setInput( script["node"]["sum"] )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 4 )
-		self.assertEqual( widget.updateContexts[3], contextTracker.context( script["node"] ) )
-		self.assertIn( "testVariable", widget.updateContexts[3] )
+			# Editor viewing `node`, so we should use the context that has been
+			# tracked for it.
 
-		# Editor viewing `contextVariables`, so we should use the context that
-		# has been tracked for that.
+			editor.settings()["in"].setInput( script["node"]["sum"] )
+			handler.waitForUpdate( widget )
 
-		editor.settings()["in"].setInput( script["contextVariables"]["out"] )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 6 )
-		self.assertEqual( widget.updateContexts[5], contextTracker.context( script["contextVariables"] ) )
-		self.assertNotIn( "testVariable", widget.updateContexts[5] )
+			self.assertEqual( widget.updateCount, 4 )
+			self.assertEqual( widget.updateContexts[3], contextTracker.context( script["node"] ) )
+			self.assertIn( "testVariable", widget.updateContexts[3] )
+
+			# Editor viewing `contextVariables`, so we should use the context that
+			# has been tracked for that.
+
+			editor.settings()["in"].setInput( script["contextVariables"]["out"] )
+			handler.waitForUpdate( widget )
+
+			self.assertEqual( widget.updateCount, 6 )
+			self.assertEqual( widget.updateContexts[5], contextTracker.context( script["contextVariables"] ) )
+			self.assertNotIn( "testVariable", widget.updateContexts[5] )
 
 	def testContextTrackerUpdates( self ) :
 
@@ -445,43 +451,48 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( widget.updateCount, 0 )
 		self.assertEqual( len( widget.updateContexts ), 0 )
 
-		# First update should occur when we make the widget visible.
-		# Since we're showing a computed plug, we get two updates - one
-		# to indicate the start of the background update and one when
-		# it finishes.
-		window.setVisible( True )
-		self.waitForUpdate( widget )
-		self.assertEqual( widget.updateCount, 2 )
-		self.assertEqual( widget.updateContexts[-1], script.context() )
+		with self.WidgetUpdateHandler() as handler :
 
-		# Changing focus should cause an update when the ContextTracker
-		# comes up with a new tracked context.
+			# First update should occur when we make the widget visible.
+			# Since we're showing a computed plug, we get two updates - one
+			# to indicate the start of the background update and one when
+			# it finishes.
 
-		contextTracker = GafferUI.ContextTracker.acquireForFocus( script )
-		with GafferUITest.ContextTrackerTest.UpdateHandler() as h :
-			script.setFocus( script["contextVariables0"] )
-		self.waitForUpdate( widget )
+			window.setVisible( True )
+			handler.waitForUpdate( widget )
 
-		self.assertEqual( widget.updateCount, 4 )
-		self.assertEqual( widget.updateContexts[-1], contextTracker.context( script["add"]["sum"] ) )
+			self.assertEqual( widget.updateCount, 2 )
+			self.assertEqual( widget.updateContexts[-1], script.context() )
 
-		# Changing focus to an equivalent node should not cause an update,
-		# because the same context will be found.
+			# Changing focus should cause an update when the ContextTracker
+			# comes up with a new tracked context.
 
-		with GafferUITest.ContextTrackerTest.UpdateHandler() as h :
-			script.setFocus( script["contextVariables1"] )
-		self.waitForIdle()
-		self.assertEqual( widget.updateCount, 4 )
+			contextTracker = GafferUI.ContextTracker.acquireForFocus( script )
+			with GafferUITest.ContextTrackerTest.UpdateHandler() :
+				script.setFocus( script["contextVariables0"] )
 
-		# But changing focus to a node that yields a different context should
-		# trigger an update.
+			handler.waitForUpdate( widget )
+			self.assertEqual( widget.updateCount, 4 )
+			self.assertEqual( widget.updateContexts[-1], contextTracker.context( script["add"]["sum"] ) )
 
-		with GafferUITest.ContextTrackerTest.UpdateHandler() as h :
-			script.setFocus( script["contextVariables2"] )
-		self.waitForUpdate( widget )
+			# Changing focus to an equivalent node should not cause an update,
+			# because the same context will be found.
 
-		self.assertEqual( widget.updateCount, 6 )
-		self.assertEqual( widget.updateContexts[-1], contextTracker.context( script["add"]["sum"] ) )
+			with GafferUITest.ContextTrackerTest.UpdateHandler() as h :
+				script.setFocus( script["contextVariables1"] )
+
+			self.waitForIdle()
+			self.assertEqual( widget.updateCount, 4 )
+
+			# But changing focus to a node that yields a different context should
+			# trigger an update.
+
+			with GafferUITest.ContextTrackerTest.UpdateHandler() as h :
+				script.setFocus( script["contextVariables2"] )
+
+			handler.waitForUpdate( widget )
+			self.assertEqual( widget.updateCount, 6 )
+			self.assertEqual( widget.updateContexts[-1], contextTracker.context( script["add"]["sum"] ) )
 
 	def tearDown( self ) :
 

--- a/python/GafferUITest/StandardNodeToolbarTest.py
+++ b/python/GafferUITest/StandardNodeToolbarTest.py
@@ -67,8 +67,10 @@ class StandardNodeToolbarTest( GafferUITest.TestCase ) :
 			( view, view["testPlug" ] ),
 		] :
 
-			toolbar = GafferUI.StandardNodeToolbar( node )
-			widget = toolbar._StandardNodeToolbar__layout.plugValueWidget( plug )
-			GafferUITest.PlugValueWidgetTest.waitForUpdate( widget )
-			self.assertEqual( widget.updateCount, 1 )
-			self.assertEqual( widget.updateContexts[0], script.context() )
+			with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
+
+				toolbar = GafferUI.StandardNodeToolbar( node )
+				widget = toolbar._StandardNodeToolbar__layout.plugValueWidget( plug )
+				handler.waitForUpdate( widget )
+				self.assertEqual( widget.updateCount, 1 )
+				self.assertEqual( widget.updateContexts[0], script.context() )

--- a/python/GafferUITest/StringPlugValueWidgetTest.py
+++ b/python/GafferUITest/StringPlugValueWidgetTest.py
@@ -53,52 +53,54 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["p1"].setValue( "p1" )
 		n["user"]["p2"].setValue( "p2" )
 
-		w = GafferUI.StringPlugValueWidget( n["user"]["p1"] )
-		self.assertEqual( w.getPlug(), n["user"]["p1"] )
-		self.assertEqual( w.getPlugs(), { n["user"]["p1"] } )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "p1" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		n["user"]["p1"].setValue( "x" )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "x" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
+			w = GafferUI.StringPlugValueWidget( n["user"]["p1"] )
+			self.assertEqual( w.getPlug(), n["user"]["p1"] )
+			self.assertEqual( w.getPlugs(), { n["user"]["p1"] } )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "p1" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
-		w.setPlugs( n["user"].children() )
+			n["user"]["p1"].setValue( "x" )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "x" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
-		self.assertEqual( n["user"]["p1"].getValue(), "x" )
-		self.assertEqual( n["user"]["p2"].getValue(), "p2" )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
+			w.setPlugs( n["user"].children() )
 
-		w = GafferUI.StringPlugValueWidget( n["user"].children() )
-		self.assertEqual( w.getPlugs(), { n["user"]["p1"], n["user"]["p2"] } )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
+			self.assertEqual( n["user"]["p1"].getValue(), "x" )
+			self.assertEqual( n["user"]["p2"].getValue(), "p2" )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
 
-		n["user"]["p2"].setValue( "x" )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "x" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
+			w = GafferUI.StringPlugValueWidget( n["user"].children() )
+			self.assertEqual( w.getPlugs(), { n["user"]["p1"], n["user"]["p2"] } )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
 
-		n["user"]["p1"].setValue( "" )
-		n["user"]["p2"].setValue( "" )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
+			n["user"]["p2"].setValue( "x" )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "x" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
-		Gaffer.Metadata.registerValue( n["user"]["p1"], "stringPlugValueWidget:placeholderText", "test" )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
+			n["user"]["p1"].setValue( "" )
+			n["user"]["p2"].setValue( "" )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
-		Gaffer.Metadata.registerValue( n["user"]["p2"], "stringPlugValueWidget:placeholderText", "test" )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "test" )
+			Gaffer.Metadata.registerValue( n["user"]["p1"], "stringPlugValueWidget:placeholderText", "test" )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
+
+			Gaffer.Metadata.registerValue( n["user"]["p2"], "stringPlugValueWidget:placeholderText", "test" )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "test" )
 
 	def testMixedValuesPreserved( self ) :
 
@@ -112,32 +114,34 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 		Gaffer.Metadata.registerValue( n["user"]["p1"], "stringPlugValueWidget:placeholderText", "test" )
 		Gaffer.Metadata.registerValue( n["user"]["p2"], "stringPlugValueWidget:placeholderText", "test" )
 
-		w = GafferUI.StringPlugValueWidget( { n["user"]["p1"], n["user"]["p2"] } )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
 
-		w.textWidget()._qtWidget().editingFinished.emit()
+			w = GafferUI.StringPlugValueWidget( { n["user"]["p1"], n["user"]["p2"] } )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
 
-		self.assertEqual( n["user"]["p1"].getValue(), "p1" )
-		self.assertEqual( n["user"]["p2"].getValue(), "p2" )
+			w.textWidget()._qtWidget().editingFinished.emit()
 
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
+			self.assertEqual( n["user"]["p1"].getValue(), "p1" )
+			self.assertEqual( n["user"]["p2"].getValue(), "p2" )
 
-		# Simulate the user editing, even if it results in an empty string
-		self.assertEqual( w.textWidget()._qtWidget().text(), "" )
-		w.textWidget()._qtWidget().textChanged.emit( w.textWidget()._qtWidget().text() )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
 
-		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "test" )
+			# Simulate the user editing, even if it results in an empty string
+			self.assertEqual( w.textWidget()._qtWidget().text(), "" )
+			w.textWidget()._qtWidget().textChanged.emit( w.textWidget()._qtWidget().text() )
 
-		self.assertEqual( n["user"]["p1"].getValue(), "p1" )
-		self.assertEqual( n["user"]["p2"].getValue(), "p2" )
+			self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "test" )
 
-		w.textWidget()._qtWidget().editingFinished.emit()
+			self.assertEqual( n["user"]["p1"].getValue(), "p1" )
+			self.assertEqual( n["user"]["p2"].getValue(), "p2" )
 
-		self.assertEqual( n["user"]["p1"].getValue(), "" )
-		self.assertEqual( n["user"]["p2"].getValue(), "" )
+			w.textWidget()._qtWidget().editingFinished.emit()
+
+			self.assertEqual( n["user"]["p1"].getValue(), "" )
+			self.assertEqual( n["user"]["p2"].getValue(), "" )
 
 	def testExceptionHandling( self ) :
 
@@ -151,10 +155,11 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		# We want that to be reflected in the UI.
 
-		w = GafferUI.StringPlugValueWidget( script["n"]["p"] )
-		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
-		self.assertEqual( w.textWidget().getText(), "" )
-		self.assertTrue( w.textWidget().getErrored() )
+		with GafferUITest.PlugValueWidgetTest.WidgetUpdateHandler() as handler :
+			w = GafferUI.StringPlugValueWidget( script["n"]["p"] )
+			handler.waitForUpdate( w )
+			self.assertEqual( w.textWidget().getText(), "" )
+			self.assertTrue( w.textWidget().getErrored() )
 
 		# And we don't want the widget to live beyond its natural life
 		# due to reference cycles introduced by exception handling.


### PR DESCRIPTION
This fixes the same test failures as #7081, but in a more conservative way, affecting only the tests which used `PlugValueWidgetTest.waitForUpdate()`. The fundamental issue is how we deal with testing UI updates involving LazyMethod and BackgroundMethod, where in both cases we need to wait for the UI to update before we can make our assertions. We've taken two main approaches to that :

1.`TestCase.waitForIdle()` : This just runs the Qt event loop for a little bit and then stops. And calls to `ParallelAlgo::callOnUIThread()` are serviced by the regular handler in EventLoop.py. This has benefits in that it's pretty simple, and you don't need to know how many UI thread calls you're expecting. But it's also pretty vague - it's not clear how much idling is enough before we can make our assertions, so we're always in danger of not idling enough.
2. `ParallelAlgoTest.UIThreadCallHandler().assertCalled()` : This is independent of the event loop. It installs its own UI thread call handler, and syncs that with calls to `assertCalled()`. It's very controlled, and always waits until the required updates are complete. But it's also tied quite closely to the implementation of the widgets we're testing, because we need to know how many UI thread calls to expect.

Before, each test could decide what approach it wanted to take. But #7081 forces everything into option 2, meaning that tests that expect `waitForIdle()` to execute UI thread calls will fail. It would be great to settle on one approach, but that's too much work right now. And maybe a different approach entirely would be better anyway - something like the `assertEventually()` we use for interactive render tests?

Anyway, to summarise, I'm proposing that this PR replaces #7081.