### PR TITLE
MeshNormals : Pass through unchanged if `normalPlug->getValue() == ""`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- MeshNormals : Fixed bug that created an unnamed PrimitiveVariable if the `normal` plug was set to "".
 - RenderMan :
   - Fixed handling of connections between floats and color/vector components.
   - Fixed bug preventing attributes from being deleted from lights during an interactive render.

--- a/python/GafferSceneTest/MeshNormalsTest.py
+++ b/python/GafferSceneTest/MeshNormalsTest.py
@@ -117,5 +117,19 @@ class MeshNormalsTest( GafferSceneTest.SceneTestCase ) :
 				sortedVec.equalWithRelError( imath.V3f( 1, 2, 2 ).normalized(), 1e-7 )
 			)
 
+	def testEmptyString( self ) :
+
+		cube = GafferScene.Cube()
+
+		cubeFilter = GafferScene.PathFilter()
+		cubeFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		meshNormals = GafferScene.MeshNormals()
+		meshNormals["in"].setInput( cube["out"] )
+		meshNormals["filter"].setInput( cubeFilter["out"] )
+		meshNormals["normal"].setValue( "" )
+
+		self.assertEqual( meshNormals["out"].object( "/cube" ), meshNormals["in"].object( "/cube" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/MeshNormals.cpp
+++ b/src/GafferScene/MeshNormals.cpp
@@ -148,7 +148,12 @@ IECore::ConstObjectPtr MeshNormals::computeProcessedObject( const ScenePath &pat
 		return inputObject;
 	}
 
-	std::string normal = normalPlug()->getValue();
+	const std::string normal = normalPlug()->getValue();
+	if( normal.empty() )
+	{
+		return inputObject;
+	}
+
 	PrimitiveVariable::Interpolation interpolation = (PrimitiveVariable::Interpolation) interpolationPlug()->getValue();
 	MeshAlgo::NormalWeighting weighting = (MeshAlgo::NormalWeighting) weightingPlug()->getValue();
 	float thresholdAngle = thresholdAnglePlug()->getValue();


### PR DESCRIPTION
We don't want to create a primitive variable called "" - that causes problems downstream.
