### PR TITLE
PlugCreationWidget : Make plugCreationMenuSignal responders scope context()

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - LevelSetOffset : Fixed crash when attempting to offset grid types other than `FloatGrid`.
+- AttributeTweaks, CustomAttributes, OptionTweaks, CustomOptions, OptionQuery : Fixed contexts used by "From Scene", "From Selected" and "From Affected" menu items. This fixes errors caused by missing context variables (such as script variables).
 
 1.6.21.4 (relative to 1.6.21.3)
 ========

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -190,11 +190,12 @@ def __addFromPathsMenuDefinition( menu, paths ) :
 	plugCreationWidget = menu.ancestor( GafferUI.PlugCreationWidget )
 	node = plugCreationWidget.plugParent().node()
 
-	attributes = {}
-	for path in paths :
-		attr = node["in"].fullAttributes( path, withGlobalAttributes = True )
-		attributes.update( attr )
-	existingNames = { plug["name"].getValue() for plug in plugCreationWidget.plugParent() }
+	with plugCreationWidget.context():
+		attributes = {}
+		for path in paths :
+			attr = node["in"].fullAttributes( path, withGlobalAttributes = True )
+			attributes.update( attr )
+		existingNames = { plug["name"].getValue() for plug in plugCreationWidget.plugParent() }
 
 	attributes = dict( sorted( attributes.items() ) )
 

--- a/python/GafferSceneUI/CustomOptionsUI.py
+++ b/python/GafferSceneUI/CustomOptionsUI.py
@@ -116,8 +116,10 @@ def __addFromGlobalsMenuDefinition( menu ) :
 	result = IECore.MenuDefinition()
 
 	scene = next( GafferScene.ScenePlug.RecursiveInputRange( node ) )
-	options = scene["globals"].getValue()
-	existingNames = { plug["name"].getValue() for plug in plugCreationWidget.plugParent() }
+
+	with plugCreationWidget.context():
+		options = scene["globals"].getValue()
+		existingNames = { plug["name"].getValue() for plug in plugCreationWidget.plugParent() }
 
 	prefix = "option:"
 


### PR DESCRIPTION
I found three places where we respond to plugCreationMenuSignal() by evaluating the scene to list possibilities that exist in the scene: ShaderTweaksUI, CustomOptionsUI and CustomAttributesUI

ShaderTweaksUI already uses PlugCreationWidget.context() when evaluating the scene. Pretty sure it makes sense that the other two should as well.

This bug was reported on the Discord with a clear repro, so I'll just link that here:
https://discord.com/channels/722635732384219146/1537521489534779482

I've confirmed that this fixes the reported issue ( and also fixes the same issue with AttributeTweaks )