### PR TITLE
Arnold shader fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Fixes
 - LevelSetOffset : Fixed crash when attempting to offset grid types other than `FloatGrid`.
 - AttributeTweaks, CustomAttributes, OptionTweaks, CustomOptions, OptionQuery : Fixed contexts used by "From Scene", "From Selected" and "From Affected" menu items. This fixes errors caused by missing context variables (such as script variables).
 - PlugLayout : Fixed `Internal C++ object already deleted` errors when a plug stops being laid out as an inline accessory, such as when its `layout:accessory` metadata was changed or removed, or when the plug it was grouped with was hidden or deleted (#6938).
+- Arnold : Fixed crash translating network where all shaders are invalid.
 
 1.6.21.4 (relative to 1.6.21.3)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 - AttributeTweaks, CustomAttributes, OptionTweaks, CustomOptions, OptionQuery : Fixed contexts used by "From Scene", "From Selected" and "From Affected" menu items. This fixes errors caused by missing context variables (such as script variables).
 - PlugLayout : Fixed `Internal C++ object already deleted` errors when a plug stops being laid out as an inline accessory, such as when its `layout:accessory` metadata was changed or removed, or when the plug it was grouped with was hidden or deleted (#6938).
 - Arnold : Fixed crash translating network where all shaders are invalid.
+- ReferenceTest, 3Delight RendererTest : Fixed leakage of modified environment. This is handled in the TestCase base class, so in future no test can accidentally leak modifications.
 
 1.6.21.4 (relative to 1.6.21.3)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,9 @@ Fixes
 - LevelSetOffset : Fixed crash when attempting to offset grid types other than `FloatGrid`.
 - AttributeTweaks, CustomAttributes, OptionTweaks, CustomOptions, OptionQuery : Fixed contexts used by "From Scene", "From Selected" and "From Affected" menu items. This fixes errors caused by missing context variables (such as script variables).
 - PlugLayout : Fixed `Internal C++ object already deleted` errors when a plug stops being laid out as an inline accessory, such as when its `layout:accessory` metadata was changed or removed, or when the plug it was grouped with was hidden or deleted (#6938).
-- Arnold : Fixed crash translating network where all shaders are invalid.
+- Arnold :
+  - Fixed rendering of shaders written with `IECOREUSD_WRITE_CONFORMANT_OSL_SHADERS=1`.
+  - Fixed crash translating network where all shaders are invalid.
 - ReferenceTest, 3Delight RendererTest : Fixed leakage of modified environment. This is handled in the TestCase base class, so in future no test can accidentally leak modifications.
 
 1.6.21.4 (relative to 1.6.21.3)

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import os
 import pathlib
 import inspect
 import unittest
@@ -1012,6 +1013,66 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			handler.waitFor( 0.1 ) #Just need to let the catalogue update
 
 			self.assertEqual( self.__color4fAtUV( catalogue, imath.V2f( 0.5 ) ), imath.Color4f( 0, 0.5, 0.5, 1 ) )
+
+	def testUSDConformantOSLShaders( self ) :
+
+		# Render a simple constant OSL shader.
+
+		constant = GafferOSL.OSLShader()
+		constant.loadShader( "Surface/Constant" )
+		constant["parameters"]["Cs"].setValue( imath.Color3f( 1, 0.5, 0.25 ) )
+
+		ball = GafferArnold.ArnoldShaderBall()
+		ball["shader"].setInput( constant["out"] )
+
+		imagePath = self.temporaryDirectory() / "test.exr"
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput(
+			"beauty",
+			IECoreScene.Output( imagePath.as_posix(), "exr", "rgba", {} )
+		)
+		outputs["in"].setInput( ball["out"] )
+
+		render = GafferScene.Render()
+		render["in"].setInput( outputs["out"] )
+		render["renderer"].setValue( "Arnold" )
+		render["task"].execute()
+
+		# Check the result is as expected.
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( imagePath )
+		self.assertEqual( self.__color4fAtUV( imageReader, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0.5, 0.25, 1 ) )
+
+		# Write the scene to USD, losing the "osl:" type
+		# prefix in the process.
+
+		sceneWriter = GafferScene.SceneWriter()
+		sceneWriter["in"].setInput( ball["out"] )
+		sceneWriter["fileName"].setValue( self.temporaryDirectory() / "test.usda" )
+
+		os.environ["IECOREUSD_WRITE_CONFORMANT_OSL_SHADERS"] = "1"
+		sceneWriter["task"].execute()
+
+		# Render using the USD.
+
+		sceneReader = GafferScene.SceneReader()
+		sceneReader["fileName"].setInput( sceneWriter["fileName"] )
+
+		outputs["in"].setInput( sceneReader["out"] )
+		# Make sure the shader is on the path. The wrapper would have done
+		# this for us if IECOREUSD_WRITE_CONFORMANT_OSL_SHADERS was set at
+		# the time it ran.
+		os.environ["OSL_SHADER_PATHS"] = "{}{}{}".format(
+			os.environ["OSL_SHADER_PATHS"], os.pathsep, Gaffer.rootPath() / "shaders" / "Surface"
+		)
+		render["task"].execute()
+
+		# Check we still managed to find the right shader.
+
+		imageReader["refreshCount"].setValue( 1 )
+		self.assertEqual( self.__color4fAtUV( imageReader, imath.V2f( 0.5 ) ), imath.Color4f( 1, 0.5, 0.25, 1 ) )
 
 	def testDefaultLightsMistakesDontForceLinking( self ) :
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -38,7 +38,6 @@
 import pathlib
 import inspect
 import unittest
-import subprocess
 import threading
 
 import arnold

--- a/python/GafferDispatchTest/LocalDispatcherTest.py
+++ b/python/GafferDispatchTest/LocalDispatcherTest.py
@@ -1275,7 +1275,6 @@ class LocalDispatcherTest( GafferTest.TestCase ) :
 		# environment variable instead. Still, we want to test that variables created
 		# this way are passed to child tasks.
 		os.environ["gafferLocalDispatcherTestMIXEDcaseA"] = "testTEST"
-		self.addCleanup( os.environ.__delitem__, "gafferLocalDispatcherTestMIXEDcaseA" )
 
 		# If we bypass `os.environ`, then we can create a mixed-case variable even
 		# on Windows.

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -95,7 +95,6 @@ class ApplicationTest( GafferTest.TestCase ) :
 		# environment variable instead. Still, we want to test that variables created
 		# this way are passed to child applications.
 		os.environ["gafferApplicationTestMIXEDcaseA"] = "testTEST"
-		self.addCleanup( os.environ.__delitem__, "gafferApplicationTestMIXEDcaseA" )
 
 		# If we bypass `os.environ`, then we can create a mixed-case variable even
 		# on Windows.

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -93,7 +93,26 @@ class TestCase( unittest.TestCase ) :
 		Gaffer.ValuePlug.clearCache()
 		Gaffer.ValuePlug.clearHashCache()
 
+		# Stash a copy of the current environment, so we can restore it
+		# in `tearDown()`. This allows tests to make temporary modifications
+		# without needing to do manual cleanup.
+		self.__originalEnv = os.environ.copy()
+
 	def tearDown( self ) :
+
+		# Restore the original environment. Do this using the minimal
+		# number of edits to `os.environ`, since Windows doesn't seem to
+		# like clearing it and rebuilding it completely.
+
+		for key, value in self.__originalEnv.items() :
+			if os.environ.get( key ) != value :
+				os.environ[key] = value
+
+		for key in list( os.environ.keys() ) :
+			if key not in self.__originalEnv :
+				del os.environ[key]
+
+		assert( os.environ == self.__originalEnv )
 
 		# Clear any previous exceptions, as they can be holding
 		# references to resources we would like to die. This is

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -1381,5 +1381,20 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( len( messageHandler.messages ), 0 )
 
+	def testMissingShaderWithBlindData( self ) :
+
+		shader = IECoreScene.Shader( "nonexistent", "ai:surface" )
+		shader.blindData()["test"] = IECore.IntData( 1 )
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = { "output" : shader },
+			output = "output"
+		)
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			nodes = IECoreArnold.ShaderNetworkAlgo.convert( network, universe, "test" )
+			self.assertEqual( len( nodes ), 0 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -101,18 +101,26 @@ AtNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECo
 		nodeName += ":" + outputParameter.shader.string();
 	}
 
-	const bool isOSLShader = boost::starts_with( shader->getType(), "osl:" );
+	const AtString shaderName( shader->getName().c_str() );
+
+	const bool isOSLShader =
+		// If the type says it's OSL, then it's definitely OSL.
+		boost::starts_with( shader->getType(), "osl:" ) ||
+		// But we're trying to wean ourselves off `Shader::getType()`,
+		// as it doesn't round-trip through USD. In this case use
+		// some heuristics : if it's not an Arnold shader then assume
+		// it's OSL.
+		( !boost::starts_with( shader->getType(), "ai:" ) && !AiNodeEntryLookUp( shaderName ) )
+	;
+
 	if( isOSLShader )
 	{
 		node = nodeCreator( g_oslArnoldString, AtString( nodeName.c_str() ) );
-		AiNodeSetStr( node, g_shaderNameArnoldString, AtString( shader->getName().c_str() ) );
+		AiNodeSetStr( node, g_shaderNameArnoldString, shaderName );
 	}
 	else
 	{
-		node = nodeCreator(
-			AtString( shader->getName().c_str() ),
-			AtString( nodeName.c_str() )
-		);
+		node = nodeCreator( shaderName, AtString( nodeName.c_str() ) );
 		if( node && AiNodeEntryGetNameAtString( AiNodeGetNodeEntry( node ) ) == g_oslArnoldString )
 		{
 			// Need to set the `code` parameter on `osl` shaders _before_ we try to set

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -455,9 +455,12 @@ std::vector<AtNode *> convert( const IECoreScene::ShaderNetwork *shaderNetwork, 
 			return AiNode( universe, nodeType, nodeName, parentNode );
 		};
 		convertWalk( network->getOutput(), network.get(), name, nodeCreator, result, converted, nodeParameters );
-		for( const auto &kv : network->outputShader()->blindData()->readable() )
+		if( result.size() )
 		{
-			ParameterAlgo::setParameter( result.back(), AtString( kv.first.c_str() ), kv.second.get() );
+			for( const auto &kv : network->outputShader()->blindData()->readable() )
+			{
+				ParameterAlgo::setParameter( result.back(), AtString( kv.first.c_str() ), kv.second.get() );
+			}
 		}
 	}
 	return result;


### PR DESCRIPTION
This fixes a couple of bugs in our Arnold shader translation code, the most important one being a failure to handle OSL shaders written with `IECOREUSD_WRITE_CONFORMANT_OSL_SHADERS`.