### PR TITLE
Remove `IECoreImage::ImagePrimitive` from API

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Breaking Changes
     Use `with script.context()` instead.
 - TractorDispatcher : Removed deprecated support for `preSpoolSignal` slots without `taskData` arguments.
 - ImageAlgo : Removed `image()` method.
+- ImageGadget : Removed constructor taking an `IECoreImage::ImagePrimitive`.
 
 1.7.x.x (relative to 1.7.0.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Breaking Changes
   - Removed deprecated support for passing `script` and `context` arguments to `frameRange()` method.
     Use `with script.context()` instead.
 - TractorDispatcher : Removed deprecated support for `preSpoolSignal` slots without `taskData` arguments.
+- ImageAlgo : Removed `image()` method.
 
 1.7.x.x (relative to 1.7.0.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -16,7 +16,7 @@ Breaking Changes
     Use `with script.context()` instead.
 - TractorDispatcher : Removed deprecated support for `preSpoolSignal` slots without `taskData` arguments.
 - ImageAlgo : Removed `image()` method.
-- ImageGadget : Removed constructor taking an `IECoreImage::ImagePrimitive`.
+- ImageGadget, Image : Removed constructors taking an `IECoreImage::ImagePrimitive`.
 
 1.7.x.x (relative to 1.7.0.0)
 =======

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -183,9 +183,6 @@ void parallelGatherTiles(
 /// prefer to process just one tile at a time, but useful for testing and interoperability.
 /// If the view is not specified, it must be set in the current Context.
 
-/// \deprecated
-GAFFERIMAGE_API IECoreImage::ImagePrimitivePtr image( const ImagePlug *imagePlug, const std::string *viewName = nullptr );
-
 /// Return a hash that will vary if any aspect of the return from image( ... ) varies
 GAFFERIMAGE_API IECore::MurmurHash imageHash( const ImagePlug *imagePlug, const std::string *viewName = nullptr );
 

--- a/include/GafferUI/ImageGadget.h
+++ b/include/GafferUI/ImageGadget.h
@@ -63,8 +63,6 @@ class GAFFERUI_API ImageGadget : public Gadget
 		/// the GAFFERUI_IMAGE_PATHS environment variable.
 		/// Throws if the file cannot be loaded.
 		explicit ImageGadget( const std::string &fileName );
-		/// \deprecated
-		ImageGadget( const IECoreImage::ConstImagePrimitivePtr image );
 		~ImageGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::ImageGadget, ImageGadgetTypeId, Gadget );
@@ -96,11 +94,10 @@ class GAFFERUI_API ImageGadget : public Gadget
 	private :
 
 		Imath::Box3f m_bound;
-		// We can't actually generate the GL texture until renderLayer(), as
-		// the GL state might not be valid until then. so we store either
-		// the image to convert, the filename to load, or the previously
-		// converted texture in this member.
-		mutable IECore::ConstRunTimeTypedPtr m_imageOrTextureOrFileName;
+		// We can't actually generate the GL texture until `renderLayer()`, as
+		// the GL state might not be valid until then. So we store the filename
+		// to load or the previously converted texture in this member.
+		mutable IECore::ConstRunTimeTypedPtr m_textureOrFileName;
 
 };
 

--- a/python/GafferImageTest/ImageAlgoTest.py
+++ b/python/GafferImageTest/ImageAlgoTest.py
@@ -150,7 +150,6 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( crop["out"]["dataWindow"].getValue(), imath.Box2i() )
 
 		GafferImageTest.processTiles( crop["out"] )
-		GafferImage.ImageAlgo.image( crop["out"] )
 		GafferImage.ImageAlgo.imageHash( crop["out"] )
 
 	def testLayerNames( self ) :

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -203,21 +203,6 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 		self.assertTrue( metadata["out"].metadata( _copy = False ).isSame( metadata["out"]["metadata"].getValue( _copy = False ) ) )
 		self.assertEqual( metadata["out"].metadataHash(), metadata["out"]["metadata"].hash() )
 
-	def testImageDeepException( self ) :
-
-		constant1 = GafferImage.Constant()
-		constant1["color"].setValue( imath.Color4f( 1 ) )
-
-		constant2 = GafferImage.Constant()
-		constant2["color"].setValue( imath.Color4f( 1 ) )
-
-		merge = GafferImage.DeepMerge()
-		merge["in"][0].setInput( constant1["out"] )
-		merge["in"][1].setInput( constant2["out"] )
-
-		with self.assertRaises( RuntimeError ) :
-			GafferImage.ImageAlgo.image( merge["out"] )
-
 	def testBlackTile( self ) :
 
 		ts = GafferImage.ImagePlug.tileSize()

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -197,7 +197,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["metadata"].getValue )
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["channelNames"].getValue )
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
-		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
+		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", GafferImageTest.processTiles, reader["out"] )
 
 	def testMissingFrameMode( self ) :
 
@@ -232,12 +232,12 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		# everything throws
 		reader["missingFrameMode"].setValue( GafferImage.ImageReader.MissingFrameMode.Error )
 		with context :
+			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["viewNames"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["channelNames"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
 
 		# Hold mode matches OpenImageIOReader
 		reader["missingFrameMode"].setValue( GafferImage.ImageReader.MissingFrameMode.Hold )
@@ -285,7 +285,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		reader["fileName"].setValue( testSequence.fileNameForFrame( 0 ) )
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context :
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
+			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["viewNames"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
@@ -295,8 +295,8 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		oiio["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context :
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
+			self.assertEqual( reader["out"]["viewNames"].getValue(), oiio["out"]["viewNames"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), oiio["out"]["metadata"].getValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), oiio["out"]["channelNames"].getValue() )

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -279,7 +279,7 @@ parent["color"] = imath.Color4f( 0.5, 0.6, 0.7, 0.8 ) if context.get( "collect:l
 
 		deep = GafferImage.Empty()
 		node["in"].setInput( deep["out"] )
-		self.assertRaisesRegex( RuntimeError, 'Deep data not supported in input "in*', GafferImage.ImageAlgo.image, node["out"] )
+		self.assertRaisesRegex( RuntimeError, 'Deep data not supported in input "in*', GafferImage.ImageAlgo.tiles, node["out"] )
 
 	@staticmethod
 	def imagesPath() :

--- a/python/GafferImageTest/LUTTest.py
+++ b/python/GafferImageTest/LUTTest.py
@@ -81,7 +81,7 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 		o = GafferImage.LUT()
 		o["in"].setInput( n["out"] )
 		o["fileName"].setValue( "/not/a/real.cube" )
-		self.assertRaises( RuntimeError, GafferImage.ImageAlgo.image, o["out"] )
+		self.assertRaises( RuntimeError, GafferImageTest.processTiles, o["out"] )
 
 	def testBadInterpolation( self ) :
 

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -494,10 +494,10 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		self.assertNotEqual( GafferImage.ImageAlgo.imageHash( merge["out"] ), GafferImage.ImageAlgo.imageHash( flat["out"] ) )
 
 		merge["in"][0].setInput( deep["out"] )
-		self.assertRaisesRegex( RuntimeError, 'Deep data not supported in input "in.in0"', GafferImage.ImageAlgo.image, merge["out"] )
+		self.assertRaisesRegex( RuntimeError, 'Deep data not supported in input "in.in0"', GafferImage.ImageAlgo.tiles, merge["out"] )
 		merge["in"][0].setInput( flat["out"] )
 		merge["in"][1].setInput( deep["out"] )
-		self.assertRaisesRegex( RuntimeError, 'Deep data not supported in input "in.in1"', GafferImage.ImageAlgo.image, merge["out"] )
+		self.assertRaisesRegex( RuntimeError, 'Deep data not supported in input "in.in1"', GafferImage.ImageAlgo.tiles, merge["out"] )
 
 	def testDefaultFormat( self ) :
 

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -281,12 +281,12 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		reader = GafferImage.OpenImageIOReader()
 		reader["fileName"].setValue( "wellIDontExist.exr" )
 
+		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["viewNames"].getValue )
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["format"].getValue )
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["dataWindow"].getValue )
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["metadata"].getValue )
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"]["channelNames"].getValue )
 		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", reader["out"].channelData, "R", imath.V2i( 0 ) )
-		self.assertRaisesRegex( RuntimeError, ".*wellIDontExist.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
 
 	def testAvailableFrames( self ) :
 
@@ -424,7 +424,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		# everything throws
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context :
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.tiles, reader["out"] )
+			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["viewNames"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
@@ -490,7 +490,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		reader["fileName"].setValue( pathlib.Path( testSequence.fileNameForFrame( 0 ) ) )
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context :
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.tiles, reader["out"] )
+			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["viewNames"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
@@ -499,7 +499,6 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context :
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), IECore.CompoundData( { "fileValid" : False } ) )

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -35,10 +35,8 @@
 ##########################################################################
 
 import os
-import imath
 
 import IECore
-import IECoreImage
 
 import GafferUI
 
@@ -50,7 +48,7 @@ from Qt import QtWidgets
 # as either a filename or an IECore.ImagePrimitive.
 class Image( GafferUI.Widget ) :
 
-	def __init__( self, imagePrimitiveOrFileName, **kw ) :
+	def __init__( self, fileName, **kw ) :
 
 		GafferUI.Widget.__init__( self, QtWidgets.QLabel(), **kw )
 
@@ -58,19 +56,12 @@ class Image( GafferUI.Widget ) :
 		# the same size.
 		self._qtWidget().setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed ) )
 
-		self.updateImage( imagePrimitiveOrFileName )
+		self.updateImage( fileName )
 
-	def updateImage( self, imagePrimitiveOrFileName ) :
+	def updateImage( self, fileName ) :
 
-		if isinstance( imagePrimitiveOrFileName, str ) :
-			pixmap = self._qtPixmapFromFile( str( imagePrimitiveOrFileName ) )
-		elif isinstance( imagePrimitiveOrFileName, IECoreImage.ImagePrimitive ) :
-			pixmap = self._qtPixmapFromImagePrimitive( imagePrimitiveOrFileName )
-		else :
-			pixmap = None
-
-		if pixmap is not None :
-			self._qtWidget().setPixmap( pixmap )
+		if fileName is not None :
+			self._qtWidget().setPixmap( self._qtPixmapFromFile( str( fileName ) ) )
 
 		self.__pixmapHighlighted = None
 		self.__pixmapDisabled = None
@@ -222,54 +213,6 @@ class Image( GafferUI.Widget ) :
 		icon = QtGui.QIcon( self._qtPixmapHighlighted() if highlighted else self._qtPixmap() )
 		icon.addPixmap( self._qtPixmapDisabled(), QtGui.QIcon.Disabled )
 		return icon
-
-	## \todo Deprecate and remove - we want to phase out ImagePrimitive.
-	# Although we don't use this function or the `Image( ImagePrimitive )`
-	# constructor in Gaffer itself, we can't do this immediately because some
-	# external code currently depends on it.
-	@staticmethod
-	def _qtPixmapFromImagePrimitive( image ) :
-
-		image = image.copy()
-		IECoreImage.ColorAlgo.transformImage( image, "linear", "sRGB" )
-
-		y = image["Y"] if "Y" in image else None
-		r = image["R"] if "R" in image else None
-		g = image["G"] if "G" in image else None
-		b = image["B"] if "B" in image else None
-
-		if r and g and b :
-			channels = [ r, g, b ]
-		elif y :
-			channels = [ y, y, y ]
-		else :
-			raise ValueError( "Expected RGB or Y channels in image" )
-
-		if "A" in image :
-			channels.reverse()
-			channels.append( image["A"] )
-			format = QtGui.QImage.Format_ARGB32_Premultiplied
-		else :
-			format = QtGui.QImage.Format_RGB888
-
-		interleaved = IECore.DataInterleaveOp()(
-			data = IECore.ObjectVector( channels ),
-			targetType = IECore.UCharVectorData.staticTypeId(),
-		)
-
-		imageSize = image.dataWindow.size() + imath.V2i( 1 )
-
-		s = interleaved.toString()
-		image = QtGui.QImage( s, imageSize.x, imageSize.y, format )
-		# The image is referencing the data we provided directly (s), and
-		# expects us to keep it alive as long as the image/pixmap is
-		# used. Since we don't want to do that, we make a deep copy of
-		# the image so we can dispose of s.
-		image = image.copy()
-
-		pixmap = QtGui.QPixmap( image )
-
-		return pixmap
 
 	__pixmapCache = None
 	@classmethod

--- a/python/GafferUITest/ImageGadgetTest.py
+++ b/python/GafferUITest/ImageGadgetTest.py
@@ -40,20 +40,11 @@ import unittest
 import imath
 
 import IECore
-import IECoreImage
 
 import GafferUI
 import GafferUITest
 
 class ImageGadgetTest( GafferUITest.TestCase ) :
-
-	def testConstructFromImagePrimitive( self ) :
-
-		window = imath.Box2i( imath.V2i( 0 ), imath.V2i( 255 ) )
-		imagePrimitive = IECoreImage.ImagePrimitive.createRGBFloat( imath.Color3f( 0.25, .5, .75 ), window, window )
-
-		i = GafferUI.ImageGadget( imagePrimitive )
-		self.assertEqual( i.bound(), imath.Box3f( imath.V3f( -128, -128, 0 ), imath.V3f( 128, 128, 0 ) ) )
 
 	def testConstructFromFile( self ) :
 

--- a/src/GafferImage/ImageAlgo.cpp
+++ b/src/GafferImage/ImageAlgo.cpp
@@ -55,52 +55,6 @@ using namespace GafferImage;
 namespace
 {
 
-class CopyTile
-{
-
-	public :
-
-		CopyTile(
-				const vector<float *> &imageChannelData,
-				const vector<string> &channelNames,
-				const Imath::Box2i &dataWindow
-			) :
-				m_imageChannelData( imageChannelData ),
-				m_channelNames( channelNames ),
-				m_dataWindow( dataWindow )
-		{}
-
-		void operator()( const ImagePlug *imagePlug, const string &channelName, const Imath::V2i &tileOrigin )
-		{
-			const Imath::Box2i tileBound( tileOrigin, tileOrigin + Imath::V2i( ImagePlug::tileSize() ) );
-			const Imath::Box2i b = BufferAlgo::intersection( tileBound, m_dataWindow );
-
-			const size_t imageStride = m_dataWindow.size().x;
-			const size_t tileStrideSize = sizeof(float) * b.size().x;
-
-			const int channelIndex = std::find( m_channelNames.begin(), m_channelNames.end(), channelName ) - m_channelNames.begin();
-			float *channelBegin = m_imageChannelData[channelIndex];
-
-			IECore::ConstFloatVectorDataPtr tileData = imagePlug->channelDataPlug()->getValue();
-			const float *tileDataBegin = &(tileData->readable()[0]);
-
-			for( int y = b.min.y; y < b.max.y; y++ )
-			{
-				const float *tilePtr = tileDataBegin + ( y - tileOrigin.y ) * ImagePlug::tileSize() + ( b.min.x - tileOrigin.x );
-				float *channelPtr = channelBegin + ( m_dataWindow.size().y - ( 1 + y - m_dataWindow.min.y ) ) * imageStride + ( b.min.x - m_dataWindow.min.x );
-				std::memcpy( channelPtr, tilePtr, tileStrideSize );
-			}
-		}
-
-	private :
-
-		const vector<float *> &m_imageChannelData;
-		const vector<string> &m_channelNames;
-		const Imath::Box2i &m_dataWindow;
-
-};
-
-
 // \todo : We likely need to come up with a better general way of iterating tiles, which could
 // translate back and forth from a tileOrigin to a flat index.  This potentially be used in
 // parallelProcessTiles, and could potentially be public so that code that uses tiles() would
@@ -277,66 +231,6 @@ std::vector<std::string> ImageAlgo::sortedChannelNames( const std::vector<std::s
 	} );
 
 	return result;
-}
-
-IECoreImage::ImagePrimitivePtr GafferImage::ImageAlgo::image( const ImagePlug *imagePlug, const std::string *viewName )
-{
-	GafferImage::ImagePlug::ViewScope viewScope( Gaffer::Context::current() );
-	if( viewName )
-	{
-		viewScope.setViewName( viewName );
-	}
-	if( !viewIsValid( viewScope.context(), imagePlug->viewNames()->readable() ) )
-	{
-		throw IECore::Exception(
-			"ImageAlgo::image() : No view \"" +
-			viewScope.context()->get<std::string>( ImagePlug::viewNameContextName, ImagePlug::defaultViewName ) + "\""
-		);
-	}
-
-	if( imagePlug->deepPlug()->getValue() )
-	{
-		throw IECore::Exception( "ImageAlgo::image() only works on flat image data ");
-	}
-
-	Format format = imagePlug->formatPlug()->getValue();
-	Imath::Box2i dataWindow = imagePlug->dataWindowPlug()->getValue();
-	Imath::Box2i newDataWindow( Imath::V2i( 0 ) );
-
-	if( !BufferAlgo::empty( dataWindow ) )
-	{
-		newDataWindow = format.toEXRSpace( dataWindow );
-	}
-	else
-	{
-		dataWindow = newDataWindow;
-	}
-
-	Imath::Box2i newDisplayWindow = format.toEXRSpace( format.getDisplayWindow() );
-
-	IECoreImage::ImagePrimitivePtr result = new IECoreImage::ImagePrimitive( newDataWindow, newDisplayWindow );
-
-	IECore::ConstCompoundDataPtr metadata = imagePlug->metadataPlug()->getValue();
-	result->blindData()->Object::copyFrom( metadata.get() );
-
-	IECore::ConstStringVectorDataPtr channelNamesData = imagePlug->channelNamesPlug()->getValue();
-	const vector<string> &channelNames = channelNamesData->readable();
-
-	vector<float *> imageChannelData;
-	for( vector<string>::const_iterator it = channelNames.begin(), eIt = channelNames.end(); it!=eIt; it++ )
-	{
-		IECore::FloatVectorDataPtr cd = new IECore::FloatVectorData;
-		vector<float> &c = cd->writable();
-		c.resize( result->channelSize(), 0.0f );
-		result->channels[*it] = cd;
-		imageChannelData.push_back( &(c[0]) );
-	}
-
-	CopyTile copyTile( imageChannelData, channelNames, dataWindow );
-	ImageAlgo::parallelProcessTiles( imagePlug, channelNames, copyTile, dataWindow );
-
-	return result;
-
 }
 
 IECore::MurmurHash GafferImage::ImageAlgo::imageHash( const ImagePlug *imagePlug, const std::string *viewName )

--- a/src/GafferImageModule/ImageAlgoBinding.cpp
+++ b/src/GafferImageModule/ImageAlgoBinding.cpp
@@ -174,13 +174,6 @@ void parallelGatherTiles2( const GafferImage::ImagePlug &image, object pythonCha
 	);
 }
 
-IECoreImage::ImagePrimitivePtr imageWrapper( const ImagePlug *plug, const char *viewName )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	std::string viewNameStr( viewName ? viewName : "" );
-	return ImageAlgo::image( plug, viewName ? &viewNameStr : nullptr );
-}
-
 IECore::MurmurHash imageHashWrapper( const ImagePlug *plug, const char *viewName )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -243,7 +236,6 @@ void GafferImageModule::bindImageAlgo()
 		)
 	);
 
-	def( "image", &imageWrapper, ( boost::python::arg( "viewName" ) = object() ) );
 	def( "imageHash", &imageHashWrapper, ( boost::python::arg( "viewName" ) = object() ) );
 	def( "tiles", &tilesWrapper, ( boost::python::arg( "_copy" ) = true, boost::python::arg( "viewName" ) = object() ) );
 

--- a/src/GafferScene/OpenGLShader.cpp
+++ b/src/GafferScene/OpenGLShader.cpp
@@ -58,6 +58,8 @@
 
 #include "fmt/format.h"
 
+#include <array>
+
 using namespace std;
 using namespace Imath;
 using namespace IECore;

--- a/src/GafferScene/OpenGLShader.cpp
+++ b/src/GafferScene/OpenGLShader.cpp
@@ -59,8 +59,10 @@
 #include "fmt/format.h"
 
 using namespace std;
+using namespace Imath;
 using namespace IECore;
 using namespace Gaffer;
+using namespace GafferImage;
 using namespace GafferScene;
 
 GAFFER_NODE_DEFINE_TYPE( OpenGLShader );
@@ -74,6 +76,88 @@ IECore::InternedString g_glGeometrySource( "glGeometrySource" );
 IECore::InternedString g_glNamespacedGeometrySource( "gl:geometrySource" );
 IECore::InternedString g_glFragmentSource( "glFragmentSource" );
 IECore::InternedString g_glNamespacedFragmentSource( "gl:fragmentSource" );
+
+CompoundDataPtr textureParameterValue( const GafferImage::ImagePlug *image )
+{
+	// Find the subset of channels supported by `IECoreGL::ToGLTextureConverter`.
+
+	static std::array<std::string, 5> g_validChannelNames = { "R", "G", "B", "A", "Y" };
+
+	vector<string> textureChannelNames;
+	ConstStringVectorDataPtr imageChannelNames = image->channelNames();
+	for( const auto &channelName : imageChannelNames->readable() )
+	{
+		if( std::find( g_validChannelNames.begin(), g_validChannelNames.end(), channelName ) != g_validChannelNames.end() )
+		{
+			textureChannelNames.push_back( channelName );
+		}
+	}
+
+	if( textureChannelNames.empty() )
+	{
+		return nullptr;
+	}
+
+	// Get data and display windows, and prep CompoundData in format
+	// accepted by ToGLTextureConverter.
+
+	const auto dataWindow = image->dataWindow();
+	if( BufferAlgo::empty( dataWindow ) )
+	{
+		return nullptr;
+	}
+
+	const auto format = image->format();
+
+	CompoundDataPtr result = new CompoundData;
+	result->writable()["displayWindow"] = new Box2iData( format.toEXRSpace( format.getDisplayWindow() ) );
+	const auto cortexDataWindow = format.toEXRSpace( dataWindow );
+	result->writable()["dataWindow"] = new Box2iData( cortexDataWindow );
+
+	const size_t numPixels = dataWindow.size().x * dataWindow.size().y;
+
+	CompoundDataPtr channelsData = new CompoundData;
+	for( const auto &channelName : textureChannelNames )
+	{
+		FloatVectorDataPtr channelData = new FloatVectorData;
+		channelData->writable().resize( numPixels, 1.0f );
+		channelsData->writable()[channelName] = channelData;
+	}
+	result->writable()["channels"] = channelsData;
+
+	// Fill in channel data.
+
+	ImageAlgo::parallelProcessTiles(
+
+		image, textureChannelNames,
+
+		[&] ( const ImagePlug *imagePlug, const string &channelName, const Imath::V2i &tileOrigin ) {
+
+			const Imath::Box2i tileBound( tileOrigin, tileOrigin + Imath::V2i( ImagePlug::tileSize() ) );
+			const Imath::Box2i validTileBound = BufferAlgo::intersection( tileBound, dataWindow );
+
+			IECore::ConstFloatVectorDataPtr tileData = imagePlug->channelDataPlug()->getValue();
+			FloatVectorData *channelData = channelsData->member<FloatVectorData>( channelName );
+
+			for( int y = validTileBound.min.y; y < validTileBound.max.y; y++ )
+			{
+				size_t tileIndex = BufferAlgo::index( V2i( validTileBound.min.x, y ), tileBound );
+				size_t channelIndex = ( format.toEXRSpace( y ) - cortexDataWindow.min.y ) * dataWindow.size().x + ( validTileBound.min.x - cortexDataWindow.min.x );
+				std::copy(
+					tileData->readable().begin() + tileIndex,
+					tileData->readable().begin() + tileIndex + validTileBound.size().x,
+					channelData->writable().begin() + channelIndex
+				);
+			}
+
+		},
+
+		dataWindow
+
+	);
+
+	return result;
+}
 
 } // namespace
 
@@ -203,19 +287,9 @@ void OpenGLShader::parameterHash( const Gaffer::Plug *parameterPlug, IECore::Mur
 
 IECore::DataPtr OpenGLShader::parameterValue( const Gaffer::Plug *parameterPlug ) const
 {
-	if( const GafferImage::ImagePlug *imagePlug = runTimeCast<const GafferImage::ImagePlug>( parameterPlug ) )
+	if( auto *imagePlug = runTimeCast<const GafferImage::ImagePlug>( parameterPlug ) )
 	{
-		IECoreImage::ImagePrimitivePtr image = GafferImage::ImageAlgo::image( imagePlug );
-		if( image )
-		{
-			CompoundDataPtr value = new CompoundData;
-			value->writable()["displayWindow"] = new Box2iData( image->getDisplayWindow() );
-			value->writable()["dataWindow"] = new Box2iData( image->getDataWindow() );
-			CompoundDataPtr channelData = new CompoundData( CompoundDataMap( image->channels.begin(), image->channels.end() ) );
-			value->writable()["channels"] = channelData;
-			return value;
-		}
-		return nullptr;
+		return textureParameterValue( imagePlug );
 	}
 	else
 	{

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -189,31 +189,20 @@ IECoreGL::ConstTexturePtr textureGetter( const TextureCacheKey &key, size_t &cos
 	return texture;
 }
 
-const IECoreGL::Texture *loadTexture( IECore::ConstRunTimeTypedPtr &imageOrTextureOrFileName )
+const IECoreGL::Texture *loadTexture( IECore::ConstRunTimeTypedPtr &textureOrFileName )
 {
-	if( const Texture *texture = runTimeCast<const Texture>( imageOrTextureOrFileName.get() ) )
+	if( const Texture *texture = runTimeCast<const Texture>( textureOrFileName.get() ) )
 	{
 		return texture;
 	}
 
 	ConstTexturePtr texture;
-	if( const StringData *filename = runTimeCast<const StringData>( imageOrTextureOrFileName.get() ) )
+	if( const StringData *filename = runTimeCast<const StringData>( textureOrFileName.get() ) )
 	{
 		// Load texture from file
 		texture = ImageGadget::loadTexture( filename->readable() );
 	}
-	else if( const ImagePrimitive *image = runTimeCast<const ImagePrimitive>( imageOrTextureOrFileName.get() ) )
-	{
-		// Convert image to texture
-		ToGLTextureConverterPtr converter = new ToGLTextureConverter( image );
-		if( auto converted = boost::static_pointer_cast<Texture>( converter->convert() ) )
-		{
-			applyTextureParameters( converted.get(), ImageGadget::TextureParameters() );
-			texture = converted;
-		}
-	}
-
-	imageOrTextureOrFileName = texture;
+	textureOrFileName = texture;
 
 	return texture.get();
 }
@@ -237,15 +226,7 @@ ImageGadget::ImageGadget( const std::string &fileName )
 	static ImageBoundCache g_imageBoundCache( boundGetter, 10000 );
 	m_bound = g_imageBoundCache.get( fileName );
 
-	m_imageOrTextureOrFileName = new StringData( fileName );
-}
-
-ImageGadget::ImageGadget( IECoreImage::ConstImagePrimitivePtr image )
-	:	Gadget( defaultName<ImageGadget>() ), m_imageOrTextureOrFileName( image->copy() )
-{
-	const V2i pixelSize = image->getDisplayWindow().size() + V2i( 1 );
-	const V3f size( pixelSize.x, pixelSize.y, 0.0f );
-	m_bound = Box3f( -size/2.0f, size/2.0f );
+	m_textureOrFileName = new StringData( fileName );
 }
 
 ImageGadget::~ImageGadget()
@@ -265,7 +246,7 @@ void ImageGadget::renderLayer( Layer layer, const Style *style, RenderReason rea
 		return;
 	}
 
-	if( const Texture *texture = ::loadTexture( m_imageOrTextureOrFileName ) )
+	if( const Texture *texture = ::loadTexture( m_textureOrFileName ) )
 	{
 		Box2f b( V2f( m_bound.min.x, m_bound.min.y ), V2f( m_bound.max.x, m_bound.max.y ) );
 		style->renderImage( b, texture );

--- a/src/GafferUIModule/ImageGadgetBinding.cpp
+++ b/src/GafferUIModule/ImageGadgetBinding.cpp
@@ -51,6 +51,5 @@ void GafferUIModule::bindImageGadget()
 {
 	GadgetClass<ImageGadget>()
 		.def( init<const std::string &>() )
-		.def( init<IECoreImage::ConstImagePrimitivePtr>() )
 	;
 }


### PR DESCRIPTION
This removes all usage of `IECoreImage::ImagePrimitive` from our APIs, with a view to jettisoning it completely. We still have a few uses in the unit tests, particularly via ImageDisplayDriver, but I'm hoping that between us we can polish those off in subsequent PRs.

@ivanimanishi, from the comments in the code, I suspect IE is relying on the constructor removed in https://github.com/GafferHQ/gaffer/commit/02d8b2a9fd51a149780045c00719aaa6ce3762d3. I'm open to providing a separate shim for you if it's too hard to ween yourself off it now, but my intention is definitely that Gaffer 1.8 itself will be ImagePrimitive-free.