### PR TITLE
VisualiserAlgo, ShaderAssignment : Don't cache `getenv()` results

### DIFF
--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -101,9 +101,7 @@ class TestCase( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		# Restore the original environment. Do this using the minimal
-		# number of edits to `os.environ`, since Windows doesn't seem to
-		# like clearing it and rebuilding it completely.
+		# Restore the original environment.
 
 		for key, value in self.__originalEnv.items() :
 			if os.environ.get( key ) != value :

--- a/src/GafferArnoldUI/VisualiserAlgo.cpp
+++ b/src/GafferArnoldUI/VisualiserAlgo.cpp
@@ -50,7 +50,6 @@
 
 #include "OSL/oslquery.h"
 
-
 using namespace OSL;
 using namespace IECore;
 using namespace IECoreScene;
@@ -62,7 +61,10 @@ namespace
 // OSL query LRU cache
 //////////////////////////////////////////////////////////////////////////
 
-const char *g_oslSearchPaths = getenv( "OSL_SHADER_PATHS" );
+const std::string g_oslSearchPaths = [] {
+	const char *e = getenv( "OSL_SHADER_PATHS" );
+	return std::string( e ? e : "" );
+}();
 
 using OSLQueryPtr = std::shared_ptr<OSLQuery>;
 
@@ -71,7 +73,7 @@ OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost, const I
 	cost = 1;
 
 	OSLQueryPtr result( new OSLQuery() );
-	if( result->open( shaderName, g_oslSearchPaths ? g_oslSearchPaths : "" ) )
+	if( result->open( shaderName, g_oslSearchPaths ) )
 	{
 		return result;
 	}

--- a/src/GafferScene/ShaderAssignment.cpp
+++ b/src/GafferScene/ShaderAssignment.cpp
@@ -54,8 +54,10 @@ namespace
 const InternedString g_oslShader( "osl:shader" );
 const InternedString g_oslSurface( "osl:surface" );
 
-const char *g_oslPrefix( getenv( "GAFFERSCENE_SHADERASSIGNMENT_OSL_PREFIX" ) );
-const InternedString g_oslTarget( g_oslPrefix ? std::string( g_oslPrefix ) + ":surface" : "osl:surface" );
+const InternedString g_oslTarget = [] {
+	const char *oslPrefix = getenv( "GAFFERSCENE_SHADERASSIGNMENT_OSL_PREFIX" );
+	return oslPrefix ? std::string( oslPrefix ) + ":surface" : "osl:surface";
+}();
 
 } // namespace
 


### PR DESCRIPTION
They can become dangling following a call to `putenv()` or `setenv()`. I believe this is the source of these recent VisualiserAlgoTest failures on Windows :

```
ERROR: File __viewer/__arnold_image.oso not found
FAIL: testConformToOSLNetworkFull (GafferArnoldUITest.VisualiserAlgoTest.VisualiserAlgoTest.testConformToOSLNetworkFull)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\a\gaffer\gaffer\build\python\GafferTest\TestCase.py", line 171, in tearDown
    self.fail( f"Unexpected message : {message}" )
AssertionError: Unexpected message : ERROR : GafferArnold::VisualiserAlgo : Unsupported Arnold shaders in network (blackbody, image, multiply), unable to convert network to OSL.
```