### PR TITLE
TestCase : assertEventually() improvements

### DIFF
--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -201,7 +201,7 @@ class TestCase( unittest.TestCase ) :
 			raise TypeError( "assertEventually requires a callable" )
 
 		start = time.time()
-		lastError = None
+		errors = []
 
 		while True :
 			try :
@@ -209,13 +209,16 @@ class TestCase( unittest.TestCase ) :
 				return
 			except AssertionError as e :
 				elapsed = time.time() - start
-				lastError = e
+				errors.append( ( elapsed, e ) )
 				if elapsed >= timeout :
 					break
 				delayFn( min( interval, timeout - elapsed ) )
 				interval *= 2.0
 
-		raise AssertionError( f"Timed out after {elapsed:.2f}s : {lastError}" )
+		attempts = "\n".join( f"{timestamp:8.2f}s : {error}" for timestamp, error in errors )
+		raise AssertionError(
+			f"Timed out after {elapsed:.2f}s : {errors[-1][1]}\n\nAttempts:\n{attempts}"
+		)
 
 	## Attempts to ensure that the hashes for a node
 	# are reasonable by jiggling around input values

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -203,16 +203,19 @@ class TestCase( unittest.TestCase ) :
 		start = time.time()
 		lastError = None
 
-		while time.time() - start < timeout :
+		while True :
 			try :
 				fn()
 				return
 			except AssertionError as e :
+				elapsed = time.time() - start
 				lastError = e
-				delayFn( interval )
+				if elapsed >= timeout :
+					break
+				delayFn( min( interval, timeout - elapsed ) )
 				interval *= 2.0
 
-		raise AssertionError( f"Timed out after {timeout}s : {lastError}" )
+		raise AssertionError( f"Timed out after {elapsed:.2f}s : {lastError}" )
 
 	## Attempts to ensure that the hashes for a node
 	# are reasonable by jiggling around input values


### PR DESCRIPTION
On the ongoing topic of tracking down intermittent test failures, this makes some small improvements to assertEventually. Fixing an issue where it wasn't using all of the specified timeout and improving the reporting to include an attempt summary so it's easier to determine whether the test is converging on the correct result but ran out of time, or has already converged on an incorrect result.

```
AssertionError: Timed out after 10.00s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)

Attempts:
    0.00s : Color3f(1, 2, 4) != Color3f(1, 0.550000012, 0.25)
    0.10s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)
    0.30s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)
    0.71s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)
    1.51s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)
    3.11s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)
    6.31s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)
   10.00s : Color3f(1, 0.5, 0.25) != Color3f(1, 0.550000012, 0.25)
```