### PR TITLE
RenderTest : Raise testPointInstancerMotionBlur empty pixel tolerance

### DIFF
--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -1589,7 +1589,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 			# space above and below.
 			for y in ( 150, 320 ) :
 				sampler["pixel"].setValue( imath.V2f( x, y ) )
-				self.assertEqualWithAbsError( sampler["color"]["a"].getValue(), 0, 0.005 )
+				self.assertEqualWithAbsError( sampler["color"]["a"].getValue(), 0, 0.006 )
 
 	@GafferTest.TestRunner.CategorisedTestMethod( { "pointInstancer" } )
 	def testPointInstancerInstanceAttributes( self ) :


### PR DESCRIPTION
Arnold render tests have failed after producing values in the range of 0.0051-0.0055, so increase the tolerance to 0.006 to avoid unnecessary failures.