### PR TITLE
bug:fix Node editor flicker 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 -----
 
 - Cycles : Fixed rendering of shaders written with `IECOREUSD_WRITE_CONFORMANT_OSL_SHADERS=1`.
+- NodeEditor : Fixed flicker when changing the node being viewed.
 
 1.7.1.0 (relative to 1.7.0.0)
 =======

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -149,6 +149,14 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 
 		self.__nodeUI = GafferUI.NodeUI.create( node )
 		self.__nodeUIFrame.setChild( self.__nodeUI )
+		# Activate all layouts now, bottom up from the leaf layouts to the
+		# `__nodeUIFrame`. This works around flicker caused by widgets changing
+		# size after an initial round of layout. One culprit seems to be the usage
+		# of `QtWidgets.QLayout.SetMinAndMaxSize` by Widget - see comments there.
+		for widget in reversed( self.__nodeUIFrame._qtWidget().findChildren( QtWidgets.QWidget ) ) :
+			layout = widget.layout()
+			if layout is not None :
+				layout.activate()
 
 	def _titleFormat( self ) :
 

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -175,6 +175,14 @@ class Widget( Gaffer.Signals.Trackable, metaclass = _WidgetMetaclass ) :
 			# way. However we may want other types to expand in the future. I think what we
 			# really need to do is somehow make __qtWidget without a layout, and just have
 			# it's size etc. dictated directly by self.__gafferWidget._qtWidget() somehow.
+			#
+			# See `NodeEditor._updateFromSet()` where we work around layout
+			# flicker caused by this. Our theory is that when the layout first
+			# runs, it sets the minimum and maximum sizes of the widget, causing
+			# a second layout event to be posted to the event loop. Before that
+			# is dealt with, a paint event draws a layout computed without the
+			# right constraints and we get flicker when the second round of
+			# layout completes.
 			self.__qtWidget.layout().setSizeConstraint( QtWidgets.QLayout.SetMinAndMaxSize )
 			self.__qtWidget.layout().setContentsMargins( 0, 0, 0, 0 )
 			self.__qtWidget.layout().addWidget( self.__gafferWidget._qtWidget(), 0, 0 )


### PR DESCRIPTION
The NodeEditor flickers noticeably every time the node selection changes.
（This is my first pull request and my first attempt at fixing a bug in Gaffer, so please let me know if anything should be done differently）
Tested with Gaffer 1.6.5.1.

Before/after comparison :
<img width="772" height="715" alt="nodeEditor_01" src="https://github.com/user-attachments/assets/7ef67e01-df06-4f76-bbb2-d3a21ca90bf4" />
<img width="772" height="715" alt="nodeEditor_02" src="https://github.com/user-attachments/assets/b2e8301b-b98b-4870-9a82-fccb03e450f2" />


The capture frame rate limits what the GIF can show, so the difference is much
clearer when switching nodes in a running Gaffer.

The fix suspends painting of `__nodeUIFrame` while the new NodeUI is swapped in,
performs the layout once, bottom up, and then re-enables painting before
returning to the event loop. Laying out bottom up matters because
`QLayout.activate()` uses the current size hints of the child widgets, so a
parent laid out before its children would just have to be done again.

- List specific new features and changes to project components

- GafferUI NodeEditor : `_updateFromSet` suspends painting and completes the
  layout explicitly while replacing the NodeUI.
- GafferUI NodeEditor : Added private static method `__layOut`, which performs
  the layout for a widget and all its descendants, bottom up.
- Changes.md : Added an entry under Fixes for 1.6.21.x.

The change is limited to `python/GafferUI/NodeEditor.py`, and behaviour outside
`_updateFromSet` is unchanged. This code is identical on `1.6_maintenance` and
`main`, so merging forward should not conflict.

### Related issues ###

- None

### Dependencies ###

- None

### Breaking changes ###

- None. The change only affects the internal Python implementation of GafferUI,
  with no API or ABI changes.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
