### PR TITLE
SceneHistoryUI : Add NodeEditor location drop target

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - SetFilter, Scene Editors : Set expressions containing operators are now editable via drag and drop of set names.
+- NodeEditor : Scene locations can now be dropped to pin the editor to their source node. Locations may be dragged from the Viewer, AttributeEditor, LightEditor, HierarchyView and LightLinkingEditor.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 
 - LevelSetOffset : Fixed crash when attempting to offset grid types other than `FloatGrid`.
 - AttributeTweaks, CustomAttributes, OptionTweaks, CustomOptions, OptionQuery : Fixed contexts used by "From Scene", "From Selected" and "From Affected" menu items. This fixes errors caused by missing context variables (such as script variables).
+- GraphEditor : Stopped drag & dropped scene locations from navigating to private internal nodes.
 
 Documentation
 -------------

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -72,10 +72,13 @@ def connectToEditor( editor ) :
 		editor.keyPressSignal().connect( __hierarchyViewKeyPress )
 	elif isinstance( editor, GafferUI.NodeEditor ) :
 		editor.keyPressSignal().connect( __nodeEditorKeyPress )
-	elif isinstance( editor, GafferUI.GraphEditor ) :
-		editor.graphGadget().dragEnterSignal().connect( __graphGadgetDragEnter )
-		editor.graphGadget().dragLeaveSignal().connect( __graphGadgetDragLeave )
-		editor.graphGadget().dropSignal().connect( functools.partial( __graphGadgetDrop, graphEditor = weakref.ref( editor ) ) )
+		editor.dragEnterSignal().connect( __locationDragEnter )
+		editor.dragLeaveSignal().connect( __locationDragLeave )
+		editor.dropSignal().connect( __locationDrop )
+	elif isinstance( editor, ( GafferUI.GraphEditor ) ) :
+		editor.graphGadget().dragEnterSignal().connect( __locationDragEnter )
+		editor.graphGadget().dragLeaveSignal().connect( __locationDragLeave )
+		editor.graphGadget().dropSignal().connect( functools.partial( __locationDrop, graphEditor = weakref.ref( editor ) ) )
 
 ##########################################################################
 # Internal implementation
@@ -258,7 +261,7 @@ def __dropLocationData( event ) :
 		"context" : sourceEditor.context(),
 	}
 
-def __graphGadgetDragEnter( graphGadget, event ) :
+def __locationDragEnter( target, event ) :
 
 	if __dropLocationData( event ) is None :
 		return False
@@ -266,26 +269,27 @@ def __graphGadgetDragEnter( graphGadget, event ) :
 	GafferUI.Pointer.setCurrent( "targetObjects" )
 	return True
 
-def __graphGadgetDragLeave( graphGadget, event ) :
+def __locationDragLeave( target, event ) :
 
-	if __dropLocationData( event ) is not None :
-		if event.destinationWidget is None :
-			# Hack to restore (what we assume to have been) the original
-			# drag pointer. We don't do this when another widget has
-			# accepted the drag, because it would clobber any pointer
-			# change they made in `dragEnter`. But of course that means
-			# that if another widget _has_ accepted the drag but hasn't
-			# changed the pointer themselves (maybe they use highlighting
-			# instead), they will be stuck with the wrong pointer.
-			## \todo This is far too fragile. We need to manage
-			# pointer restoration at a higher level, in Widget.py's
-			# _EventFilter (and ViewportGadget's handlers).
-			GafferUI.Pointer.setCurrent( "objects" )
-		return True
+	if __dropLocationData( event ) is None :
+		return False
 
-	return False
+	if event.destinationWidget is None :
+		# Hack to restore (what we assume to have been) the original
+		# drag pointer. We don't do this when another widget has
+		# accepted the drag, because it would clobber any pointer
+		# change they made in `dragEnter`. But of course that means
+		# that if another widget _has_ accepted the drag but hasn't
+		# changed the pointer themselves (maybe they use highlighting
+		# instead), they will be stuck with the wrong pointer.
+		## \todo This is far too fragile. We need to manage
+		# pointer restoration at a higher level, in Widget.py's
+		# _EventFilter (and ViewportGadget's handlers).
+		GafferUI.Pointer.setCurrent( "objects" )
 
-def __graphGadgetDrop( graphGadget, event, graphEditor ) :
+	return True
+
+def __locationDrop( target, event, graphEditor = None ) :
 
 	dropLocationData = __dropLocationData( event )
 	if dropLocationData is None :
@@ -295,12 +299,16 @@ def __graphGadgetDrop( graphGadget, event, graphEditor ) :
 		sourceScene = GafferScene.SceneAlgo.source( dropLocationData["scene"], dropLocationData["path"] )
 
 	if sourceScene is not None :
-		graphGadget.setRoot( sourceScene.node().parent() )
-		## \todo The `frame()` method should probably be on the GraphGadget itself, and the `at`
-		# functionality should be made public.
-		graphEditor()._GraphEditor__frame(
-			[ sourceScene.node() ],
-			at = imath.V2f( GafferUI.Widget.mousePosition( relativeTo = graphEditor() ) )
-		)
+		if isinstance( target, GafferUI.GraphGadget ) :
+			target.setRoot( sourceScene.node().parent() )
+			## \todo The `frame()` method should probably be on the GraphGadget itself, and the `at`
+			# functionality should be made public.
+			graphEditor()._GraphEditor__frame(
+				[ sourceScene.node() ],
+				at = imath.V2f( GafferUI.Widget.mousePosition( relativeTo = graphEditor() ) )
+			)
+		else :
+			assert( isinstance( target, GafferUI.NodeEditor ) )
+			target.setNodeSet( Gaffer.StandardSet( [ sourceScene.node() ] ) )
 
 	return True

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -255,7 +255,7 @@ def __dropLocationData( event ) :
 	return {
 		"path" : event.data[0],
 		"scene" : scene,
-		"context" : sourceEditor.getContext(),
+		"context" : sourceEditor.context(),
 	}
 
 def __graphGadgetDragEnter( graphGadget, event ) :

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -299,16 +299,17 @@ def __locationDrop( target, event, graphEditor = None ) :
 		sourceScene = GafferScene.SceneAlgo.source( dropLocationData["scene"], dropLocationData["path"] )
 
 	if sourceScene is not None :
+		sourceNode = Gaffer.MetadataAlgo.firstViewableNode( sourceScene )
 		if isinstance( target, GafferUI.GraphGadget ) :
-			target.setRoot( sourceScene.node().parent() )
+			target.setRoot( sourceNode.parent() )
 			## \todo The `frame()` method should probably be on the GraphGadget itself, and the `at`
 			# functionality should be made public.
 			graphEditor()._GraphEditor__frame(
-				[ sourceScene.node() ],
+				[ sourceNode ],
 				at = imath.V2f( GafferUI.Widget.mousePosition( relativeTo = graphEditor() ) )
 			)
 		else :
 			assert( isinstance( target, GafferUI.NodeEditor ) )
-			target.setNodeSet( Gaffer.StandardSet( [ sourceScene.node() ] ) )
+			target.setNodeSet( Gaffer.StandardSet( [ sourceNode ] ) )
 
 	return True

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -35,6 +35,9 @@
 ##########################################################################
 
 import functools
+import weakref
+
+import imath
 
 import IECore
 import IECoreScene
@@ -69,6 +72,10 @@ def connectToEditor( editor ) :
 		editor.keyPressSignal().connect( __hierarchyViewKeyPress )
 	elif isinstance( editor, GafferUI.NodeEditor ) :
 		editor.keyPressSignal().connect( __nodeEditorKeyPress )
+	elif isinstance( editor, GafferUI.GraphEditor ) :
+		editor.graphGadget().dragEnterSignal().connect( __graphGadgetDragEnter )
+		editor.graphGadget().dragLeaveSignal().connect( __graphGadgetDragLeave )
+		editor.graphGadget().dropSignal().connect( functools.partial( __graphGadgetDrop, graphEditor = weakref.ref( editor ) ) )
 
 ##########################################################################
 # Internal implementation
@@ -220,3 +227,80 @@ def __nodeEditorKeyPress( nodeEditor, event ) :
 		if selectedPath is not None :
 			__editTweaksNode( nodeEditor.scriptNode().context(), scene, selectedPath, nodeEditor )
 		return True
+
+def __dropLocationData( event ) :
+
+	if (
+		not isinstance( event.data, IECore.StringVectorData ) or
+		len( event.data ) != 1 or
+		not event.data[0].startswith( "/" ) or
+		event.sourceWidget is None
+	) :
+		return None
+
+	scene = None
+	sourceEditor = event.sourceWidget.ancestor( GafferUI.Editor )
+	if isinstance( sourceEditor, GafferUI.Viewer ) :
+		if isinstance( event.sourceGadget, GafferSceneUI.SceneGadget ) :
+			scene = sourceEditor.view()["in"].getInput()
+	elif isinstance(
+		sourceEditor,
+		( GafferSceneUI.HierarchyView, GafferSceneUI.LightEditor, GafferSceneUI.AttributeEditor, GafferSceneUI.LightLinkingEditor )
+	) :
+		scene = sourceEditor.settings()["in"].getInput()
+
+	if scene is None :
+		return None
+
+	return {
+		"path" : event.data[0],
+		"scene" : scene,
+		"context" : sourceEditor.getContext(),
+	}
+
+def __graphGadgetDragEnter( graphGadget, event ) :
+
+	if __dropLocationData( event ) is None :
+		return False
+
+	GafferUI.Pointer.setCurrent( "targetObjects" )
+	return True
+
+def __graphGadgetDragLeave( graphGadget, event ) :
+
+	if __dropLocationData( event ) is not None :
+		if event.destinationWidget is None :
+			# Hack to restore (what we assume to have been) the original
+			# drag pointer. We don't do this when another widget has
+			# accepted the drag, because it would clobber any pointer
+			# change they made in `dragEnter`. But of course that means
+			# that if another widget _has_ accepted the drag but hasn't
+			# changed the pointer themselves (maybe they use highlighting
+			# instead), they will be stuck with the wrong pointer.
+			## \todo This is far too fragile. We need to manage
+			# pointer restoration at a higher level, in Widget.py's
+			# _EventFilter (and ViewportGadget's handlers).
+			GafferUI.Pointer.setCurrent( "objects" )
+		return True
+
+	return False
+
+def __graphGadgetDrop( graphGadget, event, graphEditor ) :
+
+	dropLocationData = __dropLocationData( event )
+	if dropLocationData is None :
+		return False
+
+	with dropLocationData["context"] :
+		sourceScene = GafferScene.SceneAlgo.source( dropLocationData["scene"], dropLocationData["path"] )
+
+	if sourceScene is not None :
+		graphGadget.setRoot( sourceScene.node().parent() )
+		## \todo The `frame()` method should probably be on the GraphGadget itself, and the `at`
+		# functionality should be made public.
+		graphEditor()._GraphEditor__frame(
+			[ sourceScene.node() ],
+			at = imath.V2f( GafferUI.Widget.mousePosition( relativeTo = graphEditor() ) )
+		)
+
+	return True

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -38,7 +38,6 @@
 import functools
 import pathlib
 import re
-import weakref
 
 import imath
 
@@ -240,95 +239,10 @@ def __fileDrop( graphGadget, event ) :
 
 	return True
 
-##########################################################################
-# Scene location drop handler
-##########################################################################
-
-def __dropLocationData( event ) :
-
-	if (
-		not isinstance( event.data, IECore.StringVectorData ) or
-		len( event.data ) != 1 or
-		not event.data[0].startswith( "/" ) or
-		event.sourceWidget is None
-	) :
-		return None
-
-	scene = None
-	sourceEditor = event.sourceWidget.ancestor( GafferUI.Editor )
-	if isinstance( sourceEditor, GafferUI.Viewer ) :
-		if isinstance( event.sourceGadget, GafferSceneUI.SceneGadget ) :
-			scene = sourceEditor.view()["in"].getInput()
-	elif isinstance(
-		sourceEditor,
-		( GafferSceneUI.HierarchyView, GafferSceneUI.LightEditor, GafferSceneUI.AttributeEditor, GafferSceneUI.LightLinkingEditor )
-	) :
-		scene = sourceEditor.settings()["in"].getInput()
-
-	if scene is None :
-		return None
-
-	return {
-		"path" : event.data[0],
-		"scene" : scene,
-		"context" : sourceEditor.getContext(),
-	}
-
-def __locationDragEnter( graphGadget, event ) :
-
-	if __dropLocationData( event ) is None :
-		return False
-
-	GafferUI.Pointer.setCurrent( "targetObjects" )
-	return True
-
-def __locationDragLeave( graphGadget, event ) :
-
-	if __dropLocationData( event ) is not None :
-		if event.destinationWidget is None :
-			# Hack to restore (what we assume to have been) the original
-			# drag pointer. We don't do this when another widget has
-			# accepted the drag, because it would clobber any pointer
-			# change they made in `dragEnter`. But of course that means
-			# that if another widget _has_ accepted the drag but hasn't
-			# changed the pointer themselves (maybe they use highlighting
-			# instead), they will be stuck with the wrong pointer.
-			## \todo This is far too fragile. We need to manage
-			# pointer restoration at a higher level, in Widget.py's
-			# _EventFilter (and ViewportGadget's handlers).
-			GafferUI.Pointer.setCurrent( "objects" )
-		return True
-
-	return False
-
-def __locationDrop( graphGadget, event, graphEditor ) :
-
-	dropLocationData = __dropLocationData( event )
-	if dropLocationData is None :
-		return False
-
-	with dropLocationData["context"] :
-		sourceScene = GafferScene.SceneAlgo.source( dropLocationData["scene"], dropLocationData["path"] )
-
-	if sourceScene is not None :
-		graphGadget.setRoot( sourceScene.node().parent() )
-		## \todo The `frame()` method should probably be on the GraphGadget itself, and the `at`
-		# functionality should be made public.
-		graphEditor()._GraphEditor__frame(
-			[ sourceScene.node() ],
-			at = imath.V2f( GafferUI.Widget.mousePosition( relativeTo = graphEditor() ) )
-		)
-
-	return True
-
 def __graphEditorCreated( graphEditor ) :
 
 	graphEditor.graphGadget().dragEnterSignal().connect( __fileDragEnter )
 	graphEditor.graphGadget().dropSignal().connect( __fileDrop )
-
-	graphEditor.graphGadget().dragEnterSignal().connect( __locationDragEnter )
-	graphEditor.graphGadget().dragLeaveSignal().connect( __locationDragLeave )
-	graphEditor.graphGadget().dropSignal().connect( functools.partial( __locationDrop, graphEditor = weakref.ref( graphEditor ) ) )
 
 GafferUI.GraphEditor.instanceCreatedSignal().connect( __graphEditorCreated )
 


### PR DESCRIPTION
This rejigs SceneHistoryUI a bit to adopt the location drag&drop functionality from `startup/gui/graphEditor.py`, and then to extend it to support dropping into the NodeEditor. This provides a convenient way of pinning the NodeEditor to the source node of a location selected in the Viewer or HierarchyView.