### PR TITLE
ProcessTest : Skip testCollaborationTaskDistribution on macOS CI

### DIFF
--- a/python/GafferTest/ProcessTest.py
+++ b/python/GafferTest/ProcessTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import sys
 import unittest
 
 import IECore
@@ -229,6 +230,7 @@ class ProcessTest( GafferTest.TestCase ) :
 
 			self.assertIn( monitor.plugStatistics( plug ).computeCount, { 5, 6, 8 } )
 
+	@unittest.skipIf( GafferTest.inCI() and sys.platform == "darwin", "Intermittent failures on macOS CI" )
 	@GafferTest.TestRunner.CategorisedTestMethod( { "taskCollaboration" } )
 	def testCollaborationTaskDistribution( self ) :
 


### PR DESCRIPTION
This test passes with -repeat 1000 locally on macOS when run with various thread counts, but intermittently fails on CI with values under the expected 3 workers.