### PR TITLE
ImagePlug, Pointer : Remove redundant `ImagePrimitive.h` includes

### DIFF
--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -46,8 +46,6 @@
 #include "Gaffer/TypedObjectPlug.h"
 #include "Gaffer/TypedPlug.h"
 
-#include "IECoreImage/ImagePrimitive.h"
-
 namespace GafferImage
 {
 

--- a/include/GafferUI/Pointer.h
+++ b/include/GafferUI/Pointer.h
@@ -40,7 +40,7 @@
 
 #include "GafferUI/Export.h"
 
-#include "IECoreImage/ImagePrimitive.h"
+#include "Imath/ImathVec.h"
 
 namespace GafferUI
 {

--- a/src/GafferScene/MeshSplit.cpp
+++ b/src/GafferScene/MeshSplit.cpp
@@ -46,6 +46,7 @@
 #include "IECore/DataAlgo.h"
 #include "IECore/NullObject.h"
 #include "IECore/StringAlgo.h"
+#include "IECore/TypeTraits.h"
 
 #include "fmt/compile.h"
 #include "fmt/core.h"

--- a/src/GafferScene/PointInstancerAlgo.cpp
+++ b/src/GafferScene/PointInstancerAlgo.cpp
@@ -40,6 +40,7 @@
 
 #include "IECore/DataAlgo.h"
 #include "IECore/NullObject.h"
+#include "IECore/TypeTraits.h"
 
 #include "Imath/ImathMatrixAlgo.h"
 

--- a/src/GafferScene/SceneStats.cpp
+++ b/src/GafferScene/SceneStats.cpp
@@ -51,6 +51,7 @@
 #include "IECore/DataAlgo.h"
 #include "IECore/NullObject.h"
 #include "IECore/SimpleTypedData.h"
+#include "IECore/TypeTraits.h"
 
 #include "boost/bind.hpp"
 

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -36,7 +36,11 @@
 
 #include "GafferUI/Pointer.h"
 
+#include "IECore/Exception.h"
+
 #include "fmt/format.h"
+
+#include <map>
 
 using namespace GafferUI;
 


### PR DESCRIPTION
This revealed several nodes which were relying on transitive includes from SceneAlgo.h->ImagePlug.h, so fix those too.

Making the PR to `main`, since for 1.7.x we wouldn't want to break the compilation of any extension nodes that might have been relying on the includes too.