### PR TITLE
CI : Update to build container 4.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
             os: ubuntu-24.04
             buildType: RELEASE
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:4.0.0a2
+            containerImage: ghcr.io/gafferhq/build/build:4.0.0
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -58,7 +58,7 @@ jobs:
             os: ubuntu-24.04
             buildType: DEBUG
             publish: false
-            containerImage: ghcr.io/gafferhq/build/build:4.0.0a2
+            containerImage: ghcr.io/gafferhq/build/build:4.0.0
             testRunner: runuser -u testUser --
             testArguments: -excludedCategories performance
             # Debug builds are ludicrously big, so we must use a larger cache
@@ -196,7 +196,7 @@ jobs:
     - name: 'Install Python Modules'
       run: |
         python --version
-        pip install PyJWT==1.7.1 PyGitHub==1.45 beautifulsoup4
+        pip install PyJWT==2.13.0 PyGitHub==1.59.0 beautifulsoup4
 
     - name: Set Custom Variables
       run: |


### PR DESCRIPTION
Also bump PyGitHub and PyJWT versions as the older ones are no longer installable by pip 26.2.