### PR TITLE
BoxIO : Fix `noduleLayout:section` from opposite direction source plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Cycles : Fixed rendering of shaders written with `IECOREUSD_WRITE_CONFORMANT_OSL_SHADERS=1`.
+- BoxIO : Fixed `noduleLayout:section` metadata when BoxIn/BoxOut are set up from a plug of the opposite direction. This could result in EditScope nodes created immediately downstream of a Box having their `in` plug at the bottom of the node rather than the top.
 
 1.6.21.5 (relative to 1.6.21.4)
 ========

--- a/python/GafferTest/BoxInTest.py
+++ b/python/GafferTest/BoxInTest.py
@@ -220,6 +220,20 @@ class BoxInTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s["b"]["i"].promotedPlug(), "noduleLayout:section" ), "left" )
 		self.assertEqual( Gaffer.Metadata.value( s["b"]["i"].plug(), "noduleLayout:section" ), "right" )
 
+	def testNoduleSectionMetadataFromOutPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		Gaffer.Metadata.registerValue( s["n"]["sum"], "noduleLayout:section", "bottom" )
+
+		s["b"] = Gaffer.Box()
+		s["b"]["i"] = Gaffer.BoxIn()
+		s["b"]["i"].setup( s["n"]["sum"] )
+
+		self.assertEqual( Gaffer.Metadata.value( s["b"]["i"].promotedPlug(), "noduleLayout:section" ), "top" )
+		self.assertIsNone( Gaffer.Metadata.value( s["b"]["i"].plug(), "noduleLayout:section" ) )
+
 	def testPromotedPlugRemovalDeletesBoxIn( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/BoxOutTest.py
+++ b/python/GafferTest/BoxOutTest.py
@@ -178,6 +178,20 @@ class BoxOutTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s["b"]["o"].promotedPlug(), "noduleLayout:section" ), "right" )
 		self.assertEqual( Gaffer.Metadata.value( s["b"]["o"].plug(), "noduleLayout:section" ), "left" )
 
+	def testNoduleSectionMetadataFromInPlug( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "noduleLayout:section", "top" )
+
+		s["b"] = Gaffer.Box()
+		s["b"]["o"] = Gaffer.BoxOut()
+		s["b"]["o"].setup( s["n"]["op1"] )
+
+		self.assertEqual( Gaffer.Metadata.value( s["b"]["o"].promotedPlug(), "noduleLayout:section" ), "bottom" )
+		self.assertIsNone( Gaffer.Metadata.value( s["b"]["o"].plug(), "noduleLayout:section" ) )
+
 	def testPromotedPlugRemovalDeletesBoxOut( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/EditScopeTest.py
+++ b/python/GafferTest/EditScopeTest.py
@@ -189,5 +189,33 @@ class EditScopeTest( GafferTest.TestCase ) :
 		self.assertEqual( p2["variables"][0]["value"].getValue(), p["variables"][0]["value"].getValue() )
 		self.assertEqual( s2["e"]["out"].getValue(), s["e"]["out"].getValue() )
 
+	def testSetupFromOutPlugWithSectionMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.AddNode()
+		Gaffer.BoxIO.promote( s["b"]["n"]["sum"] )
+		Gaffer.Metadata.registerValue( s["b"]["sum"], "noduleLayout:section", "bottom" )
+
+		s["e"] = Gaffer.EditScope()
+		s["e"].setup( s["b"]["sum"] )
+
+		self.assertEqual( Gaffer.Metadata.value( s["e"]["in"], "noduleLayout:section" ), "top" )
+		self.assertEqual( Gaffer.Metadata.value( s["e"]["out"], "noduleLayout:section" ), "bottom" )
+
+	def testSetupFromInPlugWithSectionMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["b"] = Gaffer.Box()
+		s["b"]["n"] = GafferTest.AddNode()
+		Gaffer.BoxIO.promote( s["b"]["n"]["op1"] )
+		Gaffer.Metadata.registerValue( s["b"]["op1"], "noduleLayout:section", "top" )
+
+		s["e"] = Gaffer.EditScope()
+		s["e"].setup( s["b"]["op1"] )
+
+		self.assertEqual( Gaffer.Metadata.value( s["e"]["in"], "noduleLayout:section" ), "top" )
+		self.assertEqual( Gaffer.Metadata.value( s["e"]["out"], "noduleLayout:section" ), "bottom" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -244,7 +244,7 @@ void BoxIO::setup( const Plug *plug )
 	);
 
 	setupNoduleSectionMetadata(
-		m_direction == Plug::In ? outPlugInternal() : inPlugInternal(),
+		plug->direction() == Plug::In ? outPlugInternal() : inPlugInternal(),
 		plug
 	);
 


### PR DESCRIPTION
`noduleLayout:section` metadata copied from the source plug is only valid when the source plug and the BoxIO's promoted plug are of the same direction. A BoxIn set up from an `out` plug with `noduleLayout:section "bottom"` registered would cause its promoted `in` plug to also appear on the bottom of the Box. This is common with EditScopes as they set up both their BoxIn and BoxOut from the same source plug.

We now choose the target of `setupNoduleSectionMetadata()` based on the direction of the source plug, rather than `m_direction`. When they match, the existing behaviour is unchanged. When they don't match, the metadata target is now the promoted plug, overwriting any `noduleLayout:section` metadata copied from the source.

An alternate approach might be to always call `setupNoduleSectionMetadata()` for both `outPlugInternal()` and `inPlugInternal()`, I think that might help ensure the internal plugs better represent the flow of their external equivalents in cases where an EditScope is set up with an `in` plug on the left and the `out` on the right (note the current lack of "noduleLayout:section" metadata on the internal BoxIO plugs in the additions to BoxInTest/BoxOutTest). But in the general case that feels like it'd only further proliferate instance `noduleLayout:section` metadata registrations unless we only registered instance metadata when it differs from the default...