### PR TITLE
CatalogueTest : Fix wait for Catalogue save

### DIFF
--- a/python/GafferSceneTest/CatalogueTest.py
+++ b/python/GafferSceneTest/CatalogueTest.py
@@ -57,13 +57,24 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 	@staticmethod
 	def sendImage( image, catalogue, extraParameters = {}, waitForSave = True, close = True ) :
 
-		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as h :
-			result = GafferSceneTest.DisplayTest.Driver.sendImage( image, GafferScene.Catalogue.displayDriverServer().portNumber(), extraParameters, close = close )
-			if catalogue["directory"].getValue() and waitForSave :
-				# When the image has been received, the Catalogue will
-				# save it to disk on a background thread, and we need
-				# to wait for that to complete.
+		result = GafferSceneTest.DisplayTest.Driver.sendImage( image, GafferScene.Catalogue.displayDriverServer().portNumber(), extraParameters, close = False )
+
+		if close :
+
+			# We always do the closing ourselves, because we need to manage
+			# the UI thread call triggered by the Catalogue saving the
+			# image.
+			with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as h :
+
+				result.close( withCallHandler = False )
 				h.assertCalled()
+
+				if catalogue["directory"].getValue() and waitForSave :
+					# When the image has been received, the Catalogue will
+					# save it to disk on a background thread, and we need
+					# to wait for that to complete.
+					h.assertCalled()
+
 				h.assertDone()
 
 		return result


### PR DESCRIPTION
This fixes errors like the following :

```
Error: FAIL: testDisplayDriverAndPromotion (GafferSceneTest.CatalogueTest.CatalogueTest.testDisplayDriverAndPromotion)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/python/GafferSceneTest/CatalogueTest.py", line 387, in testDisplayDriverAndPromotion
    self.sendImage( r["out"], s["b"]["c"] )
  File "/__w/gaffer/gaffer/build/python/GafferSceneTest/CatalogueTest.py", line 61, in sendImage
    result = GafferSceneTest.DisplayTest.Driver.sendImage( image, GafferScene.Catalogue.displayDriverServer().portNumber(), extraParameters, close = close )
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/gaffer/gaffer/build/python/GafferSceneTest/DisplayTest.py", line 150, in sendImage
    driver.close()
  File "/__w/gaffer/gaffer/build/python/GafferSceneTest/DisplayTest.py", line 115, in close
    with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as h :
  File "/__w/gaffer/gaffer/build/python/GafferTest/ParallelAlgoTest.py", line 70, in __exit__
    raise AssertionError( "UIThread call queue not empty" )
AssertionError: UIThread call queue not empty
```

We have only seen these on CI, but they can be reproduced artificially by inserting `time.sleep()` before L119 in DisplayTest. The problem is that with the right thread timings, the Catalogue can save the image to disk and request an extra UI thread call before `close()` calls `assertDone()`. The `sleep()` just makes the bad timing inevitable, but it could occur naturally when the CI machine is under unusual load.

The solution is to move the `close()` call under the same UIThreadCallHandler as the one used to check for saving, and only call `assertDone()` once at the end.

The weaving of `DisplayTest.sendImage()` and `CatalogueTest.sendImage()` with all their various permutations is getting a bit much. It does seem tempting to attempt an approach based on `assertEventually()` instead.
