### PR TITLE
CI : Update RenderMan 26.4 download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,7 +288,7 @@ jobs:
     - name: Install RenderMan 26.4
       run: |
         rm -r "$RMANTREE" # Free up precious disk space from the previous installation
-        ./.github/workflows/main/installRenderMan.py --version 26.4 --dailyBuildDate 2026-07-16 --outputFormat "RMANTREE={rmanTree}" >> $GITHUB_ENV
+        ./.github/workflows/main/installRenderMan.py --version 26.4 --dailyBuildDate 2026-08-15 --outputFormat "RMANTREE={rmanTree}" >> $GITHUB_ENV
       shell: bash
       env:
         RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,14 +294,14 @@ jobs:
         RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}
         RENDERMAN_DOWNLOAD_PASSWORD: ${{ secrets.RENDERMAN_DOWNLOAD_PASSWORD }}
         RENDERMAN_LICENSE_PASSPHRASE: ${{ secrets.RENDERMAN_LICENSE_PASSPHRASE }}
-      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' }}
+      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' && runner.os != 'Windows' }}
 
     - name: Build against RenderMan 26.4
       run: |
         scons -j ${{ matrix.jobs }} build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
       env:
         PYTHONUTF8: 1
-      if: ${{ env.RMANTREE != '' }}
+      if: ${{ env.RMANTREE != '' && runner.os != 'Windows' }}
 
     - name: Test against RenderMan 26.4
       # See comments for RenderMan 27.1.

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 1.6.21.x (relative to 1.6.21.4)
 ========
 
+> Note : RenderMan 26.4 is no longer supported on Windows, due to being unavailable for download from https://renderman.pixar.com.
+
 Fixes
 -----
 


### PR DESCRIPTION
This month's round of "find the latest available 26.4 build as the previous one has been removed".
