### PR TITLE
Reduce dependencies on IECoreImage

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,11 @@ Fixes
 - AttributeTweaks, CustomAttributes, OptionTweaks, CustomOptions, OptionQuery : Fixed contexts used by "From Scene", "From Selected" and "From Affected" menu items. This fixes errors caused by missing context variables (such as script variables).
 - GraphEditor : Stopped drag & dropped scene locations from navigating to private internal nodes.
 
+API
+---
+
+- ImageAlgo : Deprecated `image()` method. This will be removed in Gaffer 1.8.
+
 Documentation
 -------------
 

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -183,12 +183,7 @@ void parallelGatherTiles(
 /// prefer to process just one tile at a time, but useful for testing and interoperability.
 /// If the view is not specified, it must be set in the current Context.
 
-/// Returns a pointer to an IECore::ImagePrimitive. Note that the image's
-/// coordinate system will be converted to the OpenEXR and Cortex specification
-/// and have it's origin in the top left of it's display window with the positive
-/// Y axis pointing downwards rather than Gaffer's internal representation where
-/// the origin is in the bottom left of the display window with the Y axis
-/// ascending towards the top of the display window.
+/// \deprecated
 GAFFERIMAGE_API IECoreImage::ImagePrimitivePtr image( const ImagePlug *imagePlug, const std::string *viewName = nullptr );
 
 /// Return a hash that will vary if any aspect of the return from image( ... ) varies

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -851,9 +851,12 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.option( "camera", IECore.StringData( "testCamera" ) )
 		renderer.render()
 
-		image = IECoreImage.ImageReader( str( fileName ) ).read()
-		self.assertEqual( image.dataWindow, imath.Box2i( imath.V2i( 500, 250 ), imath.V2i( 1499, 749 ) ) )
-		self.assertEqual( image.displayWindow, imath.Box2i( imath.V2i( 0 ), imath.V2i( 1999, 999 ) ) )
+		imageSpec = OpenImageIO.ImageInput.open( str( fileName ) ).spec()
+		self.assertEqual( ( imageSpec.x, imageSpec.y ), ( 500, 250 ) )
+		self.assertEqual( ( imageSpec.width, imageSpec.height ), ( 1000, 500 ) )
+
+		self.assertEqual( ( imageSpec.full_x, imageSpec.full_y ), ( 0, 0 ) )
+		self.assertEqual( ( imageSpec.full_width, imageSpec.full_height ), ( 2000, 1000 ) )
 
 	def testPointsWithNormals( self ) :
 

--- a/python/GafferImageTest/BleedFillTest.py
+++ b/python/GafferImageTest/BleedFillTest.py
@@ -74,13 +74,10 @@ class BleedFillTest( GafferImageTest.ImageTestCase ) :
 		# Test passthrough
 		bleedFill["enabled"].setValue( False )
 
-		self.assertEqual( GafferImage.ImageAlgo.imageHash( bleedFill["out"] ), GafferImage.ImageAlgo.imageHash( c["out"] ) )
-		self.assertEqual( GafferImage.ImageAlgo.image( bleedFill["out"] ), GafferImage.ImageAlgo.image( c["out"] ) )
+		self.assertImageHashesEqual( bleedFill["out"], c["out"] )
+		self.assertImagesEqual( bleedFill["out"], c["out"] )
 
 		bleedFill["enabled"].setValue( True )
-
-		self.assertNotEqual( GafferImage.ImageAlgo.imageHash( bleedFill["out"] ), GafferImage.ImageAlgo.imageHash( c["out"] ) )
-		self.assertNotEqual( GafferImage.ImageAlgo.image( bleedFill["out"] ), GafferImage.ImageAlgo.image( c["out"] ) )
 
 		def sample( position ) :
 			sampler = GafferImage.Sampler(

--- a/python/GafferImageTest/CDLTest.py
+++ b/python/GafferImageTest/CDLTest.py
@@ -54,38 +54,38 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.imageFile )
-		orig = GafferImage.ImageAlgo.image( n["out"] )
+		orig = GafferImage.ImageAlgo.tiles( n["out"] )
 
 		o = GafferImage.CDL()
 		o["in"].setInput( n["out"] )
 
-		self.assertEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
+		self.assertImagesEqual( n["out"], o["out"] )
 
 		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
-		slope = GafferImage.ImageAlgo.image( o["out"] )
+		slope = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, slope )
 
 		o["offset"].setValue( imath.Color3f( 1, 2, 3 ) )
-		offset = GafferImage.ImageAlgo.image( o["out"] )
+		offset = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, offset )
 		self.assertNotEqual( slope, offset )
 
 		o["power"].setValue( imath.Color3f( 1, 2, 3 ) )
-		power = GafferImage.ImageAlgo.image( o["out"] )
+		power = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, power )
 		self.assertNotEqual( slope, power )
 		self.assertNotEqual( offset, power )
 
 		o["saturation"].setValue( 0.5 )
-		saturation = GafferImage.ImageAlgo.image( o["out"] )
+		saturation = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, saturation )
 		self.assertNotEqual( slope, saturation )
 		self.assertNotEqual( offset, saturation )
 		self.assertNotEqual( power, saturation )
 
 		o["direction"].setValue( GafferImage.OpenColorIOTransform.Direction.Inverse ) # inverse
-		inverse = GafferImage.ImageAlgo.image( o["out"] )
+		inverse = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, inverse )
 		self.assertNotEqual( slope, inverse )
 		self.assertNotEqual( offset, inverse )
@@ -105,7 +105,7 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
+		self.assertImagesNotEqual( n["out"], o["out"] )
 
 		o["enabled"].setValue( False )
 

--- a/python/GafferImageTest/ColorSpaceTest.py
+++ b/python/GafferImageTest/ColorSpaceTest.py
@@ -67,7 +67,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		o["inputSpace"].setValue( "scene_linear" )
 		o["outputSpace"].setValue( "color_picking" )
 
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
+		self.assertImagesNotEqual( n["out"], o["out"] )
 
 	def testHashPassThrough( self ) :
 
@@ -83,7 +83,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		o["inputSpace"].setValue( "scene_linear" )
 		o["outputSpace"].setValue( "color_picking" )
 
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
+		self.assertImagesNotEqual( n["out"], o["out"] )
 
 		o["enabled"].setValue( False )
 

--- a/python/GafferImageTest/CreateViewsTest.py
+++ b/python/GafferImageTest/CreateViewsTest.py
@@ -77,14 +77,8 @@ class CreateViewsTest( GafferImageTest.ImageTestCase ) :
 		createViews["views"]["view1"]["value"].setInput( constant1["out"] )
 
 		self.assertEqual( createViews["out"].viewNames(), IECore.StringVectorData( [ "left", "right" ] ) )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "left" ),
-			GafferImage.ImageAlgo.image( reader["out"], "default" )
-		)
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "right" ),
-			GafferImage.ImageAlgo.image( constant1["out"], "default" )
-		)
+		self.__assertViewsEqual( createViews["out"], "left", reader["out"], "default" )
+		self.__assertViewsEqual( createViews["out"], "right", constant1["out"], "default" )
 
 		serialised = script.serialise()
 		deserialise = Gaffer.ScriptNode()
@@ -92,24 +86,14 @@ class CreateViewsTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertImagesEqual( createViews["out"], deserialise["CreateViews"]["out"] )
 
-
 		createViews["views"].resize( 3 )
 		createViews["views"][2]["name"].setValue( "blah" )
 		createViews["views"][2]["value"].setInput( constant2["out"] )
 
 		self.assertEqual( createViews["out"].viewNames(), IECore.StringVectorData( [ "left", "right", "blah" ] ) )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "left" ),
-			GafferImage.ImageAlgo.image( reader["out"], "default" )
-		)
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "right" ),
-			GafferImage.ImageAlgo.image( constant1["out"], "default" )
-		)
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "blah" ),
-			GafferImage.ImageAlgo.image( constant2["out"], "default" )
-		)
+		self.__assertViewsEqual( createViews["out"], "left", reader["out"], "default" )
+		self.__assertViewsEqual( createViews["out"], "right", constant1["out"], "default" )
+		self.__assertViewsEqual( createViews["out"], "blah", constant2["out"], "default" )
 
 		serialised = script.serialise()
 		deserialise = Gaffer.ScriptNode()
@@ -126,46 +110,26 @@ class CreateViewsTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( createViews["out"].viewNames(), IECore.StringVectorData( [ "left", "right", "blah" ] ) )
 
 		# Test duplicate names
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "left" ),
-			GafferImage.ImageAlgo.image( reader["out"], "default" )
-		)
+		self.__assertViewsEqual( createViews["out"], "left", reader["out"], "default" )
 		createViews["views"]["view2"]["name"].setValue( "left" )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "left" ),
-			GafferImage.ImageAlgo.image( constant2["out"], "default" )
-		)
+		self.__assertViewsEqual( createViews["out"], "left", constant2["out"], "default" )
 		self.assertEqual( createViews["out"].viewNames(), IECore.StringVectorData( [ "left", "right" ] ) )
 
 		# Test default view supplies defaults
 		createViews["views"]["view0"]["name"].setValue( "default" )
 		self.assertEqual( createViews["out"].viewNames(), IECore.StringVectorData( [ "default", "right", "left" ] ) )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "default" ),
-			GafferImage.ImageAlgo.image( reader["out"], "default" )
-		)
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "undeclared" ),
-			GafferImage.ImageAlgo.image( reader["out"], "default" )
-		)
+		self.__assertViewsEqual( createViews["out"], "default", reader["out"], "default" )
+		self.__assertViewsEqual( createViews["out"], "undeclared", reader["out"], "default" )
+
 		createViews["views"]["view2"]["name"].setValue( "default" )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "undeclared" ),
-			GafferImage.ImageAlgo.image( constant2["out"], "default" )
-		)
+		self.__assertViewsEqual( createViews["out"], "undeclared", constant2["out"], "default" )
 		createViews["views"]["view2"]["name"].setValue( "blah" )
 
 		# Test removing view
 		del createViews["views"]["view0"]
 		self.assertEqual( createViews["out"].viewNames(), IECore.StringVectorData( [ "right", "blah" ] ) )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "right" ),
-			GafferImage.ImageAlgo.image( constant1["out"], "default" )
-		)
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( createViews["out"], "blah" ),
-			GafferImage.ImageAlgo.image( constant2["out"], "default" )
-		)
+		self.__assertViewsEqual( createViews["out"], "right", constant1["out"], "default" )
+		self.__assertViewsEqual( createViews["out"], "blah", constant2["out"], "default" )
 
 		serialised = script.serialise()
 		deserialise = Gaffer.ScriptNode()
@@ -251,3 +215,15 @@ class CreateViewsTest( GafferImageTest.ImageTestCase ) :
 		script2.execute( script.serialise() )
 
 		assertLoadedOK( script2 )
+
+	def __assertViewsEqual( self, imageA, viewA, imageB, viewB ) :
+
+		selectA = GafferImage.SelectView()
+		selectA["in"].setInput( imageA )
+		selectA["view"].setValue( viewA )
+
+		selectB = GafferImage.SelectView()
+		selectB["in"].setInput( imageB )
+		selectB["view"].setValue( viewB )
+
+		self.assertImagesEqual( selectA["out"], selectB["out"] )

--- a/python/GafferImageTest/DeleteChannelsTest.py
+++ b/python/GafferImageTest/DeleteChannelsTest.py
@@ -156,12 +156,10 @@ class DeleteChannelsTest( GafferImageTest.ImageTestCase ) :
 		d["mode"].setValue( d.Mode.Keep )
 		d["channels"].setValue( "R" )
 
-		ri = GafferImage.ImageAlgo.image( r["out"] )
-		di = GafferImage.ImageAlgo.image( d["out"] )
+		self.assertEqual( set( r["out"].channelNames() ), { "R", "G", "B", "A" } )
+		self.assertEqual( d["out"].channelNames(), IECore.StringVectorData( [ "R" ] ) )
 
-		self.assertEqual( set( ri.keys() ), set( [ "R", "G", "B", "A" ] ) )
-		self.assertEqual( di.keys(), [ "R" ] )
-		self.assertEqual( di["R"], ri["R"] )
+		self.assertEqual( GafferImage.ImageAlgo.tiles( d["out"] )["R"], GafferImage.ImageAlgo.tiles( r["out"] )["R"] )
 
 	def testPassThrough( self ) :
 

--- a/python/GafferImageTest/DisplayTransformTest.py
+++ b/python/GafferImageTest/DisplayTransformTest.py
@@ -57,7 +57,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.imageFile )
-		orig = GafferImage.ImageAlgo.image( n["out"] )
+		orig = GafferImage.ImageAlgo.tiles( n["out"] )
 
 		o = GafferImage.DisplayTransform()
 		o["in"].setInput( n["out"] )
@@ -67,16 +67,16 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		o["display"].setValue( config.getDefaultDisplay() )
 		o["view"].setValue( config.getDefaultView( config.getDefaultDisplay() ) )
 
-		transform1 = GafferImage.ImageAlgo.image( o["out"] )
+		transform1 = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, transform1 )
 
 		o["view"].setValue( "Un-tone-mapped" )
-		transform2 = GafferImage.ImageAlgo.image( o["out"] )
+		transform2 = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, transform2 )
 		self.assertNotEqual( transform1, transform2 )
 
 		o["inputColorSpace"].setValue( "V-Log V-Gamut" )
-		transform3 = GafferImage.ImageAlgo.image( o["out"] )
+		transform3 = GafferImage.ImageAlgo.tiles( o["out"] )
 		self.assertNotEqual( orig, transform3 )
 		self.assertNotEqual( transform1, transform3 )
 		self.assertNotEqual( transform2, transform3 )
@@ -98,7 +98,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 
 		o["view"].setValue( config.getDefaultView( config.getDefaultDisplay() ) )
 
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
+		self.assertImagesNotEqual( n["out"], o["out"] )
 
 		o["enabled"].setValue( False )
 

--- a/python/GafferImageTest/ImageNodeTest.py
+++ b/python/GafferImageTest/ImageNodeTest.py
@@ -56,7 +56,7 @@ class ImageNodeTest( GafferImageTest.ImageTestCase ) :
 		g["in"].setInput( c["out"] )
 		g["multiply"].setValue( imath.Color3f( 0.4, 0.5, 0.6 ) )
 
-		gradedImage = GafferImage.ImageAlgo.image( g["out"] )
+		gradedImage = GafferImage.ImageAlgo.tiles( g["out"] )
 
 		# not enough for both images - will cause cache thrashing
 		Gaffer.ValuePlug.setCacheMemoryLimit( 2 * g["out"].channelData( "R", imath.V2i( 0 ) ).memoryUsage() )
@@ -66,7 +66,7 @@ class ImageNodeTest( GafferImageTest.ImageTestCase ) :
 		def grader() :
 
 			try :
-				images.append( GafferImage.ImageAlgo.image( g["out"], viewName = "default" ) )
+				images.append( GafferImage.ImageAlgo.tiles( g["out"], viewName = "default" ) )
 			except Exception as e :
 				exceptions.append( e )
 

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -174,10 +174,10 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 		with Gaffer.Context( Gaffer.Context.current() ) as c :
 
 			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 100, 200 ) )
-			self.assertEqual( GafferImage.ImageAlgo.image( constant["out"] ).displayWindow, imath.Box2i( imath.V2i( 0 ), imath.V2i( 99, 199 ) ) )
+			self.assertEqual( constant["out"].format(), GafferImage.Format( 100, 200 ) )
 
 			GafferImage.FormatPlug.setDefaultFormat( c, GafferImage.Format( 200, 300 ) )
-			self.assertEqual( GafferImage.ImageAlgo.image( constant["out"] ).displayWindow, imath.Box2i( imath.V2i( 0 ), imath.V2i( 199, 299 ) ) )
+			self.assertEqual( constant["out"].format(), GafferImage.Format( 200, 300 ) )
 
 	def testGlobalConvenienceMethods( self ) :
 

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -176,16 +176,16 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
 		reader = GafferImage.ImageReader()
 		reader["fileName"].setValue( testFile )
-		image1 = GafferImage.ImageAlgo.image( reader["out"] )
+		image1 = GafferImage.ImageAlgo.tiles( reader["out"] )
 
 		# even though we've change the image on disk, gaffer will
 		# still have the old one in its cache.
 		shutil.copyfile( self.jpgFileName, testFile )
-		self.assertEqual( GafferImage.ImageAlgo.image( reader["out"] ), image1 )
+		self.assertEqual( GafferImage.ImageAlgo.tiles( reader["out"] ), image1 )
 
 		# until we force a refresh
 		reader["refreshCount"].setValue( reader["refreshCount"].getValue() + 1 )
-		self.assertNotEqual( GafferImage.ImageAlgo.image( reader["out"] ), image1 )
+		self.assertNotEqual( GafferImage.ImageAlgo.tiles( reader["out"] ), image1 )
 
 	def testNonexistentFiles( self ) :
 
@@ -404,7 +404,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			# format and data window still match
 			self.assertEqual( reader["out"]["format"].getValue(), oiio["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
-			self.assertNotEqual( GafferImage.ImageAlgo.image( reader["out"] ), GafferImage.ImageAlgo.image( oiio["out"] ) )
+			self.assertImagesNotEqual( reader["out"], oiio["out"] )
 			# the metadata and channel names are at the defaults
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
@@ -425,7 +425,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			context = Gaffer.Context( Gaffer.Context.current() )
 			context.setFrame( holdFrame )
 			with context :
-				holdImage = GafferImage.ImageAlgo.image( reader["out"] )
+				holdImage = GafferImage.ImageAlgo.tiles( reader["out"] )
 				holdFormat = reader["out"]["format"].getValue()
 				holdDataWindow = reader["out"]["dataWindow"].getValue()
 				holdMetadata = reader["out"]["metadata"].getValue()
@@ -437,7 +437,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["metadata"].getValue(), holdMetadata )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), holdChannelNames )
 			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), holdTile )
-			self.assertEqual( GafferImage.ImageAlgo.image( reader["out"] ), holdImage )
+			self.assertEqual( GafferImage.ImageAlgo.tiles( reader["out"] ), holdImage )
 
 		reader["start"]["frame"].setValue( 4 )
 		reader["end"]["frame"].setValue( 7 )

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -197,6 +197,14 @@ class ImageTestCase( GafferTest.TestCase ) :
 									for j in range( len( pixelDataA[k][i] ) ):
 										self.assertEqual( pixelDataA[k][i][j], pixelDataB[k][i][j] , " while checking pixel data %s : %s at index %i" % ( k, tileStr, j ) )
 
+	def assertImagesNotEqual( self, *args ) :
+
+		try :
+			self.assertImagesEqual( *args )
+			self.fail( "Images unexpectedly equal" )
+		except :
+			pass
+
 	## Returns an image node with an empty data window. This is useful in
 	# verifying that nodes deal correctly with such inputs.
 	def emptyImage( self ) :

--- a/python/GafferImageTest/ImageTimeWarpTest.py
+++ b/python/GafferImageTest/ImageTimeWarpTest.py
@@ -92,13 +92,13 @@ class ImageTimeWarpTest( GafferImageTest.ImageTestCase ) :
 			with script.context() :
 
 				script.context().setFrame( f )
-				c0 = GafferImage.ImageAlgo.image( script["constant"]["out"], viewName = "default" )
+				c0 = GafferImage.ImageAlgo.tiles( script["constant"]["out"], viewName = "default" )
 				c0Hash = GafferImage.ImageAlgo.imageHash( script["constant"]["out"], viewName = "default" )
-				t = GafferImage.ImageAlgo.image( script["timeWarp"]["out"], viewName = "default" )
+				t = GafferImage.ImageAlgo.tiles( script["timeWarp"]["out"], viewName = "default" )
 				tHash = GafferImage.ImageAlgo.imageHash( script["timeWarp"]["out"], viewName = "default" )
 
 				script.context().setFrame( f + 1 )
-				c1 = GafferImage.ImageAlgo.image( script["constant"]["out"], viewName = "default" )
+				c1 = GafferImage.ImageAlgo.tiles( script["constant"]["out"], viewName = "default" )
 				c1Hash = GafferImage.ImageAlgo.imageHash( script["constant"]["out"], viewName = "default" )
 
 			self.assertEqual( c1, t )
@@ -155,9 +155,9 @@ class ImageTimeWarpTest( GafferImageTest.ImageTestCase ) :
 
 		with script.context() :
 
-			c = GafferImage.ImageAlgo.image( script["constant"]["out"], viewName = "default" )
+			c = GafferImage.ImageAlgo.tiles( script["constant"]["out"], viewName = "default" )
 			cHash = GafferImage.ImageAlgo.imageHash( script["constant"]["out"], viewName = "default" )
-			t = GafferImage.ImageAlgo.image( script["timeWarp"]["out"], viewName = "default" )
+			t = GafferImage.ImageAlgo.tiles( script["timeWarp"]["out"], viewName = "default" )
 			tHash = GafferImage.ImageAlgo.imageHash( script["timeWarp"]["out"], viewName = "default" )
 
 		self.assertNotEqual( c, t )
@@ -167,9 +167,9 @@ class ImageTimeWarpTest( GafferImageTest.ImageTestCase ) :
 
 		with script.context() :
 
-			c = GafferImage.ImageAlgo.image( script["constant"]["out"], viewName = "default" )
+			c = GafferImage.ImageAlgo.tiles( script["constant"]["out"], viewName = "default" )
 			cHash = GafferImage.ImageAlgo.imageHash( script["constant"]["out"], viewName = "default" )
-			t = GafferImage.ImageAlgo.image( script["timeWarp"]["out"], viewName = "default" )
+			t = GafferImage.ImageAlgo.tiles( script["timeWarp"]["out"], viewName = "default" )
 			tHash = GafferImage.ImageAlgo.imageHash( script["timeWarp"]["out"], viewName = "default" )
 
 		self.assertEqual( c, t )

--- a/python/GafferImageTest/ImageTransformTest.py
+++ b/python/GafferImageTest/ImageTransformTest.py
@@ -66,7 +66,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		t["filter"].setValue( "blackman-harris" )
 
 		self.assertNotEqual( GafferImage.ImageAlgo.imageHash( t["out"] ), GafferImage.ImageAlgo.imageHash( t["in"] ) )
-		self.assertNotEqual( GafferImage.ImageAlgo.image( t["out"] ), GafferImage.ImageAlgo.image( t["in"] ) )
+		self.assertImagesNotEqual( t["out"], t["in"] )
 
 	def testTilesWithSameInputTiles( self ) :
 

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -703,10 +703,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		s["w"] = GafferImage.ImageWriter()
 		s["w"]["in"].setInput( s["c"]["out"] )
 
-		ci = GafferImage.ImageAlgo.image( s["c"]["out"] )
-		wi = GafferImage.ImageAlgo.image( s["w"]["out"] )
-
-		self.assertEqual( ci, wi )
+		self.assertImagesEqual( s["w"]["out"], s["c"]["out"] )
 
 	def testPassThroughSerialisation( self ) :
 

--- a/python/GafferImageTest/LUTTest.py
+++ b/python/GafferImageTest/LUTTest.py
@@ -65,12 +65,12 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 		o["fileName"].setValue( self.lut )
 		o["interpolation"].setValue( GafferImage.LUT.Interpolation.Linear )
 
-		forward = GafferImage.ImageAlgo.image( o["out"] )
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), forward )
+		forward = GafferImage.ImageAlgo.tiles( o["out"] )
+		self.assertNotEqual( GafferImage.ImageAlgo.tiles( n["out"] ), forward )
 
 		o["direction"].setValue( GafferImage.OpenColorIOTransform.Direction.Inverse )
-		inverse = GafferImage.ImageAlgo.image( o["out"] )
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), inverse )
+		inverse = GafferImage.ImageAlgo.tiles( o["out"] )
+		self.assertNotEqual( GafferImage.ImageAlgo.tiles( n["out"] ), inverse )
 		self.assertNotEqual( forward, inverse )
 
 	def testBadFileName( self ) :
@@ -92,7 +92,7 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 		o["in"].setInput( n["out"] )
 		o["fileName"].setValue( self.lut )
 
-		image = GafferImage.ImageAlgo.image( o["out"] )
+		image = GafferImage.ImageAlgo.tiles( o["out"] )
 
 		log = []
 		def loggingFunction( message ) :
@@ -103,7 +103,7 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 			o["interpolation"].setValue( GafferImage.LUT.Interpolation.Tetrahedral )
 			# Bad interpolations fall back to the default interpolation, but
 			# also emit a warning message.
-			self.assertEqual( GafferImage.ImageAlgo.image( o["out"] ), image )
+			self.assertEqual( GafferImage.ImageAlgo.tiles( o["out"] ), image )
 		finally :
 			PyOpenColorIO.ResetToDefaultLoggingFunction()
 
@@ -128,7 +128,7 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 
 		o["fileName"].setValue( self.lut )
 
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
+		self.assertImagesNotEqual( n["out"], o["out"] )
 
 		o["enabled"].setValue( False )
 

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -536,7 +536,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		merge["in"][0].setInput( r["out"] )
 		merge["in"][1].setInput( o["out"] )
-		GafferImage.ImageAlgo.image( merge["out"] )
+		GafferImage.ImageAlgo.tiles( merge["out"] )
 
 	def testPassthroughs( self ) :
 

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -71,10 +71,17 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 	def testInternalImageSpaceConversion( self ) :
 
-		r = IECore.Reader.create( str( self.negativeDataWindowFileName ) )
-		image = r.read()
-		exrDisplayWindow = image.displayWindow
-		exrDataWindow = image.dataWindow
+		imageSpec = OpenImageIO.ImageInput.open( str( self.negativeDataWindowFileName ) ).spec()
+
+		exrDisplayWindow = imath.Box2i(
+			imath.V2i( imageSpec.full_x, imageSpec.full_y ),
+			imath.V2i( imageSpec.full_x + imageSpec.full_width - 1, imageSpec.full_y + imageSpec.full_height - 1 ),
+		)
+
+		exrDataWindow = imath.Box2i(
+			imath.V2i( imageSpec.x, imageSpec.y ),
+			imath.V2i( imageSpec.x + imageSpec.width - 1, imageSpec.y + imageSpec.height - 1 ),
+		)
 
 		n = GafferImage.OpenImageIOReader()
 		n["fileName"].setValue( self.negativeDataWindowFileName )

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -128,13 +128,44 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertIn( "B", channelNames )
 		self.assertIn( "A", channelNames )
 
-		image = GafferImage.ImageAlgo.image( n["out"] )
-		self.assertEqual( image.blindData(), IECore.CompoundData( dict(expectedMetadata) ) )
+		self.assertEqual( n["out"].metadata(), expectedMetadata )
 
-		image2 = IECore.Reader.create( str( self.fileName ) ).read()
-		image.blindData().clear()
-		image2.blindData().clear()
-		self.assertEqual( image, image2 )
+		self.__assertEqualToImageBuf( n["out"], OpenImageIO.ImageBuf( str( self.fileName ) ) )
+
+	def __assertEqualToImageBuf( self, image, imageBuf ) :
+
+		# ImageBuf has inverted Y axis system compared to us.
+		# Account for that when comparing data and display windows.
+
+		spec = imageBuf.spec()
+		exrDisplayWindow = imath.Box2i(
+			imath.V2i( spec.full_x, spec.full_y ),
+			imath.V2i( spec.full_x + spec.full_width - 1, spec.full_y + spec.full_height - 1 ),
+		)
+
+		exrDataWindow = imath.Box2i(
+			imath.V2i( spec.x, spec.y ),
+			imath.V2i( spec.x + spec.width - 1, spec.y + spec.height - 1 ),
+		)
+
+		format = image.format()
+		self.assertEqual( format.toEXRSpace( format.getDisplayWindow() ), exrDisplayWindow )
+		self.assertEqual( format.toEXRSpace( image.dataWindow() ), exrDataWindow )
+
+		# Compare channel names.
+
+		self.assertEqual( set( image.channelNames() ), set( spec.channelnames ) )
+
+		# Compare pixels.
+
+		for channelIndex, channelName in enumerate( spec.channelnames ) :
+			sampler = GafferImage.Sampler( image, channelName, image.dataWindow() )
+			for y in range( exrDataWindow.min().y, exrDataWindow.max().y ) :
+				for x in range( exrDataWindow.min().x, exrDataWindow.max().x ) :
+					self.assertEqual(
+						imageBuf.getpixel( x, y, 0 )[channelIndex],
+						sampler.sample( x, format.fromEXRSpace( y ) )
+					)
 
 	def testNegativeDisplayWindowRead( self ) :
 
@@ -145,11 +176,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( f.getDisplayWindow(), imath.Box2i( imath.V2i( -5, -5 ), imath.V2i( 21, 21 ) ) )
 		self.assertEqual( d, imath.Box2i( imath.V2i( 2, -14 ), imath.V2i( 36, 20 ) ) )
 
-		expectedImage = IECore.Reader.create( str( self.negativeDisplayWindowFileName ) ).read()
-		outImage = GafferImage.ImageAlgo.image( n["out"] )
-		expectedImage.blindData().clear()
-		outImage.blindData().clear()
-		self.assertEqual( expectedImage, outImage )
+		self.__assertEqualToImageBuf( n["out"], OpenImageIO.ImageBuf( str( self.negativeDisplayWindowFileName ) ) )
 
 	def testNegativeDataWindow( self ) :
 
@@ -164,15 +191,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertIn( "G", channelNames )
 		self.assertIn( "B", channelNames )
 
-		image = GafferImage.ImageAlgo.image( n["out"] )
-		image2 = IECore.Reader.create( str( self.negativeDataWindowFileName ) ).read()
-
-		op = IECoreImage.ImageDiffOp()
-		res = op(
-			imageA = image,
-			imageB = image2
-		)
-		self.assertFalse( res.value )
+		self.__assertEqualToImageBuf( n["out"], OpenImageIO.ImageBuf( str( self.negativeDataWindowFileName ) ) )
 
 	def testTileSize( self ) :
 
@@ -212,13 +231,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		n = GafferImage.OpenImageIOReader()
 		n["fileName"].setValue( self.offsetDataWindowFileName )
 
-		image = GafferImage.ImageAlgo.image( n["out"] )
-		image2 = IECore.Reader.create( str( self.offsetDataWindowFileName ) ).read()
-
-		image.blindData().clear()
-		image2.blindData().clear()
-
-		self.assertEqual( image, image2 )
+		self.__assertEqualToImageBuf( n["out"], OpenImageIO.ImageBuf( str( self.offsetDataWindowFileName ) ) )
 
 	def testJpgRead( self ) :
 
@@ -252,16 +265,16 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 		reader = GafferImage.OpenImageIOReader()
 		reader["fileName"].setValue( testFile )
-		image1 = GafferImage.ImageAlgo.image( reader["out"] )
+		tiles1 = GafferImage.ImageAlgo.tiles( reader["out"] )
 
 		# even though we've change the image on disk, gaffer will
 		# still have the old one in its cache.
 		shutil.copyfile( self.offsetDataWindowFileName, testFile )
-		self.assertEqual( GafferImage.ImageAlgo.image( reader["out"] ), image1 )
+		self.assertEqual( GafferImage.ImageAlgo.tiles( reader["out"] ), tiles1 )
 
 		# until we force a refresh
 		reader["refreshCount"].setValue( reader["refreshCount"].getValue() + 1 )
-		self.assertNotEqual( GafferImage.ImageAlgo.image( reader["out"] ), image1 )
+		self.assertNotEqual( GafferImage.ImageAlgo.tiles( reader["out"] ), tiles1 )
 
 	def testNonexistentFiles( self ) :
 

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -219,8 +219,8 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 		r["filter"].setValue( "sinc" )
 		r["in"].setInput( c["out"] )
 
-		i = GafferImage.ImageAlgo.image( r["out"] )
-		self.assertEqual( i["R"], IECore.FloatVectorData( [ 1.0 ] * 400 * 400 ) )
+		for tile in GafferImage.ImageAlgo.tiles( r["out"] )["R"] :
+			self.assertEqual( tile, IECore.FloatVectorData( [ 1.0 ] * GafferImage.ImagePlug.tileSize() ** 2 ) )
 
 	def testExpandDataWindow( self ) :
 

--- a/python/GafferImageTest/SelectViewTest.py
+++ b/python/GafferImageTest/SelectViewTest.py
@@ -51,7 +51,6 @@ class SelectViewTest( GafferImageTest.ImageTestCase ) :
 
 	def test( self ) :
 
-
 		reader = GafferImage.ImageReader()
 		reader["fileName"].setValue( self.__rgbFilePath )
 		constant1 = GafferImage.Constant()
@@ -77,18 +76,11 @@ class SelectViewTest( GafferImageTest.ImageTestCase ) :
 		selectView = GafferImage.SelectView()
 		selectView["in"].setInput( createViews["out"] )
 
-
 		self.assertEqual( selectView["out"].viewNames(), IECore.StringVectorData( [ "default" ] ) )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( selectView["out"], "default" ),
-			GafferImage.ImageAlgo.image( reader["out"], "default" )
-		)
+		self.assertImagesEqual( selectView["out"], reader["out"] )
 
 		selectView["view"].setValue( "right" )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( selectView["out"], "default" ),
-			GafferImage.ImageAlgo.image( constant1["out"], "default" )
-		)
+		self.assertImagesEqual( selectView["out"], constant1["out"] )
 
 		selectView["view"].setValue( "undeclared" )
 		with self.assertRaisesRegex( Gaffer.ProcessException, ".*View does not exist \"undeclared\""):
@@ -98,25 +90,13 @@ class SelectViewTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( selectView["out"].viewNames(), IECore.StringVectorData( [ "default" ] ) )
 		selectView["view"].setValue( "left" )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( selectView["out"], "default" ),
-			GafferImage.ImageAlgo.image( reader["out"], "default" )
-		)
+		self.assertImagesEqual( selectView["out"], reader["out"] )
 
 		selectView["view"].setValue( "right" )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( selectView["out"], "default" ),
-			GafferImage.ImageAlgo.image( constant1["out"], "default" )
-		)
+		self.assertImagesEqual( selectView["out"], constant1["out"] )
 
 		selectView["view"].setValue( "default" )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( selectView["out"], "default" ),
-			GafferImage.ImageAlgo.image( constant2["out"], "default" )
-		)
+		self.assertImagesEqual( selectView["out"], constant2["out"] )
 
 		selectView["view"].setValue( "undeclared" )
-		self.assertEqual(
-			GafferImage.ImageAlgo.image( selectView["out"], "default" ),
-			GafferImage.ImageAlgo.image( constant2["out"], "default" )
-		)
+		self.assertImagesEqual( selectView["out"], constant2["out"] )

--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -88,7 +88,7 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 
 		# we haven't connected the shader yet, so the node should act as a pass through
 
-		self.assertEqual( GafferImage.ImageAlgo.image( image["out"] ), GafferImage.ImageAlgo.image( shuffle["out"] ) )
+		self.assertImagesEqual( image["out"], shuffle["out"], ignoreChannelNamesOrder = True )
 
 		# that should all change when we hook up a shader
 
@@ -129,7 +129,7 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 				"out.channelData", "__affectedChannels", "out.channelNames", "out"
 		] )
 
-		inputImage = GafferImage.ImageAlgo.image( shuffle["out"] )
+		inputTiles = GafferImage.ImageAlgo.tiles( shuffle["out"] )
 
 		with Gaffer.ContextMonitor( image["__shading"] ) as monitor :
 			self.assertEqual( image["out"].channelNames(), IECore.StringVectorData( [ "A", "B", "G", "R", "unchangedR" ] ) )
@@ -148,12 +148,12 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		# Should only need one shading evaluate for all channels
 		self.assertEqual( monitor.combinedStatistics().numUniqueContexts(), 1 )
 
-		outputImage = GafferImage.ImageAlgo.image( image["out"] )
+		outputTiles = GafferImage.ImageAlgo.tiles( image["out"] )
 
-		self.assertNotEqual( inputImage, outputImage )
-		self.assertEqual( outputImage["R"], inputImage["B"] )
-		self.assertEqual( outputImage["G"], inputImage["G"] )
-		self.assertEqual( outputImage["B"], inputImage["R"] )
+		self.assertNotEqual( inputTiles, outputTiles )
+		self.assertEqual( outputTiles["R"], inputTiles["B"] )
+		self.assertEqual( outputTiles["G"], inputTiles["G"] )
+		self.assertEqual( outputTiles["B"], inputTiles["R"] )
 
 		# changes in the shader network should signal more dirtiness
 
@@ -170,14 +170,14 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		] )
 
 
-		inputImage = GafferImage.ImageAlgo.image( shuffle["out"] )
-		outputImage = GafferImage.ImageAlgo.image( image["out"] )
+		inputTiles = GafferImage.ImageAlgo.tiles( shuffle["out"] )
+		outputTiles = GafferImage.ImageAlgo.tiles( image["out"] )
 
-		self.assertEqual( outputImage["R"], inputImage["R"] )
-		self.assertEqual( outputImage["G"], inputImage["R"] )
-		self.assertEqual( outputImage["B"], inputImage["R"] )
-		self.assertEqual( outputImage["A"], inputImage["A"] )
-		self.assertEqual( outputImage["unchangedR"], inputImage["unchangedR"] )
+		self.assertEqual( outputTiles["R"], inputTiles["R"] )
+		self.assertEqual( outputTiles["G"], inputTiles["R"] )
+		self.assertEqual( outputTiles["B"], inputTiles["R"] )
+		self.assertEqual( outputTiles["A"], inputTiles["A"] )
+		self.assertEqual( outputTiles["unchangedR"], inputTiles["unchangedR"] )
 
 		image["in"].setInput( None )
 		checkDirtiness( [
@@ -279,12 +279,13 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		image["in"].setInput( reader["out"] )
 		image["shader"].setInput( imageShader["out"]["out"] )
 
-		inputImage = GafferImage.ImageAlgo.image( reader["out"] )
-		outputImage = GafferImage.ImageAlgo.image( image["out"] )
+		inputTiles = GafferImage.ImageAlgo.tiles( reader["out"] )
+		outputTiles = GafferImage.ImageAlgo.tiles( image["out"] )
 
-		self.assertEqual( outputImage["R"], IECore.FloatVectorData( [ 0 ] * inputImage["R"].size() ) )
-		self.assertEqual( outputImage["G"], inputImage["G"] )
-		self.assertEqual( outputImage["B"], inputImage["B"] )
+		self.assertEqual( outputTiles["G"], inputTiles["G"] )
+		self.assertEqual( outputTiles["B"], inputTiles["B"] )
+		for tile in outputTiles["R"] :
+			self.assertEqual( tile, IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() ** 2 ) )
 
 	def testPassThrough( self ) :
 
@@ -428,14 +429,21 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 
 		oslImageDeep["channels"]["channel"]["value"].setInput( multiplyAlpha["out"]["out"] )
 
-		outImage = GafferImage.ImageAlgo.image( postFlatten["out"] )
-		size = outImage.dataWindow.size() + imath.V2i( 1 )
-		i = 0
-		for y in range( size.y ):
-			for x in range( size.x ):
-				self.assertAlmostEqual( outImage["R"][i], (x + 0.5) / size.x * outImage["A"][i], places = 5 )
-				self.assertAlmostEqual( outImage["G"][i], (size.y - y - 0.5) / size.y * outImage["A"][i], places = 5 )
-				i += 1
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( postFlatten["out"] )
+
+		size = postFlatten["out"].dataWindow().size()
+		for y in range( size.y ) :
+			for x in range( size.x ) :
+				sampler["pixel"].setValue( imath.V2f( x + 0.5, y + 0.5 ) )
+				self.assertAlmostEqual(
+					sampler["color"]["r"].getValue(),
+					(x + 0.5) / size.x * sampler["color"]["a"].getValue(), places = 5
+				)
+				self.assertAlmostEqual(
+					sampler["color"]["g"].getValue(),
+					(y + 0.5) / size.y * sampler["color"]["a"].getValue(), places = 5
+				)
 
 	def testGlobals( self ) :
 
@@ -538,7 +546,7 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		oslImage["shader"].setInput( outImage["out"]["out"] )
 
 		with Gaffer.PerformanceMonitor() as pm :
-			GafferImage.ImageAlgo.image( oslImage["out"] )
+			GafferImageTest.processTiles( oslImage["out"] )
 
 		# Because the shader doesn't use any input channels,
 		# the OSLImage node shouldn't have needed to pull on
@@ -580,26 +588,33 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 	def testAllTypes( self ) :
 
 		i = GafferOSL.OSLImage()
-		i["defaultFormat"].setValue( GafferImage.Format( imath.Box2i( imath.V2i(0), imath.V2i( 5 ) ) ) )
+		i["defaultFormat"].setValue(
+			GafferImage.Format(
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( GafferImage.ImagePlug.tileSize() ) )
+			)
+		)
 
 		i["channels"].addChild( Gaffer.NameValuePlug( "", imath.Color3f(1,3,5) ) )
 		i["channels"].addChild( Gaffer.NameValuePlug( "testFloat", 42.42 ) )
 		i["channels"].addChild( Gaffer.NameValuePlug( "testColor", imath.Color3f(12,13,14) ) )
 
-		image = GafferImage.ImageAlgo.image( i['out'] )
-
-		self.assertEqual( image["R"], IECore.FloatVectorData( [1]*25 ) )
-		self.assertEqual( image["G"], IECore.FloatVectorData( [3]*25 ) )
-		self.assertEqual( image["B"], IECore.FloatVectorData( [5]*25 ) )
-		self.assertEqual( image["testFloat"], IECore.FloatVectorData( [42.42]*25 ) )
-		self.assertEqual( image["testColor.R"], IECore.FloatVectorData( [12]*25 ) )
-		self.assertEqual( image["testColor.G"], IECore.FloatVectorData( [13]*25 ) )
-		self.assertEqual( image["testColor.B"], IECore.FloatVectorData( [14]*25 ) )
+		numPixels = GafferImage.ImagePlug.tileSize() ** 2
+		self.assertEqual( i["out"].channelData( "R", imath.V2i( 0 ) ), IECore.FloatVectorData( [1] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "G", imath.V2i( 0 ) ), IECore.FloatVectorData( [3] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "B", imath.V2i( 0 ) ), IECore.FloatVectorData( [5] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "testFloat", imath.V2i( 0 ) ), IECore.FloatVectorData( [42.42] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "testColor.R", imath.V2i( 0 ) ), IECore.FloatVectorData( [12] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "testColor.G", imath.V2i( 0 ) ), IECore.FloatVectorData( [13] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "testColor.B", imath.V2i( 0 ) ), IECore.FloatVectorData( [14] * numPixels ) )
 
 	def testClosure( self ) :
 
 		i = GafferOSL.OSLImage()
-		i["defaultFormat"].setValue( GafferImage.Format( imath.Box2i( imath.V2i(0), imath.V2i( 5 ) ) ) )
+		i["defaultFormat"].setValue(
+			GafferImage.Format(
+				imath.Box2i( imath.V2i( 0 ), imath.V2i( GafferImage.ImagePlug.tileSize() ) )
+			)
+		)
 		i["channels"].addChild( Gaffer.NameValuePlug( "testClosure", GafferOSL.ClosurePlug() ) )
 
 		code = GafferOSL.OSLCode( "OSLCode" )
@@ -608,11 +623,11 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 
 		i["channels"][0]["value"].setInput( code["out"]["output1"] )
 
-		image = GafferImage.ImageAlgo.image( i['out'] )
-		self.assertEqual( image["blah.R"], IECore.FloatVectorData( [0.1]*25 ) )
-		self.assertEqual( image["blah.G"], IECore.FloatVectorData( [0.2]*25 ) )
-		self.assertEqual( image["blah.B"], IECore.FloatVectorData( [0.3]*25 ) )
-		self.assertEqual( image["foo"], IECore.FloatVectorData( [0.5]*25 ) )
+		numPixels = GafferImage.ImagePlug.tileSize() ** 2
+		self.assertEqual( i["out"].channelData( "blah.R", imath.V2i( 0 ) ), IECore.FloatVectorData( [0.1] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "blah.G", imath.V2i( 0 ) ), IECore.FloatVectorData( [0.2] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "blah.B", imath.V2i( 0 ) ), IECore.FloatVectorData( [0.3] * numPixels ) )
+		self.assertEqual( i["out"].channelData( "foo", imath.V2i( 0 ) ), IECore.FloatVectorData( [0.5] * numPixels ) )
 
 	def testUndo( self ) :
 
@@ -660,7 +675,6 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertEqual( oslImage["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 5, 5 ) ) )
 		self.assertEqual( oslImage["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 5, 5 ) ) )
-		self.assertEqual( GafferImage.ImageAlgo.image( oslImage["out"] )["G"], IECore.FloatVectorData( [0.6] * 25 ) )
 
 		oslImage["in"].setInput( constant["out"] )
 
@@ -670,7 +684,6 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		constant["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i(0), imath.V2i( 4 ) ) ) )
 		self.assertEqual( oslImage["out"]["dataWindow"].getValue(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 4, 4 ) ) )
 		self.assertEqual( oslImage["out"]["format"].getValue().getDisplayWindow(), imath.Box2i( imath.V2i( 0 ), imath.V2i( 4, 4 ) ) )
-		self.assertEqual( GafferImage.ImageAlgo.image( oslImage["out"] )["G"], IECore.FloatVectorData( [0.6] * 16 ) )
 
 	# Extreme example of doing something very expensive in OSLImage
 	def mandelbrotNode( self ):
@@ -815,11 +828,11 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		oslImage["channels"].addChild( Gaffer.NameValuePlug( "", Gaffer.Color3fPlug( "value" ), True, "channel" ) )
 		oslImage["channels"]["channel"]["value"].setInput( floatToColor["out"]["c"] )
 
-		GafferImage.ImageAlgo.image( constant["out"] )
+		GafferImageTest.processTiles( constant["out"] )
 
 		# Run the fastest possible OSLImage on lots of tiles, to highlight any constant overhead
 		with GafferTest.TestRunner.PerformanceScope() :
-			GafferImage.ImageAlgo.image( oslImage["out"] )
+			GafferImageTest.processTiles( oslImage["out"] )
 
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1)
 	def testCollaboratePerf( self ) :
@@ -850,7 +863,7 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		resize["filter"].setValue( 'box' )
 
 		with GafferTest.TestRunner.PerformanceScope() :
-			GafferImage.ImageAlgo.image( resize["out"] )
+			GafferImageTest.processTiles( resize["out"] )
 
 	def testOSLSplineMatch( self ):
 

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -999,25 +999,26 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		image = GafferOSL.OSLImage()
 		image["in"].setInput( constant["out"] )
-
 		image["shader"].setInput( n["out"]["out"] )
+
+		sampler = GafferImage.ImageSampler()
+		sampler["image"].setInput( image["out"] )
 
 		for interpolation in [
 			IECore.RampInterpolation.Linear,
 			IECore.RampInterpolation.CatmullRom,
 			IECore.RampInterpolation.BSpline,
 			IECore.RampInterpolation.MonotoneCubic
-			]:
+		] :
 
 			n["parameters"]["colorSpline"].setValue( IECore.RampfColor3f( points, interpolation ) )
+			evaluator = n['parameters']['colorSpline'].getValue().evaluator()
 
-			oslSamples = list( reversed( GafferImage.ImageAlgo.image( image['out'] )["R"] ) )
-
-			s = n['parameters']['colorSpline'].getValue().evaluator()
-			cortexSamples = [ s( ( i + 0.5 ) / numSamples )[0] for i in range( numSamples ) ]
-
-			for a, b in zip( oslSamples, cortexSamples ):
-				self.assertAlmostEqual( a, b, places = 4 )
+			for i in range( 0, numSamples ) :
+				sampler["pixel"].setValue( imath.V2f( 0.5, i + 0.5 ) )
+				oslSample = sampler["color"]["r"].getValue()
+				cortexSample = evaluator( ( i + 0.5 ) / numSamples )[0]
+				self.assertAlmostEqual( oslSample, cortexSample, places = 4 )
 
 	def testArrays( self ) :
 

--- a/python/GafferSceneTest/CatalogueTest.py
+++ b/python/GafferSceneTest/CatalogueTest.py
@@ -668,7 +668,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 				r"\(Permission denied\)" if os.name != "nt" else r"\(No such file or directory\)"
 			)
 		) :
-			GafferImage.ImageAlgo.image( s["c"]["out"] )
+			GafferImageTest.processTiles( s["c"]["out"] )
 
 	def testDeleteKeepsOrder( self ) :
 


### PR DESCRIPTION
For the majority of stuff, we've abandoned IECoreImage in favour of OpenImageIO, but we still have a few holdouts, particularly in the unit tests. This gets rid of a bunch of them, putting us in striking distance of abandoning `IECoreImage.ImagePrimitive` entirely in Gaffer 1.8.