### PR TITLE
RenderMan : Add `IECORERENDERMAN_LEGACY_TEXTURECOORDINATE_BEHAVIOUR`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.21.3)
 =======
 
+Fixes
+-----
 
+- RenderMan : Added `IECORERENDERMAN_LEGACY_TEXTURECOORDINATE_BEHAVIOUR` environment variable, as a partial opt-out from the bugfix introduced in 1.6.21.0. Setting the variable to a value of `1` causes USD `texCoord3f` primitive variables to be exported to RenderMan as `point` rather than `float[3]`, as they were prior to 1.6.21.0. This is not correct, but allows folks who have been authoring `__Pref` as `texCoord3f` to temporarily continue to work as before.
 
 1.6.21.3 (relative to 1.6.21.2)
 ========

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -1275,6 +1275,14 @@ class RendererTest( GafferTest.TestCase ) :
 				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
 				IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 4, IECore.GeometricData.Interpretation.Numeric )
 			)
+			mesh["constantTextureCoordinate"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Constant,
+				IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.UV )
+			)
+			mesh["vertexTextureCoordinate"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 4, IECore.GeometricData.Interpretation.UV )
+			)
 
 			attributes = IECore.CompoundObject( {
 				"user:point" : IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Point ),
@@ -1285,6 +1293,8 @@ class RendererTest( GafferTest.TestCase ) :
 				"user:normalArray" : IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 3, IECore.GeometricData.Interpretation.Normal ),
 				"user:float3" : IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.Numeric ),
 				"user:float3Array" : IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 5, IECore.GeometricData.Interpretation.Numeric ),
+				"user:textureCoordinate" : IECore.V3fData( imath.V3f( 0 ), IECore.GeometricData.Interpretation.UV ),
+				"user:textureCoordinateArray" : IECore.V3fVectorData( [ imath.V3f( 0 ) ] * 5, IECore.GeometricData.Interpretation.UV ),
 			} )
 
 			renderer.object(
@@ -1326,6 +1336,8 @@ class RendererTest( GafferTest.TestCase ) :
 		assertExpectedPrimVar( "vertexNormal", dataTypes["normal"], 1, False )
 		assertExpectedPrimVar( "constantFloat3", dataTypes["float"], 3, True )
 		assertExpectedPrimVar( "vertexFloat3", dataTypes["float"], 3, True )
+		assertExpectedPrimVar( "constantTextureCoordinate", dataTypes["float"], 3, True )
+		assertExpectedPrimVar( "vertexTextureCoordinate", dataTypes["float"], 3, True )
 
 		instance = next(
 			x for x in capture.json if x["method"] == "CreateGeometryInstance"
@@ -1344,6 +1356,8 @@ class RendererTest( GafferTest.TestCase ) :
 		assertExpectedAttribute( "user:normalArray", dataTypes["normal"], 3, True )
 		assertExpectedAttribute( "user:float3", dataTypes["float"], 3, True )
 		assertExpectedAttribute( "user:float3Array", dataTypes["float"], 15, True )
+		assertExpectedAttribute( "user:textureCoordinate", dataTypes["float"], 3, True )
+		assertExpectedAttribute( "user:textureCoordinateArray", dataTypes["float"], 15, True )
 
 	def testSubdivInterpolatedBoundary( self ) :
 

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -39,6 +39,7 @@ import os
 import time
 import unittest
 import random
+import subprocess
 
 import imath
 
@@ -1235,6 +1236,8 @@ class RendererTest( GafferTest.TestCase ) :
 
 	def testGeometricInterpretation( self ) :
 
+		legacy = os.environ.get( "IECORERENDERMAN_LEGACY_TEXTURECOORDINATE_BEHAVIOUR", "0" ) == "1"
+
 		with IECoreRenderManTest.RileyCapture() as capture :
 
 			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
@@ -1336,8 +1339,12 @@ class RendererTest( GafferTest.TestCase ) :
 		assertExpectedPrimVar( "vertexNormal", dataTypes["normal"], 1, False )
 		assertExpectedPrimVar( "constantFloat3", dataTypes["float"], 3, True )
 		assertExpectedPrimVar( "vertexFloat3", dataTypes["float"], 3, True )
-		assertExpectedPrimVar( "constantTextureCoordinate", dataTypes["float"], 3, True )
-		assertExpectedPrimVar( "vertexTextureCoordinate", dataTypes["float"], 3, True )
+		if legacy :
+			assertExpectedPrimVar( "constantTextureCoordinate", dataTypes["point"], 1, False )
+			assertExpectedPrimVar( "vertexTextureCoordinate", dataTypes["point"], 1, False )
+		else :
+			assertExpectedPrimVar( "constantTextureCoordinate", dataTypes["float"], 3, True )
+			assertExpectedPrimVar( "vertexTextureCoordinate", dataTypes["float"], 3, True )
 
 		instance = next(
 			x for x in capture.json if x["method"] == "CreateGeometryInstance"
@@ -1356,8 +1363,30 @@ class RendererTest( GafferTest.TestCase ) :
 		assertExpectedAttribute( "user:normalArray", dataTypes["normal"], 3, True )
 		assertExpectedAttribute( "user:float3", dataTypes["float"], 3, True )
 		assertExpectedAttribute( "user:float3Array", dataTypes["float"], 15, True )
-		assertExpectedAttribute( "user:textureCoordinate", dataTypes["float"], 3, True )
-		assertExpectedAttribute( "user:textureCoordinateArray", dataTypes["float"], 15, True )
+		if legacy :
+			assertExpectedAttribute( "user:textureCoordinate", dataTypes["point"], 1, False )
+			assertExpectedAttribute( "user:textureCoordinateArray", dataTypes["point"], 5, True )
+		else :
+			assertExpectedAttribute( "user:textureCoordinate", dataTypes["float"], 3, True )
+			assertExpectedAttribute( "user:textureCoordinateArray", dataTypes["float"], 15, True )
+
+	def testLegacyGeometricInterpretation( self ) :
+
+		# Launch test above in environment to trigger legacy behaviour
+		# (unless we're in a legacy environment, in which case test clean
+		# behaviour).
+
+		legacy = os.environ.get( "IECORERENDERMAN_LEGACY_TEXTURECOORDINATE_BEHAVIOUR", "0" ) == "1"
+		env = os.environ.copy()
+		env["IECORERENDERMAN_LEGACY_TEXTURECOORDINATE_BEHAVIOUR"] = "0" if legacy else "1"
+
+		try :
+			subprocess.check_output(
+				[ "gaffer" if os.name != "nt" else "gaffer.cmd", "test", "IECoreRenderManTest.RendererTest.testGeometricInterpretation" ],
+				env = env, stderr = subprocess.STDOUT
+			)
+		except subprocess.CalledProcessError as e :
+			self.fail( e.output )
 
 	def testSubdivInterpolatedBoundary( self ) :
 

--- a/src/IECoreRenderMan/GeometryAlgo.cpp
+++ b/src/IECoreRenderMan/GeometryAlgo.cpp
@@ -94,21 +94,6 @@ RtDetailType detail( IECoreScene::PrimitiveVariable::Interpolation interpolation
 	}
 }
 
-RtDataType dataType( IECore::GeometricData::Interpretation interpretation )
-{
-	switch( interpretation )
-	{
-		case GeometricData::Vector :
-			return RtDataType::k_vector;
-		case GeometricData::Normal :
-			return RtDataType::k_normal;
-		case GeometricData::Point :
-			return RtDataType::k_point;
-		default :
-			return RtDataType::k_float;
-	}
-}
-
 struct PrimitiveVariableConverter
 {
 
@@ -148,7 +133,7 @@ struct PrimitiveVariableConverter
 
 	void operator()( const V3fData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
 	{
-		const RtDataType type = dataType( data->getInterpretation() );
+		const RtDataType type = IECoreRenderMan::ParamListAlgo::dataType( data->getInterpretation() );
 		primVarList.SetParam(
 			{
 				name,
@@ -241,7 +226,7 @@ struct PrimitiveVariableConverter
 
 	void operator()( const V3fVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
 	{
-		const RtDataType type = dataType( data->getInterpretation() );
+		const RtDataType type = IECoreRenderMan::ParamListAlgo::dataType( data->getInterpretation() );
 		emit(
 			data,
 			{

--- a/src/IECoreRenderMan/ParamListAlgo.cpp
+++ b/src/IECoreRenderMan/ParamListAlgo.cpp
@@ -50,6 +50,11 @@ using namespace IECore;
 namespace
 {
 
+const bool g_legacyTextureCoordinates = [] () {
+	const char *c = getenv( "IECORERENDERMAN_LEGACY_TEXTURECOORDINATE_BEHAVIOUR" );
+	return c && !strcmp( c, "1" );
+}();
+
 struct ParameterConverter
 {
 
@@ -196,6 +201,13 @@ RtDataType IECoreRenderMan::ParamListAlgo::dataType( IECore::GeometricData::Inte
 			return RtDataType::k_normal;
 		case GeometricData::Point :
 			return RtDataType::k_point;
+		case GeometricData::UV :
+			// This is what we end up with when loading `texCoord3f` from USD.
+			// It should be treated as pure floats so that the values don't
+			// get transformed at all, but at least one pipeline is dependent
+			// on them being treated as points for use as `__Pref`.
+			/// \todo Remove the legacy behaviour.
+			return g_legacyTextureCoordinates ? RtDataType::k_point : RtDataType::k_float;
 		default :
 			return RtDataType::k_float;
 	}

--- a/src/IECoreRenderMan/ParamListAlgo.cpp
+++ b/src/IECoreRenderMan/ParamListAlgo.cpp
@@ -95,20 +95,17 @@ struct ParameterConverter
 
 	void operator()( const V3fData *data, RtUString name, RtParamList &paramList ) const
 	{
-		switch( data->getInterpretation() )
-		{
-			case GeometricData::Vector :
-				paramList.SetVector( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
-				break;
-			case GeometricData::Normal :
-				paramList.SetNormal( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
-				break;
-			case GeometricData::Point :
-				paramList.SetPoint( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
-				break;
-			default :
-				paramList.SetFloatArray( name, data->readable().getValue(), 3 );
-		}
+		const RtDataType type = IECoreRenderMan::ParamListAlgo::dataType( data->getInterpretation() );
+		paramList.SetParam(
+			{
+				name, type, RtDetailType::k_constant,
+				/* length = */ type == RtDataType::k_float ? 3u : 1u,
+				/* array = */ type == RtDataType::k_float,
+				/* motion = */ false,
+				/* deduplicated = */ false
+			},
+			data->readable().getValue()
+		);
 	}
 
 	void operator()( const M44fData *data, RtUString name, RtParamList &paramList ) const
@@ -159,20 +156,17 @@ struct ParameterConverter
 
 	void operator()( const V3fVectorData *data, RtUString name, RtParamList &paramList ) const
 	{
-		switch( data->getInterpretation() )
-		{
-			case GeometricData::Vector :
-				paramList.SetVectorArray( name, reinterpret_cast<const RtVector3 *>( data->readable().data() ), data->readable().size() );
-				break;
-			case GeometricData::Normal :
-				paramList.SetNormalArray( name, reinterpret_cast<const RtVector3 *>( data->readable().data() ), data->readable().size() );
-				break;
-			case GeometricData::Point :
-				paramList.SetPointArray( name, reinterpret_cast<const RtVector3 *>( data->readable().data() ), data->readable().size() );
-				break;
-			default :
-				paramList.SetFloatArray( name, data->readable().front().getValue(), 3 * data->readable().size() );
-		}
+		const RtDataType type = IECoreRenderMan::ParamListAlgo::dataType( data->getInterpretation() );
+		paramList.SetParam(
+			{
+				name, type, RtDetailType::k_constant,
+				/* length = */ (uint32_t)data->readable().size() * (type == RtDataType::k_float ? 3 : 1),
+				/* array = */ true,
+				/* motion = */ false,
+				/* deduplicated = */ false
+			},
+			data->readable().front().getValue()
+		);
 	}
 
 	void operator()( const Data *data, RtUString name, RtParamList &paramList ) const
@@ -191,6 +185,21 @@ struct ParameterConverter
 //////////////////////////////////////////////////////////////////////////
 // Public API
 //////////////////////////////////////////////////////////////////////////
+
+RtDataType IECoreRenderMan::ParamListAlgo::dataType( IECore::GeometricData::Interpretation interpretation )
+{
+	switch( interpretation )
+	{
+		case GeometricData::Vector :
+			return RtDataType::k_vector;
+		case GeometricData::Normal :
+			return RtDataType::k_normal;
+		case GeometricData::Point :
+			return RtDataType::k_point;
+		default :
+			return RtDataType::k_float;
+	}
+}
 
 void IECoreRenderMan::ParamListAlgo::convertParameter( const RtUString &name, const Data *data, RtParamList &paramList )
 {

--- a/src/IECoreRenderMan/ParamListAlgo.h
+++ b/src/IECoreRenderMan/ParamListAlgo.h
@@ -35,11 +35,14 @@
 #pragma once
 
 #include "IECore/CompoundData.h"
+#include "IECore/GeometricTypedData.h"
 
 #include "RiTypesHelper.h"
 
 namespace IECoreRenderMan::ParamListAlgo
 {
+
+RtDataType dataType( IECore::GeometricData::Interpretation interpretation );
 
 void convertParameter( const RtUString &name, const IECore::Data *data, RtParamList &paramList );
 void convertParameters( const IECore::CompoundDataMap &parameters, RtParamList &paramList );


### PR DESCRIPTION
This is an environment variable which allows folks who were relying on a previous bug (fixed in 1.6.21.0) to revert back to the buggy behaviour.

<img width="555" height="772" alt="image" src="https://github.com/user-attachments/assets/efd60115-40db-48d9-a2fb-f64d6130cd7e" />
