### PR TITLE
Wrapper : Fix startup with spaces in installation directory

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
 
 - Cycles : Fixed rendering of shaders written with `IECOREUSD_WRITE_CONFORMANT_OSL_SHADERS=1`.
 - NodeEditor : Fixed flicker when changing the node being viewed.
+- Linux : Fixed startup from installation directory containing spaces.
 
 1.7.1.0 (relative to 1.7.0.0)
 =======

--- a/bin/__private/_gaffer.py
+++ b/bin/__private/_gaffer.py
@@ -392,7 +392,7 @@ if sys.platform == "win32" :
 
 if sys.platform == "linux" :
 	if os.environ.get( "GAFFER_JEMALLOC", "1" ) != "0" :
-		appendToPath( gafferRoot / "lib" / "libjemalloc.so", "LD_PRELOAD" )
+		appendToPath( "libjemalloc.so", "LD_PRELOAD" )
 
 # OIIO Setup
 # ==========

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -125,7 +125,7 @@ if [[ -n $GAFFER_DEBUG ]] ; then
 			export GAFFER_DEBUGGER="lldb -- "
 		fi
 	fi
-	exec $GAFFER_DEBUGGER $rootDir/bin/python "$rootDir/bin/__private/_gaffer.py" "$@"
+	exec $GAFFER_DEBUGGER "$rootDir/bin/python" "$rootDir/bin/__private/_gaffer.py" "$@"
 else
-	exec $rootDir/bin/python "$rootDir/bin/__private/_gaffer.py" "$@"
+	exec "$rootDir/bin/python" "$rootDir/bin/__private/_gaffer.py" "$@"
 fi


### PR DESCRIPTION
It looks like the startup itself was broken when we added the `bin/__private/gaffer` executable. But the LD_PRELOAD looks like it has been broken forever. Apparently spaces are treated as separators in LD_PRELOAD and there is no way of escaping them, so our only option is to drop the full path and let `libjemalloc.so` be found on LD_LIBRARY_PATH. This should still resolve to the same full path because we put `$GAFFER_ROOT/lib` on the front of LD_LIBRARY_PATH.

I discovered this when investigating #7134 on Linux. The good news is that it all seems well there.