### PR TITLE
GafferVDB : Add LevelSetSmooth node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.7.x.x (relative to 1.7.0.0)
 =======
 
+Features
+--------
+
+- LevelSetSmooth : Added a new node for smoothing OpenVDB level sets.
+
 Improvements
 ------------
 

--- a/include/GafferVDB/LevelSetSmooth.h
+++ b/include/GafferVDB/LevelSetSmooth.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2017, John Haddon. All rights reserved.
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -15,7 +15,7 @@
 //        disclaimer in the documentation and/or other materials provided with
 //        the distribution.
 //
-//      * Neither the name of John Haddon nor the names of
+//      * Neither the name of Image Engine Design Inc nor the names of
 //        any other contributors to this software may be used to endorse or
 //        promote products derived from this software without specific prior
 //        written permission.
@@ -36,21 +36,64 @@
 
 #pragma once
 
+#include "GafferVDB/Export.h"
+#include "GafferVDB/TypeIds.h"
+
+#include "GafferScene/Deformer.h"
+
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
+
 namespace GafferVDB
 {
 
-enum TypeId
+class GAFFERVDB_API LevelSetSmooth : public GafferScene::Deformer
 {
-	MeshToLevelSetTypeId = 123200,
-	LevelSetToMeshTypeId = 123201,
-	LevelSetOffsetTypeId = 123202,
-	PointsGridToPointsTypeId = 123203,
-	SphereLevelSetTypeId = 123204,
-	PointsToLevelSetTypeId = 123205,
-	VolumeScatterTypeId = 123206,
-	DeleteGridsTypeId = 123207,
-	LevelSetSmoothTypeId = 123208,
-	LastTypeId = 123399
+
+	public :
+
+		explicit LevelSetSmooth( const std::string &name = defaultName<LevelSetSmooth>() );
+		~LevelSetSmooth() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferVDB::LevelSetSmooth, LevelSetSmoothTypeId, GafferScene::Deformer );
+
+		enum class Mode
+		{
+			Box = 0,
+			Gaussian = 1,
+			Median = 2,
+			MeanCurvature = 3,
+			Laplacian = 4,
+			Fillet = 5
+		};
+
+		Gaffer::StringPlug *gridsPlug();
+		const Gaffer::StringPlug *gridsPlug() const;
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
+
+		Gaffer::IntPlug *radiusPlug();
+		const Gaffer::IntPlug *radiusPlug() const;
+
+		Gaffer::IntPlug *iterationsPlug();
+		const Gaffer::IntPlug *iterationsPlug() const;
+
+	protected :
+
+		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
+		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
+		Gaffer::ValuePlug::CachePolicy processedObjectComputeCachePolicy() const override;
+
+		bool adjustBounds() const override;
+
+	private:
+
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( LevelSetSmooth )
 
 } // namespace GafferVDB

--- a/python/GafferVDBTest/LevelSetSmoothTest.py
+++ b/python/GafferVDBTest/LevelSetSmoothTest.py
@@ -1,0 +1,385 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import pathlib
+import time
+
+import IECore
+import IECoreVDB
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferVDB
+import GafferVDBTest
+
+## \todo Remove from Gaffer 1.8 once we're building with OpenVDB 12 as a minimum.
+try :
+	import openvdb
+	filletAvailable = True
+except ImportError :
+	filletAvailable = False
+
+class LevelSetSmoothTest( GafferVDBTest.VDBTestCase ) :
+
+	def testAffects( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		cs = GafferTest.CapturingSlot( smooth.plugDirtiedSignal() )
+
+		def checkAffected( expected ) :
+
+			self.assertEqual(
+				{ i[0].getName() for i in cs if i[0].parent() == smooth["out"] },
+				set( expected )
+			)
+			del cs[:]
+
+		smooth["iterations"].setValue( 2 )
+		checkAffected( [ "object", "bound", "childBounds" ] )
+
+		smooth["radius"].setValue( 2 )
+		checkAffected( [ "object", "bound", "childBounds" ] )
+
+		smooth["mode"].setValue( GafferVDB.LevelSetSmooth.Mode.Gaussian )
+		checkAffected( [ "object", "bound", "childBounds" ] )
+
+		smooth["adjustBounds"].setValue( False )
+		checkAffected( [ "bound", "childBounds" ] )
+
+	def testSmoothing( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		inputLevelSet = meshToLevelSet["out"].object( "/cube" )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		smoothedLevelSet = smooth["out"].object( "/cube" )
+		self.assertNotEqual( smoothedLevelSet, inputLevelSet )
+
+		smooth["iterations"].setValue( 4 )
+
+		furtherSmoothedLevelSet = smooth["out"].object( "/cube" )
+		self.assertNotEqual( furtherSmoothedLevelSet, smoothedLevelSet )
+		self.assertNotEqual( furtherSmoothedLevelSet, inputLevelSet )
+
+		smooth["radius"].setValue( 2 )
+
+		increasedRadiusLevelSet = smooth["out"].object( "/cube" )
+		self.assertNotEqual( increasedRadiusLevelSet, furtherSmoothedLevelSet )
+		self.assertNotEqual( increasedRadiusLevelSet, smoothedLevelSet )
+		self.assertNotEqual( increasedRadiusLevelSet, inputLevelSet )
+
+	def testSmoothingModes( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		inputLevelSet = meshToLevelSet["out"].object( "/cube" )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		for mode in GafferVDB.LevelSetSmooth.Mode.values.values() :
+			with self.subTest( mode = mode ) :
+
+				if mode == GafferVDB.LevelSetSmooth.Mode.Fillet and not filletAvailable :
+					continue
+
+				smooth["mode"].setValue( mode )
+
+				smoothedLevelSet = smooth["out"].object( "/cube" )
+				self.assertIsInstance( smoothedLevelSet, IECoreVDB.VDBObject )
+				self.assertEqual( smoothedLevelSet.gridNames(), [ "surface" ] )
+
+				self.assertNotEqual( smoothedLevelSet, inputLevelSet )
+
+				grid = smoothedLevelSet.findGrid( "surface" )
+				self.assertEqual( grid.gridClass, "level set" )
+
+	def testRadiusDoesntAffectMeanCurvatureLaplacianAndFillet( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		for mode in GafferVDB.LevelSetSmooth.Mode.values.values() :
+			with self.subTest( mode = mode ) :
+
+				if mode == GafferVDB.LevelSetSmooth.Mode.Fillet and not filletAvailable :
+					continue
+
+				smooth["mode"].setValue( mode )
+
+				smooth["radius"].setValue( 1 )
+				smoothedRadius1 = smooth["out"].object( "/cube" )
+				hashRadius1 = smooth["out"].objectHash( "/cube" )
+
+				smooth["radius"].setValue( 2 )
+				smoothedRadius2 = smooth["out"].object( "/cube" )
+				hashRadius2 = smooth["out"].objectHash( "/cube" )
+
+				if mode in ( GafferVDB.LevelSetSmooth.Mode.MeanCurvature, GafferVDB.LevelSetSmooth.Mode.Laplacian, GafferVDB.LevelSetSmooth.Mode.Fillet ) :
+					self.assertEqual( smoothedRadius1, smoothedRadius2 )
+					self.assertEqual( hashRadius1, hashRadius2 )
+				else :
+					self.assertNotEqual( smoothedRadius1, smoothedRadius2 )
+					self.assertNotEqual( hashRadius1, hashRadius2 )
+
+	def testBounds( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		self.assertNotEqual( smooth["out"].bound( "/cube" ), meshToLevelSet["out"].bound( "/cube" ) )
+
+		smooth["adjustBounds"].setValue( False )
+
+		self.assertEqual( smooth["out"].bound( "/cube" ), meshToLevelSet["out"].bound( "/cube" ) )
+
+	def testZeroIterations( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		smooth["iterations"].setValue( 0 )
+
+		self.assertScenesEqual( smooth["out"], meshToLevelSet["out"] )
+		self.assertSceneHashesEqual( smooth["out"], meshToLevelSet["out"] )
+
+	def testZeroRadius( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		smooth["radius"].setValue( 0 )
+
+		for mode in GafferVDB.LevelSetSmooth.Mode.values.values() :
+			with self.subTest( mode = mode ) :
+
+				if mode == GafferVDB.LevelSetSmooth.Mode.Fillet and not filletAvailable :
+					continue
+
+				smooth["mode"].setValue( mode )
+
+				if mode in ( GafferVDB.LevelSetSmooth.Mode.MeanCurvature, GafferVDB.LevelSetSmooth.Mode.Laplacian, GafferVDB.LevelSetSmooth.Mode.Fillet ) :
+
+					self.assertNotEqual( smooth["out"].object( "/cube" ), meshToLevelSet["out"].object( "/cube" ) )
+					self.assertNotEqual( smooth["out"].objectHash( "/cube" ), meshToLevelSet["out"].objectHash( "/cube" ) )
+
+				else :
+
+					self.assertScenesEqual( smooth["out"], meshToLevelSet["out"] )
+					self.assertSceneHashesEqual( smooth["out"], meshToLevelSet["out"] )
+
+	def testGridName( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube"] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+		meshToLevelSet["grid"].setValue( "custom" )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( meshToLevelSet["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+		smooth["grids"].setValue( "custom" )
+
+		smoothedLevelSet = smooth["out"].object( "/cube" )
+		self.assertIsInstance( smoothedLevelSet, IECoreVDB.VDBObject )
+		self.assertEqual( smoothedLevelSet.gridNames(), [ "custom" ] )
+		self.assertNotEqual( smoothedLevelSet, meshToLevelSet["out"].object( "/cube" ) )
+
+		smooth["grids"].setValue( "missing" )
+		missingGridLevelSet = smooth["out"].object( "/cube" )
+
+		self.assertIsInstance( missingGridLevelSet, IECoreVDB.VDBObject )
+		self.assertEqual( missingGridLevelSet.gridNames(), [ "custom" ] )
+		self.assertEqual( missingGridLevelSet, meshToLevelSet["out"].object( "/cube" ) )
+
+		smooth["grids"].setValue( "*" )
+		wildcardLevelSet = smooth["out"].object( "/cube" )
+		self.assertIsInstance( wildcardLevelSet, IECoreVDB.VDBObject )
+		self.assertEqual( wildcardLevelSet.gridNames(), [ "custom" ] )
+		self.assertEqual( wildcardLevelSet, smoothedLevelSet )
+
+	def testNonVDBsPassThrough( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( cube["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+
+		self.assertEqual( smooth["out"].object( "/cube" ), smooth["in"].object( "/cube" ) )
+
+	def testCancellation( self ) :
+
+		# Start a computation in the background, and
+		# then cancel it.
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+
+		script["pathFilter"] = GafferScene.PathFilter()
+		script["pathFilter"]["paths"].setValue( IECore.StringVectorData( [ "/sphere"] ) )
+
+		script["meshToLevelSet"] = GafferVDB.MeshToLevelSet()
+		script["meshToLevelSet"]["in"].setInput( script["sphere"]["out"] )
+		script["meshToLevelSet"]["filter"].setInput( script["pathFilter"]["out"] )
+		script["meshToLevelSet"]["voxelSize"].setValue( 0.01 )
+
+		script["smooth"] = GafferVDB.LevelSetSmooth()
+		script["smooth"]["in"].setInput( script["meshToLevelSet"]["out"] )
+		script["smooth"]["filter"].setInput( script["pathFilter"]["out"] )
+		script["smooth"]["iterations"].setValue( 4 )
+
+		def computeObject() :
+
+			script["smooth"]["out"].object( "/sphere" )
+
+		backgroundTask = Gaffer.ParallelAlgo.callOnBackgroundThread(
+			script["smooth"]["out"]["object"], computeObject
+		)
+		# Delay so that the computation actually starts, rather
+		# than being avoided entirely.
+		time.sleep( 0.2 )
+		backgroundTask.cancelAndWait()
+
+		# Get the value again. If cancellation has been managed properly, this
+		# will do a fresh compute to get a full result, and not pull a half-finished
+		# result out of the cache.
+		vdbAfterCancellation = script["smooth"]["out"].object( "/sphere" )
+
+		# Compare against a result computed from scratch.
+		Gaffer.ValuePlug.clearCache()
+		vdb = script["smooth"]["out"].object( "/sphere" )
+
+		self.assertEqual(
+			vdbAfterCancellation.findGrid( "surface" ).activeVoxelCount(),
+			vdb.findGrid( "surface" ).activeVoxelCount(),
+		)
+
+	def testParallelGetValueComputesObjectOnce( self ) :
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( pathlib.Path( __file__ ).parent / "data" / "sphere.vdb" )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/vdb" ] ) )
+
+		smooth = GafferVDB.LevelSetSmooth()
+		smooth["in"].setInput( reader["out"] )
+		smooth["filter"].setInput( pathFilter["out"] )
+		smooth["grids"].setValue( "ls_sphere" )
+
+		self.assertParallelGetValueComputesObjectOnce( smooth["out"], "/vdb" )

--- a/python/GafferVDBTest/__init__.py
+++ b/python/GafferVDBTest/__init__.py
@@ -44,3 +44,4 @@ from .SphereLevelSetTest import SphereLevelSetTest
 from .PointsToLevelSetTest import PointsToLevelSetTest
 from .VolumeScatterTest import VolumeScatterTest
 from .DeleteGridsTest import DeleteGridsTest
+from .LevelSetSmoothTest import LevelSetSmoothTest

--- a/python/GafferVDBUI/LevelSetSmoothUI.py
+++ b/python/GafferVDBUI/LevelSetSmoothUI.py
@@ -1,0 +1,116 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferVDB
+
+Gaffer.Metadata.registerNode(
+
+	GafferVDB.LevelSetSmooth,
+	"description",
+	"""
+	Smooths a level set VDB.
+	""",
+
+	"layout:activator:modeHasRadius", lambda node : node["mode"].getValue() in ( GafferVDB.LevelSetSmooth.Mode.Box, GafferVDB.LevelSetSmooth.Mode.Gaussian, GafferVDB.LevelSetSmooth.Mode.Median ),
+
+	plugs = {
+
+		"grids" : {
+
+			"description" :
+			"""
+			The names of the level set grids to smooth in the VDB object.
+			Names should be separated by spaces and may contain any of
+			Gaffer's standard wildcards.
+			"""
+
+		},
+
+		"mode" : {
+
+			"description" :
+			"""
+			The smoothing filter to apply to the level set.
+
+			- Box : A separable box/mean filter. Fast to compute and provides simple and predictable
+			  smoothing.
+			- Gaussian : Produces smooth, gradual blurring, with nearby voxels contributing more
+			  strongly than distant ones. Approximately four times slower than Box.
+			- Median : Suppresses noise and outliers while generally preserving sharp details better than
+			  Box or Gaussian. Relatively slow because the filter is not separable.
+			- Mean Curvature : Smooths the surface according to how sharply it bends, affecting bumps and
+			  sharp areas more strongly than flatter areas.
+			- Laplacian : Diffuses values to neighbouring voxels, often producing similar results to
+			  Mean Curvature while being faster to compute.
+			- Fillet : Rounds off concave edges while leaving other areas unchanged. Useful for
+			  smoothing internal corners and junctions between intersecting surfaces.
+			""",
+
+			"preset:Box" : GafferVDB.LevelSetSmooth.Mode.Box,
+			"preset:Gaussian" : GafferVDB.LevelSetSmooth.Mode.Gaussian,
+			"preset:Median" : GafferVDB.LevelSetSmooth.Mode.Median,
+			"preset:Mean Curvature" : GafferVDB.LevelSetSmooth.Mode.MeanCurvature,
+			"preset:Laplacian" : GafferVDB.LevelSetSmooth.Mode.Laplacian,
+			"preset:Fillet" : GafferVDB.LevelSetSmooth.Mode.Fillet,
+
+			"plugValueWidget:type" : "GafferUI.PresetsPlugValueWidget"
+
+		},
+
+		"radius" : {
+
+			"description" :
+			"""
+			The radius of the Box, Gaussian, and Median smoothing kernels in voxel units.
+			""",
+
+			"layout:activator" : "modeHasRadius",
+
+		},
+
+		"iterations" : {
+
+			"description" :
+			"""
+			The number of smoothing iterations.
+			""",
+
+		},
+
+	}
+
+)

--- a/python/GafferVDBUI/__init__.py
+++ b/python/GafferVDBUI/__init__.py
@@ -50,5 +50,6 @@ from . import SphereLevelSetUI
 from . import PointsToLevelSetUI
 from . import VolumeScatterUI
 from . import VDBInspector
+from . import LevelSetSmoothUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferVDBUI" )

--- a/src/GafferVDB/LevelSetSmooth.cpp
+++ b/src/GafferVDB/LevelSetSmooth.cpp
@@ -1,0 +1,283 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of Image Engine Design Inc nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferVDB/LevelSetSmooth.h"
+
+#include "GafferVDB/Interrupter.h"
+
+#include "IECoreVDB/VDBObject.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "openvdb/openvdb.h"
+#include "openvdb/tools/LevelSetFilter.h"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreVDB;
+using namespace Gaffer;
+using namespace GafferVDB;
+
+namespace
+{
+
+template<typename GridType>
+void filterGrid( GridType &grid, LevelSetSmooth::Mode mode, int radius, int iterations, const IECore::Canceller *canceller )
+{
+	Interrupter interrupter( canceller );
+	openvdb::tools::LevelSetFilter<GridType, GridType, Interrupter> filter( grid, &interrupter );
+
+	for( int i = 0; i < iterations; ++i )
+	{
+		Canceller::check( canceller );
+
+		switch( mode )
+		{
+			case GafferVDB::LevelSetSmooth::Mode::Box :
+				filter.mean( radius );
+				break;
+			case GafferVDB::LevelSetSmooth::Mode::Gaussian :
+				filter.gaussian( radius );
+				break;
+			case GafferVDB::LevelSetSmooth::Mode::Median :
+				filter.median( radius );
+				break;
+			case GafferVDB::LevelSetSmooth::Mode::MeanCurvature :
+				filter.meanCurvature();
+				break;
+			case GafferVDB::LevelSetSmooth::Mode::Laplacian :
+				filter.laplacian();
+				break;
+			case GafferVDB::LevelSetSmooth::Mode::Fillet :
+#if OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER > 11
+				filter.fillet();
+#else
+				/// \todo Remove from Gaffer 1.8 once we're building with OpenVDB 12 as a minimum.
+				throw IECore::Exception( "Fillet mode is only available when Gaffer is built with OpenVDB 12 and above." );
+#endif
+				break;
+		}
+	}
+}
+
+bool affectedByRadius( LevelSetSmooth::Mode mode )
+{
+	return
+		mode == GafferVDB::LevelSetSmooth::Mode::Box ||
+		mode == GafferVDB::LevelSetSmooth::Mode::Gaussian ||
+		mode == GafferVDB::LevelSetSmooth::Mode::Median;
+}
+
+} // namespace
+
+GAFFER_NODE_DEFINE_TYPE( LevelSetSmooth );
+
+size_t LevelSetSmooth::g_firstPlugIndex = 0;
+
+LevelSetSmooth::LevelSetSmooth( const std::string &name )
+	:	Deformer( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "grids", Plug::In, "surface" ) );
+	addChild( new IntPlug( "mode", Plug::In, (int)Mode::Box, (int)Mode::Box, (int)Mode::Fillet ) );
+	addChild( new IntPlug( "radius", Plug::In, 1, 0 ) );
+	addChild( new IntPlug( "iterations", Plug::In, 1, 0 ) );
+}
+
+LevelSetSmooth::~LevelSetSmooth()
+{
+}
+
+Gaffer::StringPlug *LevelSetSmooth::gridsPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::StringPlug *LevelSetSmooth::gridsPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+Gaffer::IntPlug *LevelSetSmooth::modePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::IntPlug *LevelSetSmooth::modePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::IntPlug *LevelSetSmooth::radiusPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::IntPlug *LevelSetSmooth::radiusPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::IntPlug *LevelSetSmooth::iterationsPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::IntPlug *LevelSetSmooth::iterationsPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+bool LevelSetSmooth::affectsProcessedObject( const Gaffer::Plug *input ) const
+{
+	return
+		Deformer::affectsProcessedObject( input ) ||
+		input == gridsPlug() ||
+		input == modePlug() ||
+		input == radiusPlug() ||
+		input == iterationsPlug()
+	;
+}
+
+void LevelSetSmooth::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	const bool requiresRadius = affectedByRadius( (Mode)modePlug()->getValue() );
+
+	if( iterationsPlug()->getValue() == 0 || ( requiresRadius && radiusPlug()->getValue() == 0 ) )
+	{
+		h = inPlug()->objectPlug()->hash();
+		return;
+	}
+
+	Deformer::hashProcessedObject( path, context, h );
+
+	iterationsPlug()->hash( h );
+	gridsPlug()->hash( h );
+	modePlug()->hash( h );
+
+	if( requiresRadius )
+	{
+		radiusPlug()->hash( h );
+	}
+}
+
+IECore::ConstObjectPtr LevelSetSmooth::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
+{
+	const int iterations = iterationsPlug()->getValue();
+	if( iterations == 0 )
+	{
+		return inputObject;
+	}
+
+	const Mode mode = (Mode)modePlug()->getValue();
+	const int radius = radiusPlug()->getValue();
+	if( affectedByRadius( mode ) && radius == 0 )
+	{
+		return inputObject;
+	}
+
+	const VDBObject *vdbObject = runTimeCast<const VDBObject>( inputObject );
+	if( !vdbObject )
+	{
+		return inputObject;
+	}
+
+	const std::string grids = gridsPlug()->getValue();
+	VDBObjectPtr result;
+
+	for( const auto &gridName : vdbObject->gridNames() )
+	{
+		if( !StringAlgo::matchMultiple( gridName, grids ) )
+		{
+			continue;
+		}
+
+		openvdb::GridBase::ConstPtr gridBase = vdbObject->findGrid( gridName );
+		if( gridBase->getGridClass() != openvdb::GRID_LEVEL_SET )
+		{
+			throw IECore::Exception( fmt::format( "Grid '{}' is not a level set", gridName ) );
+		}
+
+		openvdb::GridBase::Ptr newGrid;
+
+		if( openvdb::FloatGrid::ConstPtr floatGrid = openvdb::GridBase::constGrid<openvdb::FloatGrid>( gridBase ) )
+		{
+			openvdb::FloatGrid::Ptr newFloatGrid = openvdb::GridBase::grid<openvdb::FloatGrid> ( floatGrid->deepCopyGrid() );
+			newGrid = newFloatGrid;
+			filterGrid( *newFloatGrid, mode, radius, iterations, context->canceller() );
+		}
+		else if( openvdb::DoubleGrid::ConstPtr doubleGrid = openvdb::GridBase::constGrid<openvdb::DoubleGrid>( gridBase ) )
+		{
+			openvdb::DoubleGrid::Ptr newDoubleGrid = openvdb::GridBase::grid<openvdb::DoubleGrid>( doubleGrid->deepCopyGrid() );
+			newGrid = newDoubleGrid;
+			filterGrid( *newDoubleGrid, mode, radius, iterations, context->canceller() );
+		}
+		else
+		{
+			throw IECore::Exception( fmt::format( "Unable to smooth LevelSet grid: '{}' with type: {}", gridName, gridBase->type() ) );
+		}
+
+		// If the interrupter has stopped the VDB operation, throw
+		// so that we don't return a partial result.
+		Canceller::check( context->canceller() );
+
+		if( !result )
+		{
+			result = vdbObject->copy();
+		}
+		result->insertGrid( newGrid );
+	}
+
+	return result ? result.get() : inputObject;
+}
+
+Gaffer::ValuePlug::CachePolicy LevelSetSmooth::processedObjectComputeCachePolicy() const
+{
+	return ValuePlug::CachePolicy::TaskCollaboration;
+}
+
+bool LevelSetSmooth::adjustBounds() const
+{
+	return
+		Deformer::adjustBounds() &&
+		iterationsPlug()->getValue() > 0 &&
+		( !affectedByRadius( (Mode)modePlug()->getValue() ) || radiusPlug()->getValue() > 0 )
+	;
+}

--- a/src/GafferVDBModule/GafferVDBModule.cpp
+++ b/src/GafferVDBModule/GafferVDBModule.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferVDB/DeleteGrids.h"
 #include "GafferVDB/LevelSetOffset.h"
+#include "GafferVDB/LevelSetSmooth.h"
 #include "GafferVDB/LevelSetToMesh.h"
 #include "GafferVDB/MeshToLevelSet.h"
 #include "GafferVDB/PointsGridToPoints.h"
@@ -65,6 +66,18 @@ BOOST_PYTHON_MODULE( _GafferVDB )
 		enum_<DeleteGrids::Mode>( "Mode" )
 			.value( "Keep", DeleteGrids::Keep )
 			.value( "Delete", DeleteGrids::Delete )
+		;
+	}
+
+	{
+		scope s = GafferBindings::DependencyNodeClass<LevelSetSmooth>();
+		enum_<LevelSetSmooth::Mode>( "Mode" )
+			.value( "Box", LevelSetSmooth::Mode::Box )
+			.value( "Gaussian", LevelSetSmooth::Mode::Gaussian )
+			.value( "Median", LevelSetSmooth::Mode::Median )
+			.value( "MeanCurvature", LevelSetSmooth::Mode::MeanCurvature )
+			.value( "Laplacian", LevelSetSmooth::Mode::Laplacian )
+			.value( "Fillet", LevelSetSmooth::Mode::Fillet )
 		;
 	}
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -503,6 +503,7 @@ nodeMenu.append( "/VDB/Level Set To Mesh", GafferVDB.LevelSetToMesh, searchText 
 nodeMenu.append( "/VDB/Mesh To Level Set", GafferVDB.MeshToLevelSet, searchText = "MeshToLevelSet" )
 nodeMenu.append( "/VDB/Points To Level Set", GafferVDB.PointsToLevelSet, searchText = "PointsToLevelSet" )
 nodeMenu.append( "/VDB/Level Set Offset", GafferVDB.LevelSetOffset, searchText = "LevelSetOffset" )
+nodeMenu.append( "/VDB/Level Set Smooth", GafferVDB.LevelSetSmooth, searchText = "LevelSetSmooth" )
 nodeMenu.append( "/VDB/Points Grid To Points", GafferVDB.PointsGridToPoints, searchText = "PointsGridToPoints" )
 nodeMenu.append( "/VDB/Sphere Level Set", GafferVDB.SphereLevelSet, searchText="SphereLevelSet")
 nodeMenu.append( "/VDB/Volume Scatter", GafferVDB.VolumeScatter, searchText = "VolumeScatter" )


### PR DESCRIPTION
A little node based on LevelSetOffset that wraps `openvdb::tools::LevelSetFilter` to expose various smoothing operations for level sets.