### PR TITLE
Arnold ParameterAlgo : Support V3dVectorData

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
 
 - SetFilter, Scene Editors : Set expressions containing operators are now editable via drag and drop of set names.
 - NodeEditor : Scene locations can now be dropped to pin the editor to their source node. Locations may be dragged from the Viewer, AttributeEditor, LightEditor, HierarchyView and LightLinkingEditor.
+- Arnold : Added support for V3dVectorData primitive variables. These are converted to float vectors, since Arnold does not support doubles.
 
 Fixes
 -----

--- a/python/IECoreArnoldTest/ParameterAlgoTest.py
+++ b/python/IECoreArnoldTest/ParameterAlgoTest.py
@@ -187,3 +187,19 @@ class ParameterAlgoTest( unittest.TestCase ) :
 			self.assertEqual( len( mh.messages ), 2 )
 			self.assertEqual( mh.messages[0].message, 'Int64Data value 2147483648 is out of range for parameter "customInt64OutOfRange"' )
 			self.assertEqual( mh.messages[1].message, 'UInt64Data value 4294967296 is out of range for parameter "customUInt64OutOfRange"' )
+
+	def testV3dVectorData( self ) :
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			n = arnold.AiNode( universe, "ginstance" )
+			IECoreArnold.ParameterAlgo.setParameter( n, "test", IECore.V3dVectorData( [ imath.V3d( i, i + 1, i + 2 ) for i in range( 0, 10 ) ] ) )
+
+			a = arnold.AiNodeGetArray( n, "test" )
+			self.assertEqual( arnold.AiArrayGetType( a ), arnold.AI_TYPE_VECTOR )
+			self.assertEqual( arnold.AiArrayGetNumElements( a ), 10 )
+			for i in range( 0, 10 ) :
+				self.assertEqual(
+					arnold.AiArrayGetVec( a, i ),
+					arnold.AtVector( i, i + 1, i + 2 )
+				)

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -560,6 +560,7 @@ int parameterType( IECore::TypeId dataType, bool &array )
 			return AI_TYPE_VECTOR2;
 		case V3fVectorDataTypeId :
 		case V3iVectorDataTypeId :
+		case V3dVectorDataTypeId :
 			array = true;
 			return AI_TYPE_VECTOR;
 		case M44fVectorDataTypeId :
@@ -621,6 +622,12 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 		AtArray *array = AiArrayAllocate( 1, 1, AI_TYPE_STRING );
 		AiArraySetStr( array, 0, val.c_str() );
 		return array;
+	}
+	else if( aiType == AI_TYPE_VECTOR && IECore::runTimeCast<const V3dVectorData>( data ) )
+	{
+		const auto &v3dVector = static_cast<const V3dVectorData *>( data )->readable();
+		vector<Imath::V3f> v3fVector( v3dVector.begin(), v3dVector.end() );
+		return AiArrayConvert( v3fVector.size(), 1, aiType, v3fVector.data() );
 	}
 
 	return AiArrayConvert( size( data ), 1, aiType, address( data ) );


### PR DESCRIPTION
By converting to floats, since Arnold doesn't support doubles. Prompted by https://groups.google.com/g/gaffer-dev/c/DDseXD6zrTk/m/rI9FWsmjAAAJ.
