### PR TITLE
TestCase : Fix circular references from `assertEventually()`

### DIFF
--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -273,7 +273,7 @@ class TestCase( unittest.TestCase ) :
 				return
 			except AssertionError as e :
 				elapsed = time.time() - start
-				errors.append( ( elapsed, e ) )
+				errors.append( ( elapsed, f"{e}" ) )
 				if elapsed >= timeout :
 					break
 				delayFn( min( interval, timeout - elapsed ) )


### PR DESCRIPTION
Exceptions store tracebacks, so storing an exception in a variable in one of the frames of the traceback causes a circular reference. That keeps all the frames alive, including all local variables in the test that called `assertEventually()`. In my case this was causing havoc, with signal handlers from one test continuing to run in the next test.

We only need the exception formatted as a string anyway, so store that instead.
