### PR TITLE
UIEditor : Fix error when using the `C` shortcut with no nodes selected

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,14 +15,16 @@ Fixes
 - PathListingWidget : Paths dragged from a PathListingWidget now preserve the order in which they are displayed.
 - SetExpressionAlgo : Fixed invalid set expressions returned by `exclude()` when the set expression to be excluded contains only whitespace [^1].
 - PlugLayout : `<layoutName>:width` metadata is now correctly reapplied to widgets with labels when a PlugLayout is rebuilt.
-- GraphEditor : Fixed bug with history back and forward buttons when a node in the history has been deleted (#7071) [^1].
+- GraphEditor :
+  - Fixed bug with history back and forward buttons when a node in the history has been deleted (#7071) [^1].
+  - Fixed error when pressing <kbd>C</kbd> with no nodes selected [^1].
 
 API
 ---
 
 - SetExpressionAlgo : Added `remove` [^1].
 
-[^1]: Improvement to a feature introduced in `1.7.0.0a1`, so should be omitted from final `1.7.0.0` release notes.
+[^1]: Improvement to a feature introduced in `1.7.0.0ax`, so should be omitted from final `1.7.0.0` release notes.
 
 1.7.0.0a10 (relative to 1.7.0.0a9)
 ==========

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -360,7 +360,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 
 		selection = [ n for n in graphEditor.scriptNode().selection() if n.parent() == graphEditor.graphGadget().getRoot() ]
 		if event.key == "C" and event.modifiers == event.Modifiers.None_ :
-			if not any( Gaffer.MetadataAlgo.readOnly( n ) for n in selection ) :
+			if selection and not any( Gaffer.MetadataAlgo.readOnly( n ) for n in selection ) :
 				cls.__setColor( graphEditor, selection )
 			return True
 


### PR DESCRIPTION
Calling UIEditor.__setColor() with an empty node list results in:
```
ERROR :   File "build/cortex-10.7.0.0-linux-platform25/python/Gaffer/WeakMethod.py", line 65, in __call__
ERROR :     return self.__method( s, *args, **kwArgs )
ERROR :            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR :   File "build/cortex-10.7.0.0-linux-platform25/python/GafferUI/UIEditor.py", line 364, in __graphEditorKeyPress
ERROR :     cls.__setColor( graphEditor, selection )
ERROR :   File "build/cortex-10.7.0.0-linux-platform25/python/GafferUI/UIEditor.py", line 350, in __setColor
ERROR :     color = Gaffer.Metadata.value( nodeList[-1], "nodeGadget:color" ) or imath.Color3f( 1 )
ERROR :                                    ~~~~~~~~^^^^
ERROR : IndexError: list index out of range
```